### PR TITLE
Increase in contrast for "--very-deemphasized" colors 

### DIFF
--- a/scss/themes/_dark.scss
+++ b/scss/themes/_dark.scss
@@ -12,8 +12,8 @@
 
   --deemphasized-text-color:$deemphasized-color;
 
-  --very-deemphasized-link-color: rgba($anchor-color, 0.6);
-  --very-deemphasized-text-color: lighten($main-bg-color, 12%);
+  --very-deemphasized-link-color: rgba($anchor-color, 0.8);
+  --very-deemphasized-text-color: lighten($main-bg-color, 32%);
 
   --status-direct-background: darken($body-bg-color, 5%);
   --main-theme-color: $main-theme-color;


### PR DESCRIPTION
Some have noticed that the very-deemphasized colors could use a little more contrast on dark themes, I just bumped up the lightness/opacity a little bit. They should still be darker than regular deemphasized colors.