### PR TITLE
remove "class" prop in favor of "className"

### DIFF
--- a/routes/_components/ExternalLink.html
+++ b/routes/_components/ExternalLink.html
@@ -23,10 +23,3 @@
     fill: var(--body-text-color);
   }
 </style>
-<script>
-  export default {
-    oncreate() {
-      this.set({className: this.get('class')}) // workaround for "class" property name bug in svelte
-    }
-  }
-</script>

--- a/routes/_components/status/StatusDetails.html
+++ b/routes/_components/status/StatusDetails.html
@@ -1,5 +1,5 @@
 <div class="status-details">
-  <ExternalLink class="status-absolute-date"
+  <ExternalLink className="status-absolute-date"
                 href="{{originalStatus.url}}"
                 showIcon="true"
                 ariaLabel="{{formattedDate}} (opens in new window)"

--- a/routes/_pages/settings/instances/[instanceName].html
+++ b/routes/_pages/settings/instances/[instanceName].html
@@ -5,7 +5,7 @@
     <h2>Logged in as:</h2>
     <div class="acct-current-user">
       <Avatar account="{{verifyCredentials}}" className="acct-avatar" size="big"/>
-      <ExternalLink class="acct-handle"
+      <ExternalLink className="acct-handle"
                     href="{{verifyCredentials.url}}">
         {{'@' + verifyCredentials.acct}}
       </ExternalLink>


### PR DESCRIPTION
This was always an unnecessary hack, and will break in future versions of Svelte anyway since I can't do:

```js
let { class } = this.get()
```

Background: https://github.com/sveltejs/svelte/pull/1347