### PR TITLE
Use travis_retry, remove Firefox tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
   - ffmpeg -version
 before_script:
   - npm run lint
-script: npm run $COMMAND
+script: travis_retry npm run $COMMAND
 env:
   global:
   - PGPORT=5433
@@ -60,8 +60,9 @@ env:
 matrix:
   include:
     - env: BROWSER=chrome:headless COMMAND=test-browser
-    - env: BROWSER=firefox:headless COMMAND=test-browser
     - env: COMMAND=deploy-dev-travis
+    # disable firefox until it's passing
+    # - env: BROWSER=firefox:headless COMMAND=test-browser
   allow_failures:
     - env: BROWSER=firefox:headless COMMAND=test-browser
 branches:


### PR DESCRIPTION
The Firefox tests are consistently failing, so there's no sense in running them if we know they're going to fail. Also use `travis_retry` because the Chrome tests do occasionally fail, but we can retry them.