### PR TITLE
Mark permalinks with icons accessibly

### DIFF
--- a/routes/_components/ExternalLink.html
+++ b/routes/_components/ExternalLink.html
@@ -1,6 +1,7 @@
 <a rel="nofollow noopener"
    target="_blank"
    href="{{href}}"
+   aria-label="{{ariaLabel || ''}}"
    class="{{className || ''}} {{showIcon ? 'external-link-with-icon' : ''}} {{normalIconColor ? 'normal-icon-color' : ''}}">
   <slot></slot>{{#if showIcon}}
     <svg class="external-link-svg">

--- a/routes/_components/profile/AccountProfileHeader.html
+++ b/routes/_components/profile/AccountProfileHeader.html
@@ -2,7 +2,11 @@
   <Avatar :account size="big" />
 </div>
 <div class="account-profile-name">
-  <ExternalLink href="{{account.url}}" showIcon="true" normalIconColor="true">
+  <ExternalLink href="{{account.url}}"
+                showIcon="true"
+                normalIconColor="true"
+                ariaLabel="{{account.display_name || account.acct}} (opens in new window)"
+  >
     {{account.display_name || account.acct}}
   </ExternalLink>
 </div>

--- a/routes/_components/status/StatusDetails.html
+++ b/routes/_components/status/StatusDetails.html
@@ -1,5 +1,9 @@
 <div class="status-details">
-  <ExternalLink class="status-absolute-date" href="{{originalStatus.url}}" showIcon="true">
+  <ExternalLink class="status-absolute-date"
+                href="{{originalStatus.url}}"
+                showIcon="true"
+                ariaLabel="{{formattedDate}} (opens in new window)"
+  >
     <time datetime={{createdAtDate}} title="{{formattedDate}}">{{formattedDate}}</time>
   </ExternalLink>
   <a class="status-favs-reblogs"


### PR DESCRIPTION
Fixes #128. Based on guidance from [this document](https://www.w3.org/TR/WCAG20-TECHS/G201.html), it seems adding "(opens in new window)" is a reasonable solution. I'm not doing this for every single external link, but only for the ones where I've added a visual icon, since for those ones it's not obvious from the context that they're external links.