### PR TITLE
remove style-loader hack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8405,7 +8405,7 @@
       }
     },
     "sapper": {
-      "version": "github:nolanlawson/sapper#d9db963a055aaaf542d405619ca46eb120c6dd92",
+      "version": "github:nolanlawson/sapper#c6da54184f734d16f61c967ae8121bf2ac824b36",
       "requires": {
         "chalk": "2.4.0",
         "chokidar": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "pify": "^3.0.0",
     "quick-lru": "^1.1.0",
     "requestidlecallback": "^0.3.0",
-    "sapper": "github:nolanlawson/sapper#for-pinafore-2",
+    "sapper": "github:nolanlawson/sapper#for-pinafore-3",
     "serve-static": "^1.13.1",
     "stringz": "^1.0.0",
     "style-loader": "^0.20.3",


### PR DESCRIPTION
I believe [this hack](https://github.com/nolanlawson/sapper/commit/c6da54184f734d16f61c967ae8121bf2ac824b36) is no longer needed since we're not using extract-text-plugin.