### PR TITLE
focus container on page load

### DIFF
--- a/routes/_components/Layout.html
+++ b/routes/_components/Layout.html
@@ -1,6 +1,6 @@
 <Nav :page />
 
-<div class="container">
+<div class="container" tabindex="0">
   <main>
     <slot></slot>
   </main>
@@ -17,7 +17,10 @@
 		components: {
 			Nav,
       InformationalFooter
-		},
+    },
+    oncreate () {
+      document.querySelector('.container').focus()
+    },
     store: () => store
 	}
 </script>

--- a/routes/_components/Layout.html
+++ b/routes/_components/Layout.html
@@ -1,6 +1,6 @@
 <Nav :page />
 
-<div class="container" tabindex="0">
+<div class="container" tabindex="0" ref:container>
   <main>
     <slot></slot>
   </main>
@@ -13,13 +13,22 @@
   import { store } from '../_store/store'
   import InformationalFooter from './InformationalFooter.html'
 
+  // Only focus the `.container` div on first load so it oes not intefere 
+  // with other desired behaviours (e.g. you click a toot, you navigate from
+  // a timeline view to a thread view, you press the back button, and now
+  // you're still focused on the toot).
+  let firstTime = true
+
 	export default {
 		components: {
 			Nav,
       InformationalFooter
     },
     oncreate () {
-      document.querySelector('.container').focus()
+      if (firstTime) {
+        firstTime = false;
+        this.refs.container.focus()
+      }
     },
     store: () => store
 	}

--- a/routes/_components/Layout.html
+++ b/routes/_components/Layout.html
@@ -13,7 +13,7 @@
   import { store } from '../_store/store'
   import InformationalFooter from './InformationalFooter.html'
 
-  // Only focus the `.container` div on first load so it oes not intefere 
+  // Only focus the `.container` div on first load so it does not intefere 
   // with other desired behaviours (e.g. you click a toot, you navigate from
   // a timeline view to a thread view, you press the back button, and now
   // you're still focused on the toot).
@@ -26,7 +26,7 @@
     },
     oncreate () {
       if (firstTime) {
-        firstTime = false;
+        firstTime = false
         this.refs.container.focus()
       }
     },

--- a/tests/spec/010-focus.js
+++ b/tests/spec/010-focus.js
@@ -83,3 +83,7 @@ test('reply preserves focus and moves focus to the text input', async t => {
     .click(getNthReplyButton(1))
     .expect(getActiveElementClass()).contains('compose-box-input')
 })
+
+test('focus .container div on index page load', async t => {
+  await t.expect(getActiveElementClass()).contains('container')
+})


### PR DESCRIPTION
On page load, the focus is set the main content area instead of on the nav bar.

This fixes (#99).