### PR TITLE
remove role=alert from "show more" button

### DIFF
--- a/routes/_components/timeline/MoreHeader.html
+++ b/routes/_components/timeline/MoreHeader.html
@@ -1,4 +1,4 @@
-<div class="more-items-header" role="alert">
+<div class="more-items-header">
   <button class="primary" type="button" on:click="onClick(event)">
     Show {{count}} more
   </button>


### PR DESCRIPTION
Possible solution for issue #59. AFAICT from testing with VoiceOver, it appears that it's the role=dialog that causes confusion, not the aria-hidden. role=dialog also has the annoying habit of announcing whenever there are new toots, which on a firehose like the mastodon.social federated timeline is almost useless. It seems it's better off just being a normal button.

I'm still trying to figure out if I need to set focus after the button is clicked (it just focuses the first status afterwards), but so far this seems to be working okay, at least in VoiceOver.