### PR TITLE
remove get() with string from Svelte calls

### DIFF
--- a/routes/_actions/accounts.js
+++ b/routes/_actions/accounts.js
@@ -52,11 +52,10 @@ export async function clearProfileAndRelationship () {
 }
 
 export async function updateProfileAndRelationship (accountId) {
-  let instanceName = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
 
   await Promise.all([
-    updateAccount(accountId, instanceName, accessToken),
-    updateRelationship(accountId, instanceName, accessToken)
+    updateAccount(accountId, currentInstance, accessToken),
+    updateRelationship(accountId, currentInstance, accessToken)
   ])
 }

--- a/routes/_actions/block.js
+++ b/routes/_actions/block.js
@@ -4,13 +4,12 @@ import { toast } from '../_utils/toast'
 import { updateProfileAndRelationship } from './accounts'
 
 export async function setAccountBlocked (accountId, block, toastOnSuccess) {
-  let instanceName = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
   try {
     if (block) {
-      await blockAccount(instanceName, accessToken, accountId)
+      await blockAccount(currentInstance, accessToken, accountId)
     } else {
-      await unblockAccount(instanceName, accessToken, accountId)
+      await unblockAccount(currentInstance, accessToken, accountId)
     }
     await updateProfileAndRelationship(accountId)
     if (toastOnSuccess) {

--- a/routes/_actions/delete.js
+++ b/routes/_actions/delete.js
@@ -3,10 +3,9 @@ import { deleteStatus } from '../_api/delete'
 import { toast } from '../_utils/toast'
 
 export async function doDeleteStatus (statusId) {
-  let instanceName = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
   try {
-    await deleteStatus(instanceName, accessToken, statusId)
+    await deleteStatus(currentInstance, accessToken, statusId)
     toast.say('Status deleted.')
   } catch (e) {
     console.error(e)

--- a/routes/_actions/emoji.js
+++ b/routes/_actions/emoji.js
@@ -12,7 +12,7 @@ export async function updateCustomEmojiForInstance (instanceName) {
     () => getCustomEmojiFromDatabase(instanceName),
     emoji => setCustomEmojiInDatabase(instanceName, emoji),
     emoji => {
-      let customEmoji = store.get('customEmoji')
+      let { customEmoji } = store.get()
       customEmoji[instanceName] = emoji
       store.set({customEmoji: customEmoji})
     }
@@ -20,7 +20,8 @@ export async function updateCustomEmojiForInstance (instanceName) {
 }
 
 export function insertEmoji (realm, emoji) {
-  let idx = store.get('composeSelectionStart') || 0
+  let { composeSelectionStart } = store.get()
+  let idx = composeSelectionStart || 0
   let oldText = store.getComposeData(realm, 'text') || ''
   let pre = oldText.substring(0, idx)
   let post = oldText.substring(idx)
@@ -37,11 +38,15 @@ export function insertEmojiAtPosition (realm, emoji, startIndex, endIndex) {
 }
 
 export async function clickSelectedAutosuggestionEmoji (realm) {
-  let selectionStart = store.get('composeSelectionStart')
-  let searchText = store.get('composeAutosuggestionSearchText')
-  let selection = store.get('composeAutosuggestionSelected') || 0
-  let emoji = store.get('composeAutosuggestionSearchResults')[selection]
-  let startIndex = selectionStart - searchText.length
-  let endIndex = selectionStart
+  let {
+    composeSelectionStart,
+    composeAutosuggestionSearchText,
+    composeAutosuggestionSelected,
+    composeAutosuggestionSearchResults
+  } = store.get()
+  composeAutosuggestionSelected = composeAutosuggestionSelected || 0
+  let emoji = composeAutosuggestionSearchResults[composeAutosuggestionSelected]
+  let startIndex = composeSelectionStart - composeAutosuggestionSearchText.length
+  let endIndex = composeSelectionStart
   await insertEmojiAtPosition(realm, emoji, startIndex, endIndex)
 }

--- a/routes/_actions/favorite.js
+++ b/routes/_actions/favorite.js
@@ -6,22 +6,22 @@ import {
 } from '../_database/timelines/updateStatus'
 
 export async function setFavorited (statusId, favorited) {
-  if (!store.get('online')) {
+  let { online } = store.get()
+  if (!online) {
     toast.say(`You cannot ${favorited ? 'favorite' : 'unfavorite'} while offline.`)
     return
   }
-  let instanceName = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
   let networkPromise = favorited
-    ? favoriteStatus(instanceName, accessToken, statusId)
-    : unfavoriteStatus(instanceName, accessToken, statusId)
-  store.setStatusFavorited(instanceName, statusId, favorited) // optimistic update
+    ? favoriteStatus(currentInstance, accessToken, statusId)
+    : unfavoriteStatus(currentInstance, accessToken, statusId)
+  store.setStatusFavorited(currentInstance, statusId, favorited) // optimistic update
   try {
     await networkPromise
-    await setStatusFavoritedInDatabase(instanceName, statusId, favorited)
+    await setStatusFavoritedInDatabase(currentInstance, statusId, favorited)
   } catch (e) {
     console.error(e)
     toast.say(`Failed to ${favorited ? 'favorite' : 'unfavorite'}. ` + (e.message || ''))
-    store.setStatusFavorited(instanceName, statusId, !favorited) // undo optimistic update
+    store.setStatusFavorited(currentInstance, statusId, !favorited) // undo optimistic update
   }
 }

--- a/routes/_actions/follow.js
+++ b/routes/_actions/follow.js
@@ -7,17 +7,16 @@ import {
 } from '../_database/accountsAndRelationships'
 
 export async function setAccountFollowed (accountId, follow, toastOnSuccess) {
-  let instanceName = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
   try {
     let account
     if (follow) {
-      account = await followAccount(instanceName, accessToken, accountId)
+      account = await followAccount(currentInstance, accessToken, accountId)
     } else {
-      account = await unfollowAccount(instanceName, accessToken, accountId)
+      account = await unfollowAccount(currentInstance, accessToken, accountId)
     }
     await updateProfileAndRelationship(accountId)
-    let relationship = await getRelationshipFromDatabase(instanceName, accountId)
+    let relationship = await getRelationshipFromDatabase(currentInstance, accountId)
     if (toastOnSuccess) {
       if (follow) {
         if (account.locked && relationship.requested) {

--- a/routes/_actions/instances.js
+++ b/routes/_actions/instances.js
@@ -14,17 +14,18 @@ import {
 } from '../_database/meta'
 
 export function changeTheme (instanceName, newTheme) {
-  let instanceThemes = store.get('instanceThemes')
+  let { instanceThemes } = store.get()
   instanceThemes[instanceName] = newTheme
   store.set({instanceThemes: instanceThemes})
   store.save()
-  if (instanceName === store.get('currentInstance')) {
+  let { currentInstance } = store.get()
+  if (instanceName === currentInstance) {
     switchToTheme(newTheme)
   }
 }
 
 export function switchToInstance (instanceName) {
-  let instanceThemes = store.get('instanceThemes')
+  let { instanceThemes } = store.get()
   store.set({
     currentInstance: instanceName,
     searchResults: null,
@@ -35,11 +36,13 @@ export function switchToInstance (instanceName) {
 }
 
 export async function logOutOfInstance (instanceName) {
-  let loggedInInstances = store.get('loggedInInstances')
-  let instanceThemes = store.get('instanceThemes')
-  let loggedInInstancesInOrder = store.get('loggedInInstancesInOrder')
-  let composeData = store.get('composeData')
-  let currentInstance = store.get('currentInstance')
+  let {
+    loggedInInstances,
+    instanceThemes,
+    loggedInInstancesInOrder,
+    composeData,
+    currentInstance
+  } = store.get()
   loggedInInstancesInOrder.splice(loggedInInstancesInOrder.indexOf(instanceName), 1)
   let newInstance = instanceName === currentInstance
     ? loggedInInstancesInOrder[0]
@@ -64,13 +67,13 @@ export async function logOutOfInstance (instanceName) {
 }
 
 function setStoreVerifyCredentials (instanceName, thisVerifyCredentials) {
-  let verifyCredentials = store.get('verifyCredentials')
+  let { verifyCredentials } = store.get()
   verifyCredentials[instanceName] = thisVerifyCredentials
   store.set({verifyCredentials: verifyCredentials})
 }
 
 export async function updateVerifyCredentialsForInstance (instanceName) {
-  let loggedInInstances = store.get('loggedInInstances')
+  let { loggedInInstances } = store.get()
   let accessToken = loggedInInstances[instanceName].access_token
   await cacheFirstUpdateAfter(
     () => getVerifyCredentials(instanceName, accessToken),
@@ -81,7 +84,8 @@ export async function updateVerifyCredentialsForInstance (instanceName) {
 }
 
 export async function updateVerifyCredentialsForCurrentInstance () {
-  await updateVerifyCredentialsForInstance(store.get('currentInstance'))
+  let { currentInstance } = store.get()
+  await updateVerifyCredentialsForInstance(currentInstance)
 }
 
 export async function updateInstanceInfo (instanceName) {
@@ -90,7 +94,7 @@ export async function updateInstanceInfo (instanceName) {
     () => getInstanceInfoFromDatabase(instanceName),
     info => setInstanceInfoInDatabase(instanceName, info),
     info => {
-      let instanceInfos = store.get('instanceInfos')
+      let { instanceInfos } = store.get()
       instanceInfos[instanceName] = info
       store.set({instanceInfos: instanceInfos})
     }

--- a/routes/_actions/lists.js
+++ b/routes/_actions/lists.js
@@ -7,16 +7,16 @@ import {
 } from '../_database/meta'
 
 export async function updateLists () {
-  let instanceName = store.get('currentInstance')
+  let currentInstance = store.get('currentInstance')
   let accessToken = store.get('accessToken')
 
   await cacheFirstUpdateAfter(
-    () => getLists(instanceName, accessToken),
-    () => getListsFromDatabase(instanceName),
-    lists => setListsInDatabase(instanceName, lists),
+    () => getLists(currentInstance, accessToken),
+    () => getListsFromDatabase(currentInstance),
+    lists => setListsInDatabase(currentInstance, lists),
     lists => {
       let instanceLists = store.get('instanceLists')
-      instanceLists[instanceName] = lists
+      instanceLists[currentInstance] = lists
       store.set({instanceLists: instanceLists})
     }
   )

--- a/routes/_actions/lists.js
+++ b/routes/_actions/lists.js
@@ -7,15 +7,14 @@ import {
 } from '../_database/meta'
 
 export async function updateLists () {
-  let currentInstance = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
 
   await cacheFirstUpdateAfter(
     () => getLists(currentInstance, accessToken),
     () => getListsFromDatabase(currentInstance),
     lists => setListsInDatabase(currentInstance, lists),
     lists => {
-      let instanceLists = store.get('instanceLists')
+      let { instanceLists } = store.get()
       instanceLists[currentInstance] = lists
       store.set({instanceLists: instanceLists})
     }

--- a/routes/_actions/media.js
+++ b/routes/_actions/media.js
@@ -4,11 +4,11 @@ import { toast } from '../_utils/toast'
 import { scheduleIdleTask } from '../_utils/scheduleIdleTask'
 
 export async function doMediaUpload (realm, file) {
-  let instanceName = store.get('currentInstance')
+  let currentInstance = store.get('currentInstance')
   let accessToken = store.get('accessToken')
   store.set({uploadingMedia: true})
   try {
-    let response = await uploadMedia(instanceName, accessToken, file)
+    let response = await uploadMedia(currentInstance, accessToken, file)
     let composeMedia = store.getComposeData(realm, 'media') || []
     composeMedia.push({
       data: response,

--- a/routes/_actions/media.js
+++ b/routes/_actions/media.js
@@ -4,8 +4,7 @@ import { toast } from '../_utils/toast'
 import { scheduleIdleTask } from '../_utils/scheduleIdleTask'
 
 export async function doMediaUpload (realm, file) {
-  let currentInstance = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
   store.set({uploadingMedia: true})
   try {
     let response = await uploadMedia(currentInstance, accessToken, file)

--- a/routes/_actions/mute.js
+++ b/routes/_actions/mute.js
@@ -4,8 +4,7 @@ import { toast } from '../_utils/toast'
 import { updateProfileAndRelationship } from './accounts'
 
 export async function setAccountMuted (accountId, mute, toastOnSuccess) {
-  let currentInstance = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
   try {
     if (mute) {
       await muteAccount(currentInstance, accessToken, accountId)

--- a/routes/_actions/mute.js
+++ b/routes/_actions/mute.js
@@ -4,13 +4,13 @@ import { toast } from '../_utils/toast'
 import { updateProfileAndRelationship } from './accounts'
 
 export async function setAccountMuted (accountId, mute, toastOnSuccess) {
-  let instanceName = store.get('currentInstance')
+  let currentInstance = store.get('currentInstance')
   let accessToken = store.get('accessToken')
   try {
     if (mute) {
-      await muteAccount(instanceName, accessToken, accountId)
+      await muteAccount(currentInstance, accessToken, accountId)
     } else {
-      await unmuteAccount(instanceName, accessToken, accountId)
+      await unmuteAccount(currentInstance, accessToken, accountId)
     }
     await updateProfileAndRelationship(accountId)
     if (toastOnSuccess) {

--- a/routes/_actions/pinnedStatuses.js
+++ b/routes/_actions/pinnedStatuses.js
@@ -9,18 +9,17 @@ import {
 } from '../_api/pinnedStatuses'
 
 export async function updatePinnedStatusesForAccount (accountId) {
-  let currentInstance = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
 
   await cacheFirstUpdateAfter(
     () => getPinnedStatuses(currentInstance, accessToken, accountId),
     () => getPinnedStatusesFromDatabase(currentInstance, accountId),
     statuses => insertPinnedStatusesInDatabase(currentInstance, accountId, statuses),
     statuses => {
-      let $pinnedStatuses = store.get('pinnedStatuses')
-      $pinnedStatuses[currentInstance] = $pinnedStatuses[currentInstance] || {}
-      $pinnedStatuses[currentInstance][accountId] = statuses
-      store.set({pinnedStatuses: $pinnedStatuses})
+      let { pinnedStatuses } = store.get()
+      pinnedStatuses[currentInstance] = pinnedStatuses[currentInstance] || {}
+      pinnedStatuses[currentInstance][accountId] = statuses
+      store.set({pinnedStatuses: pinnedStatuses})
     }
   )
 }

--- a/routes/_actions/pinnedStatuses.js
+++ b/routes/_actions/pinnedStatuses.js
@@ -9,17 +9,17 @@ import {
 } from '../_api/pinnedStatuses'
 
 export async function updatePinnedStatusesForAccount (accountId) {
-  let instanceName = store.get('currentInstance')
+  let currentInstance = store.get('currentInstance')
   let accessToken = store.get('accessToken')
 
   await cacheFirstUpdateAfter(
-    () => getPinnedStatuses(instanceName, accessToken, accountId),
-    () => getPinnedStatusesFromDatabase(instanceName, accountId),
-    statuses => insertPinnedStatusesInDatabase(instanceName, accountId, statuses),
+    () => getPinnedStatuses(currentInstance, accessToken, accountId),
+    () => getPinnedStatusesFromDatabase(currentInstance, accountId),
+    statuses => insertPinnedStatusesInDatabase(currentInstance, accountId, statuses),
     statuses => {
       let $pinnedStatuses = store.get('pinnedStatuses')
-      $pinnedStatuses[instanceName] = $pinnedStatuses[instanceName] || {}
-      $pinnedStatuses[instanceName][accountId] = statuses
+      $pinnedStatuses[currentInstance] = $pinnedStatuses[currentInstance] || {}
+      $pinnedStatuses[currentInstance][accountId] = statuses
       store.set({pinnedStatuses: $pinnedStatuses})
     }
   )

--- a/routes/_actions/reblog.js
+++ b/routes/_actions/reblog.js
@@ -8,18 +8,18 @@ export async function setReblogged (statusId, reblogged) {
     toast.say(`You cannot ${reblogged ? 'boost' : 'unboost'} while offline.`)
     return
   }
-  let instanceName = store.get('currentInstance')
+  let currentInstance = store.get('currentInstance')
   let accessToken = store.get('accessToken')
   let networkPromise = reblogged
-    ? reblogStatus(instanceName, accessToken, statusId)
-    : unreblogStatus(instanceName, accessToken, statusId)
-  store.setStatusReblogged(instanceName, statusId, reblogged) // optimistic update
+    ? reblogStatus(currentInstance, accessToken, statusId)
+    : unreblogStatus(currentInstance, accessToken, statusId)
+  store.setStatusReblogged(currentInstance, statusId, reblogged) // optimistic update
   try {
     await networkPromise
-    await setStatusRebloggedInDatabase(instanceName, statusId, reblogged)
+    await setStatusRebloggedInDatabase(currentInstance, statusId, reblogged)
   } catch (e) {
     console.error(e)
     toast.say(`Failed to ${reblogged ? 'boost' : 'unboost'}. ` + (e.message || ''))
-    store.setStatusReblogged(instanceName, statusId, !reblogged) // undo optimistic update
+    store.setStatusReblogged(currentInstance, statusId, !reblogged) // undo optimistic update
   }
 }

--- a/routes/_actions/reblog.js
+++ b/routes/_actions/reblog.js
@@ -4,12 +4,12 @@ import { reblogStatus, unreblogStatus } from '../_api/reblog'
 import { setStatusReblogged as setStatusRebloggedInDatabase } from '../_database/timelines/updateStatus'
 
 export async function setReblogged (statusId, reblogged) {
-  if (!store.get('online')) {
+  let online = store.get()
+  if (!online) {
     toast.say(`You cannot ${reblogged ? 'boost' : 'unboost'} while offline.`)
     return
   }
-  let currentInstance = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
+  let { currentInstance, accessToken } = store.get()
   let networkPromise = reblogged
     ? reblogStatus(currentInstance, accessToken, statusId)
     : unreblogStatus(currentInstance, accessToken, statusId)

--- a/routes/_actions/search.js
+++ b/routes/_actions/search.js
@@ -3,14 +3,12 @@ import { toast } from '../_utils/toast'
 import { search } from '../_api/search'
 
 export async function doSearch () {
-  let currentInstance = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
-  let queryInSearch = store.get('queryInSearch')
+  let { currentInstance, accessToken, queryInSearch } = store.get()
   store.set({searchLoading: true})
   try {
     let results = await search(currentInstance, accessToken, queryInSearch)
-    let currentQueryInSearch = store.get('queryInSearch') // avoid race conditions
-    if (currentQueryInSearch === queryInSearch) {
+    let { queryInSearch: newQueryInSearch } = store.get() // avoid race conditions
+    if (newQueryInSearch === queryInSearch) {
       store.set({
         searchResultsForQuery: queryInSearch,
         searchResults: results

--- a/routes/_actions/search.js
+++ b/routes/_actions/search.js
@@ -3,12 +3,12 @@ import { toast } from '../_utils/toast'
 import { search } from '../_api/search'
 
 export async function doSearch () {
-  let instanceName = store.get('currentInstance')
+  let currentInstance = store.get('currentInstance')
   let accessToken = store.get('accessToken')
   let queryInSearch = store.get('queryInSearch')
   store.set({searchLoading: true})
   try {
-    let results = await search(instanceName, accessToken, queryInSearch)
+    let results = await search(currentInstance, accessToken, queryInSearch)
     let currentQueryInSearch = store.get('queryInSearch') // avoid race conditions
     if (currentQueryInSearch === queryInSearch) {
       store.set({

--- a/routes/_actions/timeline.js
+++ b/routes/_actions/timeline.js
@@ -79,10 +79,11 @@ export async function setupTimeline () {
   // (i.e. via offline mode), then we need to re-fetch
   // Also do this if it's a thread, because threads change pretty frequently and
   // we don't have a good way to update them.
-
-  let { timelineItemIds } = store.get()
-  let { timelineItemIdsAreStale } = store.get()
-  let { currentTimeline } = store.get()
+  let {
+    timelineItemIds,
+    timelineItemIdsAreStale,
+    currentTimeline
+  } = store.get()
   if (!timelineItemIds ||
       timelineItemIdsAreStale ||
       currentTimeline.startsWith('status/')) {

--- a/routes/_actions/timeline.js
+++ b/routes/_actions/timeline.js
@@ -60,14 +60,14 @@ export async function addTimelineItemIds (instanceName, timelineName, newIds, ne
 
 async function fetchTimelineItemsAndPossiblyFallBack () {
   mark('fetchTimelineItemsAndPossiblyFallBack')
-  let timelineName = store.get('currentTimeline')
-  let instanceName = store.get('currentInstance')
+  let currentTimeline = store.get('currentTimeline')
+  let currentInstance = store.get('currentInstance')
   let accessToken = store.get('accessToken')
   let lastTimelineItemId = store.get('lastTimelineItemId')
   let online = store.get('online')
 
-  let { items, stale } = await fetchTimelineItems(instanceName, accessToken, timelineName, lastTimelineItemId, online)
-  addTimelineItems(instanceName, timelineName, items, stale)
+  let { items, stale } = await fetchTimelineItems(currentInstance, accessToken, currentTimeline, lastTimelineItemId, online)
+  addTimelineItems(currentInstance, currentTimeline, items, stale)
   stop('fetchTimelineItemsAndPossiblyFallBack')
 }
 

--- a/routes/_actions/timeline.js
+++ b/routes/_actions/timeline.js
@@ -60,11 +60,13 @@ export async function addTimelineItemIds (instanceName, timelineName, newIds, ne
 
 async function fetchTimelineItemsAndPossiblyFallBack () {
   mark('fetchTimelineItemsAndPossiblyFallBack')
-  let currentTimeline = store.get('currentTimeline')
-  let currentInstance = store.get('currentInstance')
-  let accessToken = store.get('accessToken')
-  let lastTimelineItemId = store.get('lastTimelineItemId')
-  let online = store.get('online')
+  let {
+    currentTimeline,
+    currentInstance,
+    accessToken,
+    lastTimelineItemId,
+    online
+  } = store.get()
 
   let { items, stale } = await fetchTimelineItems(currentInstance, accessToken, currentTimeline, lastTimelineItemId, online)
   addTimelineItems(currentInstance, currentTimeline, items, stale)
@@ -78,9 +80,9 @@ export async function setupTimeline () {
   // Also do this if it's a thread, because threads change pretty frequently and
   // we don't have a good way to update them.
 
-  let timelineItemIds = store.get('timelineItemIds')
-  let timelineItemIdsAreStale = store.get('timelineItemIdsAreStale')
-  let currentTimeline = store.get('currentTimeline')
+  let { timelineItemIds } = store.get()
+  let { timelineItemIdsAreStale } = store.get()
+  let { currentTimeline } = store.get()
   if (!timelineItemIds ||
       timelineItemIdsAreStale ||
       currentTimeline.startsWith('status/')) {
@@ -109,9 +111,10 @@ export async function showMoreItemsForTimeline (instanceName, timelineName) {
 }
 
 export async function showMoreItemsForCurrentTimeline () {
+  let { currentInstance, currentTimeline } = store.get()
   return showMoreItemsForTimeline(
-    store.get('currentInstance'),
-    store.get('currentTimeline')
+    currentInstance,
+    currentTimeline
   )
 }
 

--- a/routes/_components/AccountsListPage.html
+++ b/routes/_components/AccountsListPage.html
@@ -34,7 +34,7 @@
 
   export default {
     async oncreate() {
-      let accountsFetcher = this.get('accountsFetcher')
+      let { accountsFetcher } = this.get()
       try {
         // TODO: paginate
         let accounts = await accountsFetcher()

--- a/routes/_components/IconButton.html
+++ b/routes/_components/IconButton.html
@@ -107,7 +107,8 @@
   export default {
     oncreate() {
       this.observe('animation', animation => {
-        if (!animation || this.store.get('reduceMotion')) {
+        let reduceMotion = this.store.get()
+        if (!animation || reduceMotion) {
           return
         }
         let svg = this.refs.svg

--- a/routes/_components/LazyImage.html
+++ b/routes/_components/LazyImage.html
@@ -28,8 +28,8 @@
     oncreate() {
       mark('LazyImage oncreate()')
       let img = new Image()
-      let src = this.get('src')
-      let fallback = this.get('fallback')
+      let { src } = this.get()
+      let { fallback } = this.get()
       img.onload = () => {
         requestAnimationFrame(() => {
           this.set({

--- a/routes/_components/NavItem.html
+++ b/routes/_components/NavItem.html
@@ -136,7 +136,8 @@
     },
     methods: {
       onClick(e) {
-        if (!this.get('selected')) {
+        let { selected } = this.get('selected')
+        if (!selected) {
           return
         }
         e.preventDefault()

--- a/routes/_components/NavItem.html
+++ b/routes/_components/NavItem.html
@@ -136,7 +136,7 @@
     },
     methods: {
       onClick(e) {
-        let { selected } = this.get('selected')
+        let { selected } = this.get()
         if (!selected) {
           return
         }

--- a/routes/_components/NonAutoplayImg.html
+++ b/routes/_components/NonAutoplayImg.html
@@ -28,11 +28,8 @@
   export default {
     methods: {
       onMouseOver(mouseOver) {
-        if (mouseOver) {
-          this.refs.node.src = this.get('src')
-        } else {
-          this.refs.node.src = this.get('staticSrc')
-        }
+        let { src, staticSrc } = this.get()
+        this.refs.node.src = mouseOver ? src : staticSrc
       }
     },
     events: {

--- a/routes/_components/community/PageListItem.html
+++ b/routes/_components/community/PageListItem.html
@@ -75,8 +75,7 @@
     methods: {
       onPinClick(e) {
         e.preventDefault()
-        let currentInstance = this.store.get('currentInstance')
-        let pinnedPages = this.store.get('pinnedPages')
+        let { currentInstance, pinnedPages } = this.store.get()
         let { href } = this.get()
         pinnedPages[currentInstance] = href
         this.store.set({pinnedPages: pinnedPages})

--- a/routes/_components/community/PageListItem.html
+++ b/routes/_components/community/PageListItem.html
@@ -77,7 +77,7 @@
         e.preventDefault()
         let currentInstance = this.store.get('currentInstance')
         let pinnedPages = this.store.get('pinnedPages')
-        let href = this.get('href')
+        let { href } = this.get()
         pinnedPages[currentInstance] = href
         this.store.set({pinnedPages: pinnedPages})
         this.store.save()

--- a/routes/_components/compose/ComposeAutosuggest.html
+++ b/routes/_components/compose/ComposeAutosuggest.html
@@ -59,14 +59,14 @@
       // perf improves for input responsiveness
       this.observe('composeSelectionStart', () => {
         scheduleIdleTask(() => {
-          let { composeSelectionStart } = this.get()
+          let { composeSelectionStart } = this.get() || {} // TODO: wtf svelte?
           this.set({composeSelectionStartDeferred: composeSelectionStart})
         })
       })
       this.observe('composeFocused', (composeFocused) => {
         let updateFocusedState = () => {
           scheduleIdleTask(() => {
-            let { composeFocused } = this.get()
+            let { composeFocused } = this.get() || {} // TODO: wtf svelte?
             this.set({composeFocusedDeferred: composeFocused})
           })
         }

--- a/routes/_components/compose/ComposeAutosuggest.html
+++ b/routes/_components/compose/ComposeAutosuggest.html
@@ -106,10 +106,9 @@
       onClick(item) {
         this.fire('autosuggestItemSelected')
         let { realm } = this.get()
-        let selectionStart = this.store.get('composeSelectionStart')
-        let searchText = this.store.get('composeAutosuggestionSearchText')
-        let startIndex = selectionStart - searchText.length
-        let endIndex = selectionStart
+        let { composeSelectionStart, composeAutosuggestionSearchText } = this.store.get()
+        let startIndex = composeSelectionStart - composeAutosuggestionSearchText.length
+        let endIndex = composeSelectionStart
         if (item.acct) {
           /* no await */ insertUsername(realm, item.acct, startIndex, endIndex)
         } else {
@@ -119,15 +118,15 @@
       },
       async searchAccounts(searchText) {
         searchText = searchText.substring(1)
-        let currentInstance = this.store.get('currentInstance')
+        let { currentInstance } = this.store.get()
         let results = await searchAccountsByUsernameInDatabase(
           currentInstance, searchText, DATABASE_SEARCH_RESULTS_LIMIT)
         return results.slice(0, SEARCH_RESULTS_LIMIT)
       },
       searchEmoji(searchText) {
         searchText = searchText.toLowerCase().substring(1)
-        let customEmoji = this.store.get('currentCustomEmoji')
-        let results = customEmoji.filter(emoji => emoji.shortcode.toLowerCase().startsWith(searchText))
+        let { currentCustomEmoji } = this.store.get()
+        let results = currentCustomEmoji.filter(emoji => emoji.shortcode.toLowerCase().startsWith(searchText))
           .sort((a, b) => a.shortcode.toLowerCase() < b.shortcode.toLowerCase() ? -1 : 1)
           .slice(0, SEARCH_RESULTS_LIMIT)
         return results

--- a/routes/_components/compose/ComposeAutosuggest.html
+++ b/routes/_components/compose/ComposeAutosuggest.html
@@ -59,13 +59,15 @@
       // perf improves for input responsiveness
       this.observe('composeSelectionStart', () => {
         scheduleIdleTask(() => {
-          this.set({composeSelectionStartDeferred: this.get('composeSelectionStart')})
+          let { composeSelectionStart } = this.get()
+          this.set({composeSelectionStartDeferred: composeSelectionStart})
         })
       })
       this.observe('composeFocused', (composeFocused) => {
         let updateFocusedState = () => {
           scheduleIdleTask(() => {
-            this.set({composeFocusedDeferred: this.get('composeFocused')})
+            let { composeFocused } = this.get()
+            this.set({composeFocusedDeferred: composeFocused})
           })
         }
 
@@ -103,7 +105,7 @@
       once: once,
       onClick(item) {
         this.fire('autosuggestItemSelected')
-        let realm = this.get('realm')
+        let { realm } = this.get()
         let selectionStart = this.store.get('composeSelectionStart')
         let searchText = this.store.get('composeAutosuggestionSearchText')
         let startIndex = selectionStart - searchText.length

--- a/routes/_components/compose/ComposeBox.html
+++ b/routes/_components/compose/ComposeBox.html
@@ -118,7 +118,7 @@
 
   export default {
     oncreate() {
-      let realm = this.get('realm')
+      let { realm } = this.get()
       if (realm === 'home') {
         this.setupStickyObserver()
       } else if (realm !== 'dialog') {
@@ -126,13 +126,13 @@
         insertHandleForReply(realm)
       }
 
-      let replySpoiler = this.get('replySpoiler')
+      let { replySpoiler } = this.get()
       if (replySpoiler) {
         // default spoiler is same as the replied-to status
         setReplySpoiler(realm, replySpoiler)
       }
 
-      let replyVisibility = this.get('replyVisibility')
+      let { replyVisibility } = this.get()
       if (replyVisibility) {
         // make sure the visibility is consistent with the replied-to status
         setReplyVisibility(realm, replyVisibility)
@@ -200,17 +200,19 @@
         }
       },
       doPostStatus() {
-        let text = this.get('text')
-        let media = this.get('media')
-        let postPrivacyKey = this.get('postPrivacyKey')
-        let contentWarning = this.get('contentWarning')
+        let {
+          text,
+          media,
+          postPrivacyKey,
+          contentWarning,
+          realm,
+          overLimit,
+          mediaDescriptions,
+          inReplyToUuid
+        } = this.get()
         let sensitive = media.length && !!contentWarning
-        let realm = this.get('realm')
         let mediaIds = media.map(_ => _.data.id)
         let inReplyTo = (realm === 'home' || realm === 'dialog') ? null : realm
-        let overLimit = this.get('overLimit')
-        let mediaDescriptions = this.get('mediaDescriptions')
-        let inReplyToUuid = this.get('inReplyToUuid')
 
         if (!text || overLimit) {
           return // do nothing if invalid

--- a/routes/_components/compose/ComposeBox.html
+++ b/routes/_components/compose/ComposeBox.html
@@ -189,7 +189,8 @@
     },
     methods: {
       async onClickPostButton() {
-        if (this.get('sticky')) {
+        let { sticky } = this.get()
+        if (sticky) {
           // when the button is sticky, we're scrolled down the home timeline,
           // so we should launch a new compose dialog
           let dialogs = await importDialogs()

--- a/routes/_components/compose/ComposeContentWarning.html
+++ b/routes/_components/compose/ComposeContentWarning.html
@@ -37,7 +37,8 @@
         const saveText = debounce(() => scheduleIdleTask(() => this.store.save()), 1000)
 
         this.observe('rawText', rawText => {
-          this.store.setComposeData(this.get('realm'), {
+          let { realm } = this.get()
+          this.store.setComposeData(realm, {
             contentWarning: rawText
           })
           saveText()

--- a/routes/_components/compose/ComposeInput.html
+++ b/routes/_components/compose/ComposeInput.html
@@ -50,7 +50,8 @@
         let textarea = this.refs.textarea
         let firstTime = true
         this.observe('text', text => {
-          if (this.get('rawText') !== text) {
+          let { rawText } = this.get()
+          if (rawText !== text) {
             this.set({rawText: text})
             // this next autosize is required to resize after
             // the user clicks the "toot" button
@@ -60,7 +61,8 @@
           }
           if (firstTime) {
             firstTime = false
-            if (this.get('autoFocus')) {
+            let { autoFocus } = this.get()
+            if (autoFocus) {
               requestAnimationFrame(() => textarea.focus())
             }
           }
@@ -126,27 +128,34 @@
         }
       },
       clickSelectedAutosuggestion(event) {
-        let autosuggestionShown = this.store.get('composeAutosuggestionShown')
-        if (!autosuggestionShown) {
+        let {
+          composeAutosuggestionShown,
+          composeAutosuggestionType
+        } = this.store.get()
+        if (!composeAutosuggestionShown) {
           return false
         }
-        let type = this.store.get('composeAutosuggestionType')
-        if (type === 'account') {
-          /* no await */ clickSelectedAutosuggestionUsername(this.get('realm'))
+        let { realm } = this.get()
+        if (composeAutosuggestionType === 'account') {
+          /* no await */ clickSelectedAutosuggestionUsername(realm)
         } else { // emoji
-          /* no await */ clickSelectedAutosuggestionEmoji(this.get('realm'))
+          /* no await */ clickSelectedAutosuggestionEmoji(realm)
         }
         event.preventDefault()
         event.stopPropagation()
         return true
       },
       incrementAutosuggestSelected(increment, event) {
-        let autosuggestionShown = this.store.get('composeAutosuggestionShown')
-        if (!autosuggestionShown) {
+        let {
+          composeAutosuggestionShown,
+          composeAutosuggestionSelected,
+          composeAutosuggestionSearchResults
+        } = this.store.get()
+        if (!composeAutosuggestionShown) {
           return
         }
-        let selected = this.store.get('composeAutosuggestionSelected') || 0
-        let searchResults = this.store.get('composeAutosuggestionSearchResults') || []
+        let selected = composeAutosuggestionSelected || 0
+        let searchResults = composeAutosuggestionSearchResults || []
         selected += increment
         if (selected >= 0) {
           selected = selected % searchResults.length
@@ -158,8 +167,8 @@
         event.stopPropagation()
       },
       clearAutosuggestions(event) {
-        let autosuggestionShown = this.store.get('composeAutosuggestionShown')
-        if (!autosuggestionShown) {
+        let { composeAutosuggestionShown } = this.store.get()
+        if (!composeAutosuggestionShown) {
           return
         }
         this.store.set({

--- a/routes/_components/compose/ComposeInput.html
+++ b/routes/_components/compose/ComposeInput.html
@@ -71,7 +71,7 @@
 
         this.observe('rawText', rawText => {
           mark('observe rawText')
-          let realm = this.get('realm')
+          let { realm } = this.get()
           this.store.setComposeData(realm, {text: rawText})
           saveStore()
           stop('observe rawText')

--- a/routes/_components/compose/ComposeLengthGauge.html
+++ b/routes/_components/compose/ComposeLengthGauge.html
@@ -31,7 +31,7 @@
       this.observe('lengthAsFraction', () => {
         scheduleIdleTask(() => {
           mark('set lengthAsFractionDeferred')
-          let { lengthAsFraction } = this.get()
+          let { lengthAsFraction } = this.get() || {} // TODO: wtf svelte?
           this.set({lengthAsFractionDeferred: lengthAsFraction})
           stop('set lengthAsFractionDeferred')
           requestAnimationFrame(() => this.set({shouldAnimate: true}))

--- a/routes/_components/compose/ComposeLengthGauge.html
+++ b/routes/_components/compose/ComposeLengthGauge.html
@@ -25,12 +25,14 @@
 
   export default {
     oncreate() {
-      this.set({lengthAsFractionDeferred: this.get('lengthAsFraction')})
+      let { lengthAsFraction } = this.get()
+      this.set({lengthAsFractionDeferred: lengthAsFraction})
       // perf improvement for keyboard input latency
       this.observe('lengthAsFraction', () => {
         scheduleIdleTask(() => {
           mark('set lengthAsFractionDeferred')
-          this.set({lengthAsFractionDeferred: this.get('lengthAsFraction')})
+          let { lengthAsFraction } = this.get()
+          this.set({lengthAsFractionDeferred: lengthAsFraction})
           stop('set lengthAsFractionDeferred')
           requestAnimationFrame(() => this.set({shouldAnimate: true}))
         })

--- a/routes/_components/compose/ComposeLengthIndicator.html
+++ b/routes/_components/compose/ComposeLengthIndicator.html
@@ -29,7 +29,7 @@
       this.observe('lengthToDisplay', () => {
         scheduleIdleTask(() => {
           mark('set lengthToDisplayDeferred')
-          let { lengthToDisplay } = this.get()
+          let { lengthToDisplay } = this.get() || {} // TODO: wtf svelte?
           this.set({lengthToDisplayDeferred: lengthToDisplay})
           stop('set lengthToDisplayDeferred')
         })

--- a/routes/_components/compose/ComposeLengthIndicator.html
+++ b/routes/_components/compose/ComposeLengthIndicator.html
@@ -23,12 +23,14 @@
 
   export default {
     oncreate() {
-      this.set({lengthToDisplayDeferred: this.get('lengthToDisplay')})
+      let { lengthToDisplay } = this.get()
+      this.set({lengthToDisplayDeferred: lengthToDisplay})
       // perf improvement for keyboard input latency
       this.observe('lengthToDisplay', () => {
         scheduleIdleTask(() => {
           mark('set lengthToDisplayDeferred')
-          this.set({lengthToDisplayDeferred: this.get('lengthToDisplay')})
+          let { lengthToDisplay } = this.get()
+          this.set({lengthToDisplayDeferred: lengthToDisplay})
           stop('set lengthToDisplayDeferred')
         })
       }, {init: false})

--- a/routes/_components/compose/ComposeMediaItem.html
+++ b/routes/_components/compose/ComposeMediaItem.html
@@ -93,9 +93,9 @@
       setupSyncFromStore() {
         this.observe('mediaDescriptions', mediaDescriptions => {
           mediaDescriptions = mediaDescriptions || []
-          let { index } = this.get()
+          let { index, rawText } = this.get()
           let text = mediaDescriptions[index] || ''
-          if (this.get('rawText') !== text) {
+          if (rawText !== text) {
             this.set({rawText: text})
           }
         })
@@ -119,7 +119,11 @@
         }, {init: false})
       },
       onDeleteMedia() {
-        deleteMedia(this.get('realm'), this.get('index'))
+        let {
+          realm,
+          index
+        } = this.get()
+        deleteMedia(realm, index)
       }
     }
   }

--- a/routes/_components/compose/ComposeMediaItem.html
+++ b/routes/_components/compose/ComposeMediaItem.html
@@ -93,7 +93,7 @@
       setupSyncFromStore() {
         this.observe('mediaDescriptions', mediaDescriptions => {
           mediaDescriptions = mediaDescriptions || []
-          let index = this.get('index')
+          let { index } = this.get()
           let text = mediaDescriptions[index] || ''
           if (this.get('rawText') !== text) {
             this.set({rawText: text})
@@ -104,8 +104,8 @@
         const saveStore = debounce(() => scheduleIdleTask(() => this.store.save()), 1000)
 
         this.observe('rawText', rawText => {
-          let realm = this.get('realm')
-          let index = this.get('index')
+          let { realm } = this.get()
+          let { index } = this.get()
           let mediaDescriptions = store.getComposeData(realm, 'mediaDescriptions') || []
           if (mediaDescriptions[index] === rawText) {
             return

--- a/routes/_components/compose/ComposeToolbar.html
+++ b/routes/_components/compose/ComposeToolbar.html
@@ -78,7 +78,7 @@
       },
       onFileChange(e) {
         let file = e.target.files[0]
-        let realm = this.get('realm')
+        let { realm } = this.get()
         doMediaUpload(realm, file)
       },
       async onPostPrivacyClick() {

--- a/routes/_components/compose/ComposeToolbar.html
+++ b/routes/_components/compose/ComposeToolbar.html
@@ -71,7 +71,8 @@
     methods: {
       async onEmojiClick() {
         let dialogs = await importDialogs()
-        dialogs.showEmojiDialog(this.get('realm'))
+        let { realm } = this.get()
+        dialogs.showEmojiDialog(realm)
       },
       onMediaClick() {
         this.refs.input.click()
@@ -83,10 +84,12 @@
       },
       async onPostPrivacyClick() {
         let dialogs = await importDialogs()
-        dialogs.showPostPrivacyDialog(this.get('realm'))
+        let { realm } = this.get()
+        dialogs.showPostPrivacyDialog(realm)
       },
       onContentWarningClick() {
-        toggleContentWarningShown(this.get('realm'))
+        let { realm } = this.get()
+        toggleContentWarningShown(realm)
       }
     }
   }

--- a/routes/_components/dialog/components/AccountProfileOptionsDialog.html
+++ b/routes/_components/dialog/components/AccountProfileOptionsDialog.html
@@ -99,7 +99,7 @@ export default {
       }
     },
     async onMentionClicked() {
-      let acct = this.get('acct')
+      let { acct } = this.get()
       this.store.setComposeData('dialog', {
         text: `@${acct} `
       })
@@ -108,21 +108,18 @@ export default {
       this.close()
     },
     async onFollowClicked() {
-      let accountId = this.get('accountId')
-      let following = this.get('following')
+      let { accountId, following } = this.get()
       this.close()
       await setAccountFollowed(accountId, !following, true)
     },
     async onBlockClicked() {
-      let account = this.get('account')
-      let blocking = this.get('blocking')
+      let { account, blocking } = this.get()
       let accountId = account.id
       this.close()
       await setAccountBlocked(accountId, !blocking, true)
     },
     async onMuteClicked() {
-      let accountId = this.get('accountId')
-      let muting = this.get('muting')
+      let { accountId, muting } = this.get()
       this.close()
       await setAccountMuted(accountId, !muting, true)
     }

--- a/routes/_components/dialog/components/AccountProfileOptionsDialog.html
+++ b/routes/_components/dialog/components/AccountProfileOptionsDialog.html
@@ -113,8 +113,7 @@ export default {
       await setAccountFollowed(accountId, !following, true)
     },
     async onBlockClicked() {
-      let { account, blocking } = this.get()
-      let accountId = account.id
+      let { accountId, blocking } = this.get()
       this.close()
       await setAccountBlocked(accountId, !blocking, true)
     },

--- a/routes/_components/dialog/components/ConfirmationDialog.html
+++ b/routes/_components/dialog/components/ConfirmationDialog.html
@@ -47,17 +47,23 @@
     methods: {
       show,
       close,
-      onDestroyDialog(id) {
-        if (id !== this.get('id')) {
+      onDestroyDialog(thisId) {
+        let {
+          id,
+          positiveResult,
+          onPositive,
+          onNegative
+        } = this.get()
+        if (thisId !== id) {
           return
         }
-        if (this.get('positiveResult')) {
-          if (this.get('onPositive')) {
-            this.get('onPositive')()
+        if (positiveResult) {
+          if (onPositive) {
+            onPositive()
           }
         } else {
-          if (this.get('onNegative')) {
-            this.get('onNegative')()
+          if (onNegative) {
+            onNegative()
           }
         }
       },

--- a/routes/_components/dialog/components/EmojiDialog.html
+++ b/routes/_components/dialog/components/EmojiDialog.html
@@ -82,7 +82,8 @@
       show,
       close,
       onClickEmoji(emoji) {
-        insertEmoji(this.get('realm'), emoji)
+        let { realm } = this.get()
+        insertEmoji(realm, emoji)
         this.close()
       }
     }

--- a/routes/_components/dialog/components/ModalDialog.html
+++ b/routes/_components/dialog/components/ModalDialog.html
@@ -132,7 +132,8 @@
       this._a11yDialog = new A11yDialog(dialogElement)
       this._a11yDialog.on('hide', () => {
         this._a11yDialog.destroy()
-        emit('destroyDialog', this.get('id'))
+        let { id } = this.get()
+        emit('destroyDialog', id)
         requestAnimationFrame(() => document.body.removeChild(dialogElement))
       })
       on('showDialog', this, this.showDialog)
@@ -161,8 +162,9 @@
       }
     },
     methods: {
-      showDialog(id) {
-        if (this.get('id') !== id) {
+      showDialog(thisId) {
+        let { id } = this.get()
+        if (id !== thisId) {
           return
         }
         this._a11yDialog.show()
@@ -170,8 +172,9 @@
           this.set({ fadedIn: true })
         })
       },
-      closeDialog(id) {
-        if (this.get('id') !== id) {
+      closeDialog(thisId) {
+        let { id } = this.get()
+        if (id !== thisId) {
           return
         }
         setTimeout(() => { // use setTimeout to workaround svelte timing issue

--- a/routes/_components/dialog/components/PostPrivacyDialog.html
+++ b/routes/_components/dialog/components/PostPrivacyDialog.html
@@ -30,7 +30,8 @@
       show,
       close,
       onClick(item) {
-        setPostPrivacy(this.get('realm'), item.key)
+        let { realm } = this.get()
+        setPostPrivacy(realm, item.key)
         this.close()
       }
     },

--- a/routes/_components/dialog/components/StatusOptionsDialog.html
+++ b/routes/_components/dialog/components/StatusOptionsDialog.html
@@ -102,25 +102,22 @@ export default {
       }
     },
     async onDeleteClicked() {
-      let statusId = this.get('statusId')
+      let { statusId } = this.get()
       this.close()
       await doDeleteStatus(statusId)
     },
     async onFollowClicked() {
-      let accountId = this.get('accountId')
-      let following = this.get('following')
+      let { accountId, following } = this.get()
       this.close()
       await setAccountFollowed(accountId, !following, true)
     },
     async onBlockClicked() {
-      let accountId = this.get('accountId')
-      let blocking = this.get('blocking')
+      let { accountId, blocking } = this.get()
       this.close()
       await setAccountBlocked(accountId, !blocking, true)
     },
     async onMuteClicked() {
-      let accountId = this.get('accountId')
-      let muting = this.get('muting')
+      let { accountId, muting } = this.get()
       this.close()
       await setAccountMuted(accountId, !muting, true)
     }

--- a/routes/_components/dialog/helpers/closeDialog.js
+++ b/routes/_components/dialog/helpers/closeDialog.js
@@ -1,6 +1,6 @@
 import { emit } from '../../../_utils/eventBus'
 
 export function close () {
-  let id = this.get('id')
+  let { id } = this.get()
   emit('closeDialog', id)
 }

--- a/routes/_components/dialog/helpers/onCreateDialog.js
+++ b/routes/_components/dialog/helpers/onCreateDialog.js
@@ -1,7 +1,8 @@
 import { on } from '../../../_utils/eventBus'
 
-function onDestroy (id) {
-  if (this.get('id') !== id) {
+function onDestroy (thisId) {
+  let { id } = this.get()
+  if (id !== thisId) {
     return
   }
   this.destroy()

--- a/routes/_components/dialog/helpers/showDialog.js
+++ b/routes/_components/dialog/helpers/showDialog.js
@@ -1,6 +1,6 @@
 import { emit } from '../../../_utils/eventBus'
 
 export function show () {
-  let id = this.get('id')
+  let { id } = this.get()
   emit('showDialog', id)
 }

--- a/routes/_components/profile/AccountProfileDetails.html
+++ b/routes/_components/profile/AccountProfileDetails.html
@@ -121,9 +121,7 @@
     },
     methods: {
       async onMoreOptionsClick() {
-        let account = this.get('account')
-        let relationship = this.get('relationship')
-        let verifyCredentials = this.get('verifyCredentials')
+        let { account, relationship, verifyCredentials } = this.get()
         let dialogs = await importDialogs()
         dialogs.showAccountProfileOptionsDialog(account, relationship, verifyCredentials)
       }

--- a/routes/_components/profile/AccountProfileFollow.html
+++ b/routes/_components/profile/AccountProfileFollow.html
@@ -31,11 +31,13 @@
       async onFollowButtonClick(e) {
         e.preventDefault()
         e.stopPropagation()
-        let account = this.get('account')
-        let accountId = this.get('accountId')
-        let following = this.get('following')
-        let followRequested = this.get('followRequested')
-        let blocking = this.get('blocking')
+        let {
+          account,
+          accountId,
+          following,
+          followRequested,
+          blocking
+        } = this.get()
         this.set({animateFollowButton: true}) // TODO: this should be an event, not toggling a boolean
         if (blocking) { // unblock
           await setAccountBlocked(accountId, false)

--- a/routes/_components/pseudoVirtualList/PseudoVirtualList.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualList.html
@@ -55,7 +55,7 @@
       stop('PseudoVirtualList oncreate()')
     },
     ondestroy() {
-      let intersectionObserver = this.get('intersectionObserver')
+      let { intersectionObserver } = this.get()
       if (intersectionObserver) {
         intersectionObserver.disconnect()
       }
@@ -86,7 +86,7 @@
       onIntersection(entries) {
         mark('onIntersection')
         let newIntersectionStates = {}
-        let scrollToItem = this.get('scrollToItem')
+        let { scrollToItem } = this.get()
         let intersectionStates = this.store.get('intersectionStates')
         for (let entry of entries) {
           let key = entry.target.getAttribute('pseudo-virtual-list-key')

--- a/routes/_components/pseudoVirtualList/PseudoVirtualList.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualList.html
@@ -28,25 +28,28 @@
   export default {
     oncreate() {
       mark('PseudoVirtualList oncreate()')
-      this.store.setCurrentRealm(this.get('realm'))
+      let { realm } = this.get()
+      this.store.setCurrentRealm(realm)
 
       // When re-rendering, assume all items are non-intersecting until told otherwise.
       // We already have the heights cached.
-      let intersectionStates = this.store.get('intersectionStates')
+      let { intersectionStates } = this.store.get()
       let keys = Object.keys(intersectionStates)
       for (let key of keys) {
         intersectionStates[key].isCached = true
       }
       this.store.setForRealm({intersectionStates: intersectionStates})
 
+      let { containerQuery } = this.get()
       let intersectionObserver = new IntersectionObserver(this.onIntersection.bind(this), {
-        root: document.querySelector(this.get('containerQuery')),
+        root: document.querySelector(containerQuery),
         rootMargin: '300% 0px'
       })
       this.set({intersectionObserver})
       this.observe('allItemsHaveHeight', allItemsHaveHeight => {
         console.log('allItemsHaveHeight', allItemsHaveHeight)
-        if (allItemsHaveHeight && !this.get('initialized')) {
+        let { initialized } = this.get()
+        if (allItemsHaveHeight && !initialized) {
           this.set({initialized: true})
           console.log('initialized PseudoVirtualList')
           this.fire('initialized')
@@ -74,7 +77,8 @@
     },
     methods: {
       scrollToPosition(element) {
-        if (this.get('scrolledToPosition')) {
+        let { scrolledToPosition } = this.get()
+        if (scrolledToPosition) {
           return
         }
         this.set({scrolledToPosition: true})
@@ -87,7 +91,7 @@
         mark('onIntersection')
         let newIntersectionStates = {}
         let { scrollToItem } = this.get()
-        let intersectionStates = this.store.get('intersectionStates')
+        let { intersectionStates } = this.store.get()
         for (let entry of entries) {
           let key = entry.target.getAttribute('pseudo-virtual-list-key')
           let rect = getRectFromEntry(entry)

--- a/routes/_components/pseudoVirtualList/PseudoVirtualListItem.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualListItem.html
@@ -35,7 +35,7 @@
         }
       })
 
-      let intersectionObserver = this.get('intersectionObserver')
+      let { intersectionObserver } = this.get()
       intersectionObserver.observe(this.refs.node)
     },
     computed: {

--- a/routes/_components/pseudoVirtualList/PseudoVirtualListItem.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualListItem.html
@@ -12,7 +12,6 @@
   {{/if}}
 </div>
 <script>
-
   import { scheduleIdleTask } from '../../_utils/scheduleIdleTask'
   import { mark, stop } from '../../_utils/marks'
 
@@ -27,7 +26,7 @@
           // unrender lazily; it's not a critical UI task
           scheduleIdleTask(() => {
             mark('unrender')
-            let { isIntersecting } = this.get()
+            let { isIntersecting } = this.get() || {} // TODO: wtf svelte?
             if (!isIntersecting) {
               this.set({hide: true})
             }

--- a/routes/_components/pseudoVirtualList/PseudoVirtualListItem.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualListItem.html
@@ -27,7 +27,8 @@
           // unrender lazily; it's not a critical UI task
           scheduleIdleTask(() => {
             mark('unrender')
-            if (!this.get('isIntersecting')) {
+            let { isIntersecting } = this.get()
+            if (!isIntersecting) {
               this.set({hide: true})
             }
             stop('unrender')

--- a/routes/_components/pseudoVirtualList/PseudoVirtualListLazyItem.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualListLazyItem.html
@@ -19,8 +19,7 @@
     async oncreate() {
       // TODO: there appears to be a bug in {{#await}} that means we have to do this manually.
       // Some items may appear on top of other items because their offset is 0 and never updated.
-      let makeProps = this.get('makeProps')
-      let key = this.get('key')
+      let { makeProps, key } = this.get()
       if (makeProps) {
         let props = await makeProps(key)
         mark('PseudoVirtualListLazyItem set props')

--- a/routes/_components/status/Media.html
+++ b/routes/_components/status/Media.html
@@ -138,16 +138,12 @@
     },
     methods: {
       async onClickPlayVideoButton() {
-        let media = this.get('media')
-        let width = this.get('modalWidth')
-        let height = this.get('modalHeight')
+        let { media, width, height } = this.get()
         let dialogs = await importDialogs()
         dialogs.showVideoDialog(media.preview_url, media.url, width, height, media.description)
       },
       async onClickShowImageButton() {
-        let media = this.get('media')
-        let width = this.get('modalWidth')
-        let height = this.get('modalHeight')
+        let { media, width, height } = this.get()
         let dialogs = await importDialogs()
         dialogs.showImageDialog(media.preview_url, media.url, media.type, width, height, media.description)
       }

--- a/routes/_components/status/Media.html
+++ b/routes/_components/status/Media.html
@@ -111,8 +111,10 @@
 
   export default {
     oncreate() {
-      registerClickDelegate(this, this.get('delegateKey'), () => {
-        if (this.get('media').type === 'video') {
+      let { delegateKey } = this.get()
+      registerClickDelegate(this, delegateKey, () => {
+        let { media } = this.get()
+        if (media.type === 'video') {
           this.onClickPlayVideoButton()
         } else {
           this.onClickShowImageButton()

--- a/routes/_components/status/Media.html
+++ b/routes/_components/status/Media.html
@@ -140,14 +140,16 @@
     },
     methods: {
       async onClickPlayVideoButton() {
-        let { media, width, height } = this.get()
+        let { media, modalWidth, modalHeight } = this.get()
         let dialogs = await importDialogs()
-        dialogs.showVideoDialog(media.preview_url, media.url, width, height, media.description)
+        dialogs.showVideoDialog(media.preview_url, media.url,
+          modalWidth, modalHeight, media.description)
       },
       async onClickShowImageButton() {
-        let { media, width, height } = this.get()
+        let { media, modalWidth, modalHeight } = this.get()
         let dialogs = await importDialogs()
-        dialogs.showImageDialog(media.preview_url, media.url, media.type, width, height, media.description)
+        dialogs.showImageDialog(media.preview_url, media.url, media.type,
+          modalWidth, modalHeight, media.description)
       }
     },
     data: () => ({

--- a/routes/_components/status/Status.html
+++ b/routes/_components/status/Status.html
@@ -123,12 +123,12 @@
 
   export default {
     oncreate() {
-      let { delegateKey } = this.get()
-      if (!this.get('isStatusInOwnThread')) {
+      let { delegateKey, isStatusInOwnThread, showContent } = this.get()
+      if (!isStatusInOwnThread) {
         // the whole <article> is clickable in this case
         registerClickDelegate(this, delegateKey, (e) => this.onClickOrKeydown(e))
       }
-      if (!this.get('showContent')) {
+      if (!showContent) {
         scheduleIdleTask(() => {
           // Perf optimization: lazily load the StatusContent when the user is idle so that
           // it's fast when they click the "show more" button
@@ -171,7 +171,8 @@
 
         e.preventDefault()
         e.stopPropagation()
-        goto(`/statuses/${this.get('originalStatusId')}`)
+        let { originalStatusId } = this.get()
+        goto(`/statuses/${originalStatusId}`)
       }
     },
     computed: {

--- a/routes/_components/status/Status.html
+++ b/routes/_components/status/Status.html
@@ -123,7 +123,7 @@
 
   export default {
     oncreate() {
-      let delegateKey = this.get('delegateKey')
+      let { delegateKey } = this.get()
       if (!this.get('isStatusInOwnThread')) {
         // the whole <article> is clickable in this case
         registerClickDelegate(this, delegateKey, (e) => this.onClickOrKeydown(e))

--- a/routes/_components/status/StatusComposeBox.html
+++ b/routes/_components/status/StatusComposeBox.html
@@ -39,7 +39,7 @@
           return
         }
         requestAnimationFrame(() => {
-          let uuid = this.get('uuid')
+          let { uuid } = this.get()
           let $repliesShown = this.store.get('repliesShown')
           $repliesShown[uuid] = false
           this.store.set({'repliesShown': $repliesShown})

--- a/routes/_components/status/StatusComposeBox.html
+++ b/routes/_components/status/StatusComposeBox.html
@@ -35,14 +35,15 @@
     },
     methods: {
       onPostedStatus(realm) {
-        if (realm !== this.get('originalStatusId')) {
+        let { originalStatusId } = this.get()
+        if (realm !== originalStatusId) {
           return
         }
         requestAnimationFrame(() => {
           let { uuid } = this.get()
-          let $repliesShown = this.store.get('repliesShown')
-          $repliesShown[uuid] = false
-          this.store.set({'repliesShown': $repliesShown})
+          let { repliesShown } = this.store.get()
+          repliesShown[uuid] = false
+          this.store.set({repliesShown})
           this.fire('recalculateHeight')
         })
       },

--- a/routes/_components/status/StatusContent.html
+++ b/routes/_components/status/StatusContent.html
@@ -96,8 +96,7 @@
         }
         mark('hydrateContent')
         let node = this.refs.node
-        let originalStatus = this.get('originalStatus')
-        let uuid = this.get('uuid')
+        let { originalStatus, uuid } = this.get()
         let count = 0
         let anchors = node.getElementsByTagName('A')
         let mentions = originalStatus.mentions

--- a/routes/_components/status/StatusMediaAttachments.html
+++ b/routes/_components/status/StatusMediaAttachments.html
@@ -130,7 +130,8 @@
 
   export default {
     oncreate() {
-      registerClickDelegate(this, this.get('delegateKey'), () => this.onClickSensitiveMediaButton())
+      let { delegateKey } = this.get()
+      registerClickDelegate(this, delegateKey, () => this.onClickSensitiveMediaButton())
     },
     components: {
       MediaAttachments
@@ -145,9 +146,9 @@
     methods: {
       onClickSensitiveMediaButton() {
         let { uuid } = this.get()
-        let $sensitivesShown = this.store.get('sensitivesShown') || {}
-        $sensitivesShown[uuid] = !$sensitivesShown[uuid]
-        this.store.set({'sensitivesShown': $sensitivesShown})
+        let { sensitivesShown } = this.store.get()
+        sensitivesShown[uuid] = !sensitivesShown[uuid]
+        this.store.set({sensitivesShown})
         this.fire('recalculateHeight')
       }
     }

--- a/routes/_components/status/StatusMediaAttachments.html
+++ b/routes/_components/status/StatusMediaAttachments.html
@@ -144,7 +144,7 @@
     },
     methods: {
       onClickSensitiveMediaButton() {
-        let uuid = this.get('uuid')
+        let { uuid } = this.get()
         let $sensitivesShown = this.store.get('sensitivesShown') || {}
         $sensitivesShown[uuid] = !$sensitivesShown[uuid]
         this.store.set({'sensitivesShown': $sensitivesShown})

--- a/routes/_components/status/StatusSpoiler.html
+++ b/routes/_components/status/StatusSpoiler.html
@@ -69,7 +69,7 @@
       onClickSpoilerButton() {
         requestAnimationFrame(() => {
           mark('clickSpoilerButton')
-          let uuid = this.get('uuid')
+          let { uuid } = this.get()
           let $spoilersShown = this.store.get('spoilersShown')
           $spoilersShown[uuid] = !$spoilersShown[uuid]
           this.store.set({'spoilersShown': $spoilersShown})

--- a/routes/_components/status/StatusSpoiler.html
+++ b/routes/_components/status/StatusSpoiler.html
@@ -53,7 +53,8 @@
 
   export default {
     oncreate() {
-      registerClickDelegate(this, this.get('delegateKey'), () => this.onClickSpoilerButton())
+      let { delegateKey } = this.get()
+      registerClickDelegate(this, delegateKey, () => this.onClickSpoilerButton())
     },
     store: () => store,
     computed: {
@@ -70,9 +71,9 @@
         requestAnimationFrame(() => {
           mark('clickSpoilerButton')
           let { uuid } = this.get()
-          let $spoilersShown = this.store.get('spoilersShown')
-          $spoilersShown[uuid] = !$spoilersShown[uuid]
-          this.store.set({'spoilersShown': $spoilersShown})
+          let { spoilersShown } = this.store.get()
+          spoilersShown[uuid] = !spoilersShown[uuid]
+          this.store.set({spoilersShown})
           this.fire('recalculateHeight')
           stop('clickSpoilerButton')
         })

--- a/routes/_components/status/StatusToolbar.html
+++ b/routes/_components/status/StatusToolbar.html
@@ -70,16 +70,14 @@
       onFavoriteClick(e) {
         e.preventDefault()
         e.stopPropagation()
-        let originalStatusId = this.get('originalStatusId')
-        let favorited = this.get('favorited')
+        let { originalStatusId, favorited } = this.get()
         /* no await */ setFavorited(originalStatusId, !favorited)
         this.set({animateFavorite: !favorited})
       },
       onReblogClick(e) {
         e.preventDefault()
         e.stopPropagation()
-        let originalStatusId = this.get('originalStatusId')
-        let reblogged = this.get('reblogged')
+        let { originalStatusId, reblogged } = this.get()
         /* no await */ setReblogged(originalStatusId, !reblogged)
         this.set({animateReblog: !reblogged})
       },
@@ -87,7 +85,7 @@
         e.preventDefault()
         e.stopPropagation()
         requestAnimationFrame(() => {
-          let uuid = this.get('uuid')
+          let { uuid } = this.get()
           let $repliesShown = this.store.get('repliesShown')
           $repliesShown[uuid] = !$repliesShown[uuid]
           this.store.set({'repliesShown': $repliesShown})
@@ -97,8 +95,7 @@
       async onOptionsClick(e) {
         e.preventDefault()
         e.stopPropagation()
-        let originalStatusId = this.get('originalStatusId')
-        let originalAccountId = this.get('originalAccountId')
+        let { originalStatusId, originalAccountId } = this.get()
         let updateRelationshipPromise = updateProfileAndRelationship(originalAccountId)
         let dialogs = await importDialogs()
         await updateRelationshipPromise

--- a/routes/_components/status/StatusToolbar.html
+++ b/routes/_components/status/StatusToolbar.html
@@ -54,11 +54,17 @@
 
   export default {
     oncreate() {
+      let {
+        favoriteKey,
+        reblogKey,
+        replyKey,
+        optionsKey
+      } = this.get()
       registerClickDelegates(this, {
-        [this.get('favoriteKey')]: (e) => this.onFavoriteClick(e),
-        [this.get('reblogKey')]: (e) => this.onReblogClick(e),
-        [this.get('replyKey')]: (e) => this.onReplyClick(e),
-        [this.get('optionsKey')]: (e) => this.onOptionsClick(e)
+        [favoriteKey]: (e) => this.onFavoriteClick(e),
+        [reblogKey]: (e) => this.onReblogClick(e),
+        [replyKey]: (e) => this.onReplyClick(e),
+        [optionsKey]: (e) => this.onOptionsClick(e)
       })
       on('postedStatus', this, this.onPostedStatus)
     },
@@ -86,9 +92,9 @@
         e.stopPropagation()
         requestAnimationFrame(() => {
           let { uuid } = this.get()
-          let $repliesShown = this.store.get('repliesShown')
-          $repliesShown[uuid] = !$repliesShown[uuid]
-          this.store.set({'repliesShown': $repliesShown})
+          let { repliesShown } = this.store.get()
+          repliesShown[uuid] = !repliesShown[uuid]
+          this.store.set({repliesShown})
           this.fire('recalculateHeight')
         })
       },
@@ -102,8 +108,12 @@
         dialogs.showStatusOptionsDialog(originalStatusId)
       },
       onPostedStatus(realm, inReplyToUuid) {
-        if (realm !== this.get('originalStatusId') ||
-            inReplyToUuid !== this.get('uuid')) {
+        let {
+          originalStatusId,
+          uuid
+        } = this.get()
+        if (realm !== originalStatusId ||
+            inReplyToUuid !== uuid) {
           return
         }
         try {

--- a/routes/_components/timeline/LazyTimeline.html
+++ b/routes/_components/timeline/LazyTimeline.html
@@ -17,10 +17,10 @@
 
   export default {
     oncreate() {
-      let instanceName = this.store.get('currentInstance')
-      let timeline = this.get('timeline')
+      let { currentInstance } = this.store.get()
+      let { timeline } = this.get()
       this.store.set({currentTimeline: timeline})
-      this.store.setForTimeline(instanceName, timeline, {runningUpdate: false})
+      this.store.setForTimeline(currentInstance, timeline, {runningUpdate: false})
     },
     store: () => store,
     data: () => ({

--- a/routes/_components/timeline/MoreHeader.html
+++ b/routes/_components/timeline/MoreHeader.html
@@ -15,7 +15,7 @@
   export default {
     methods: {
       onClick(event) {
-        let onClick = this.get('onClick')
+        let { onClick } = this.get()
         if (onClick) {
           onClick(event)
         }

--- a/routes/_components/timeline/PinnedStatuses.html
+++ b/routes/_components/timeline/PinnedStatuses.html
@@ -17,7 +17,7 @@
 
   export default {
     async oncreate() {
-      let accountId = this.get('accountId')
+      let { accountId } = this.get()
       await updatePinnedStatusesForAccount(accountId)
     },
     computed: {

--- a/routes/_components/timeline/Timeline.html
+++ b/routes/_components/timeline/Timeline.html
@@ -169,7 +169,7 @@
         let {
           timelineInitialized,
           runningUpdate
-        } = this.store()
+        } = this.store.get()
         let {
           timelineType
         } = this.get()

--- a/routes/_components/timeline/Timeline.html
+++ b/routes/_components/timeline/Timeline.html
@@ -150,7 +150,8 @@
     },
     methods: {
       initialize() {
-        if (this.get('initializeStarted')) {
+        let { initializeStarted } = this.get()
+        if (initializeStarted) {
           return
         }
         this.set({initializeStarted: true})
@@ -165,18 +166,28 @@
         this.set({scrollTop: scrollTop})
       },
       onScrollToBottom() {
-        if (!this.store.get('timelineInitialized') ||
-            this.store.get('runningUpdate') ||
-            this.get('timelineType') === 'status') { // for status contexts, we've already fetched the whole thread
+        let {
+          timelineInitialized,
+          runningUpdate
+        } = this.store()
+        let {
+          timelineType
+        } = this.get()
+        if (!timelineInitialized ||
+            runningUpdate ||
+            timelineType === 'status') { // for status contexts, we've already fetched the whole thread
           return
         }
+        let { currentInstance } = this.store.get()
+        let { timeline } = this.get()
         fetchTimelineItemsOnScrollToBottom(
-          this.store.get('currentInstance'),
-          this.get('timeline')
+          currentInstance,
+          timeline
         )
       },
       onScrollToTop() {
-        if (this.store.get('shouldShowHeader')) {
+        let { shouldShowHeader } = this.store.get()
+        if (shouldShowHeader) {
           this.store.setForCurrentTimeline({
             showHeader: true,
             shouldShowHeader: false
@@ -193,8 +204,10 @@
           }
           mark('handleItemIdsToAdd')
           let { scrollTop } = this.get()
-          let shouldShowHeader = this.store.get('shouldShowHeader')
-          let showHeader = this.store.get('showHeader')
+          let {
+            shouldShowHeader,
+            showHeader
+          } = this.store.get()
           if (timeline.startsWith('status/')) {
             // this is a thread, just insert the statuses already
             showMoreItemsForThread(currentInstance, timeline)
@@ -252,7 +265,8 @@
       },
       clearFocus() {
         try {
-          if (this.store.get('ignoreBlurEvents')) {
+          let { ignoreBlurEvents } = this.store.get()
+          if (ignoreBlurEvents) {
             return
           }
           console.log('clearing focus')
@@ -266,7 +280,7 @@
         }
       },
       restoreFocus() {
-        let lastFocusedElementSelector = this.store.get('lastFocusedElementSelector')
+        let { lastFocusedElementSelector } = this.store.get()
         if (!lastFocusedElementSelector) {
           return
         }

--- a/routes/_components/timeline/Timeline.html
+++ b/routes/_components/timeline/Timeline.html
@@ -184,27 +184,27 @@
         }
       },
       setupStreaming() {
-        let instanceName = this.store.get('currentInstance')
-        let timelineName = this.get('timeline')
+        let { currentInstance } = this.store.get()
+        let { timeline } = this.get()
         let handleItemIdsToAdd = () => {
-          let itemIdsToAdd = this.get('itemIdsToAdd')
+          let { itemIdsToAdd } = this.get()
           if (!itemIdsToAdd || !itemIdsToAdd.length) {
             return
           }
           mark('handleItemIdsToAdd')
-          let scrollTop = this.get('scrollTop')
+          let { scrollTop } = this.get()
           let shouldShowHeader = this.store.get('shouldShowHeader')
           let showHeader = this.store.get('showHeader')
-          if (timelineName.startsWith('status/')) {
+          if (timeline.startsWith('status/')) {
             // this is a thread, just insert the statuses already
-            showMoreItemsForThread(instanceName, timelineName)
+            showMoreItemsForThread(currentInstance, timeline)
           } else if (scrollTop === 0 && !shouldShowHeader && !showHeader) {
             // if the user is scrolled to the top and we're not showing the header, then
             // just insert the statuses. this is "chat room mode"
-            showMoreItemsForTimeline(instanceName, timelineName)
+            showMoreItemsForTimeline(currentInstance, timeline)
           } else {
             // user hasn't scrolled to the top, show a header instead
-            this.store.setForTimeline(instanceName, timelineName, {shouldShowHeader: true})
+            this.store.setForTimeline(currentInstance, timeline, {shouldShowHeader: true})
           }
           stop('handleItemIdsToAdd')
         }
@@ -232,8 +232,8 @@
       },
       saveFocus(e) {
         try {
-          let instanceName = this.store.get('currentInstance')
-          let timelineName = this.get('timeline')
+          let { currentInstance } = this.store.get()
+          let { timeline } = this.get()
           let lastFocusedElementSelector
           let activeElement = e.target
           if (activeElement) {
@@ -243,7 +243,7 @@
             }
           }
           console.log('saving focus to ', lastFocusedElementSelector)
-          this.store.setForTimeline(instanceName, timelineName, {
+          this.store.setForTimeline(currentInstance, timeline, {
             lastFocusedElementSelector
           })
         } catch (err) {
@@ -256,9 +256,9 @@
             return
           }
           console.log('clearing focus')
-          let instanceName = this.store.get('currentInstance')
-          let timelineName = this.get('timeline')
-          this.store.setForTimeline(instanceName, timelineName, {
+          let { currentInstance } = this.store.get()
+          let { timeline } = this.get()
+          this.store.setForTimeline(currentInstance, timeline, {
             lastFocusedElementSelector: null
           })
         } catch (err) {

--- a/routes/_components/timeline/Timeline.html
+++ b/routes/_components/timeline/Timeline.html
@@ -198,7 +198,7 @@
         let { currentInstance } = this.store.get()
         let { timeline } = this.get()
         let handleItemIdsToAdd = () => {
-          let { itemIdsToAdd } = this.get()
+          let { itemIdsToAdd } = this.get() || {} // TODO: wtf svelte?
           if (!itemIdsToAdd || !itemIdsToAdd.length) {
             return
           }

--- a/routes/_components/virtualList/VirtualListContainer.html
+++ b/routes/_components/virtualList/VirtualListContainer.html
@@ -13,15 +13,20 @@
   export default {
     oncreate() {
       mark('onCreate VirtualListContainer')
-      this.store.setCurrentRealm(this.get('realm'))
-      let node = document.querySelector(this.get('containerQuery'))
+      let {
+        realm,
+        containerQuery
+      } = this.get()
+      this.store.setCurrentRealm(realm)
+      let node = document.querySelector(containerQuery)
       this.setupScroll(node)
       this.setupFullscreen()
-      let scrollTop = this.store.get('scrollTop')
+      let { scrollTop } = this.store.get()
       if (scrollTop > 0) {
         this.observe('allVisibleItemsHaveHeight', allVisibleItemsHaveHeight => {
           console.log('allVisibleItemsHaveHeight', allVisibleItemsHaveHeight)
-          if (!this.get('initializedScrollTop') && allVisibleItemsHaveHeight && node) {
+          let { initializedScrollTop } = this.get()
+          if (!initializedScrollTop && allVisibleItemsHaveHeight && node) {
             this.set({'initializedScrollTop': true})
             mark('set scrollTop')
             console.log('forcing scroll top to ', scrollTop)
@@ -60,7 +65,8 @@
           return
         }
         this.scrollListener = throttle(event => {
-          if (this.get('fullscreen')) {
+          let { fullscreen } = this.get()
+          if (fullscreen) {
             return
           }
           this.onScroll(event)
@@ -71,7 +77,8 @@
         node.addEventListener('scroll', this.scrollListener)
       },
       teardownScroll() {
-        let node = document.querySelector(this.get('containerQuery'))
+        let { containerQuery } = this.get()
+        let node = document.querySelector(containerQuery)
         if (node) {
           node.removeEventListener('scroll', this.scrollListener)
         }

--- a/routes/_components/virtualList/VirtualListHeader.html
+++ b/routes/_components/virtualList/VirtualListHeader.html
@@ -39,7 +39,8 @@
     store: () => virtualListStore,
     methods: {
       doCalculateHeight() {
-        if (this.get('heightCalculated')) { // only need to calculate once, it never changes
+        let { heightCalculated } = this.get()
+        if (heightCalculated) { // only need to calculate once, it never changes
           return
         }
         this.set({heightCalculated: true})

--- a/routes/_components/virtualList/VirtualListItem.html
+++ b/routes/_components/virtualList/VirtualListItem.html
@@ -52,7 +52,7 @@
         // when clicking the "More" button on a spoiler.
         let rect = this.refs.node.getBoundingClientRect()
         let { key } = this.get()
-        let itemHeights = this.store.get('itemHeights')
+        let { itemHeights } = this.store.get()
         itemHeights[key] = rect.height
         this.store.setForRealm({itemHeights})
       }

--- a/routes/_components/virtualList/VirtualListItem.html
+++ b/routes/_components/virtualList/VirtualListItem.html
@@ -30,7 +30,7 @@
   export default {
     oncreate() {
       let asyncLayout = new AsyncLayout(node => node.getAttribute('virtual-list-key'))
-      let key = this.get('key')
+      let { key } = this.get()
       asyncLayout.observe(key, this.refs.node, (rect) => {
         asyncLayout.disconnect()
         // update all item heights in one batch for better perf
@@ -51,7 +51,7 @@
         // Recalculate immediately because this is done on-demand, e.g.
         // when clicking the "More" button on a spoiler.
         let rect = this.refs.node.getBoundingClientRect()
-        let key = this.get('key')
+        let { key } = this.get()
         let itemHeights = this.store.get('itemHeights')
         itemHeights[key] = rect.height
         this.store.setForRealm({itemHeights})

--- a/routes/_components/virtualList/VirtualListLazyItem.html
+++ b/routes/_components/virtualList/VirtualListLazyItem.html
@@ -14,8 +14,7 @@
     async oncreate() {
       // TODO: there appears to be a bug in {{#await}} that means we have to do this manually.
       // Some items may appear on top of other items because their offset is 0 and never updated.
-      let makeProps = this.get('makeProps')
-      let key = this.get('key')
+      let { makeProps, key } = this.get()
       if (makeProps) {
         let props = await makeProps(key)
         mark('VirtualListLazyItem set props')

--- a/routes/_database/cleanup.js
+++ b/routes/_database/cleanup.js
@@ -140,8 +140,8 @@ function doCleanup (instanceName) {
 
 function scheduledCleanup () {
   console.log('scheduledCleanup')
-  let instances = store.get('loggedInInstancesInOrder')
-  for (let instance of instances) {
+  let { loggedInInstancesInOrder } = store.get()
+  for (let instance of loggedInInstancesInOrder) {
     doCleanup(instance)
   }
 }

--- a/routes/_pages/accounts/[accountId].html
+++ b/routes/_pages/accounts/[accountId].html
@@ -30,7 +30,8 @@
 
   export default {
     oncreate() {
-      let { accountId } = this.get().accountId
+      let { params } = this.get()
+      let { accountId } = params
       clearProfileAndRelationship()
       updateProfileAndRelationship(accountId)
     },

--- a/routes/_pages/accounts/[accountId].html
+++ b/routes/_pages/accounts/[accountId].html
@@ -30,7 +30,7 @@
 
   export default {
     oncreate() {
-      let accountId = this.get('params').accountId
+      let { accountId } = this.get().accountId
       clearProfileAndRelationship()
       updateProfileAndRelationship(accountId)
     },

--- a/routes/_pages/community/index.html
+++ b/routes/_pages/community/index.html
@@ -96,7 +96,8 @@
 
   export default {
     async oncreate() {
-      if (this.store.get('currentInstance')) {
+      let { currentInstance } = this.store.get()
+      if (currentInstance) {
         await updateLists()
       }
     },

--- a/routes/_pages/pinned.html
+++ b/routes/_pages/pinned.html
@@ -38,13 +38,11 @@
 
   export default {
     async oncreate() {
-      let { accountsFetcher } = this.get()
       try {
-        let currentInstance = this.store.get('currentInstance')
+        let { currentInstance } = this.store.get()
         await updateVerifyCredentialsForInstance(currentInstance)
-        let accessToken = this.store.get('accessToken')
-        let verifyCredentials = this.store.get('currentVerifyCredentials')
-        let statuses = await getPinnedStatuses(currentInstance, accessToken, verifyCredentials.id)
+        let { accessToken, currentVerifyCredentials } = this.store.get()
+        let statuses = await getPinnedStatuses(currentInstance, accessToken, currentVerifyCredentials.id)
         this.set({ statuses: statuses })
       } catch (e) {
         toast.say('Error: ' + (e.name || '') + ' ' + (e.message || ''))

--- a/routes/_pages/pinned.html
+++ b/routes/_pages/pinned.html
@@ -38,7 +38,7 @@
 
   export default {
     async oncreate() {
-      let accountsFetcher = this.get('accountsFetcher')
+      let { accountsFetcher } = this.get()
       try {
         let currentInstance = this.store.get('currentInstance')
         await updateVerifyCredentialsForInstance(currentInstance)

--- a/routes/_pages/settings/instances/[instanceName].html
+++ b/routes/_pages/settings/instances/[instanceName].html
@@ -115,7 +115,7 @@
       themes: themes,
     }),
     async oncreate() {
-      let instanceName = this.get('instanceName')
+      let { instanceName } = this.get()
       await updateVerifyCredentialsForInstance(instanceName)
     },
     computed: {
@@ -125,18 +125,17 @@
     },
     methods: {
       onThemeChange() {
-        let newTheme = this.get('selectedTheme')
-        let instanceName = this.get('instanceName')
+        let { newTheme, instanceName } = this.get()
         changeTheme(instanceName,  newTheme)
       },
       onSwitchToThisInstance(e) {
         e.preventDefault()
-        let instanceName = this.get('instanceName')
+        let { instanceName } = this.get()
         switchToInstance(instanceName)
       },
       async onLogOut(e) {
         e.preventDefault()
-        let instanceName = this.get('instanceName')
+        let { instanceName } = this.get()
 
         let dialogs = await importDialogs()
         dialogs.showConfirmationDialog({

--- a/routes/_store/mixins/instanceMixins.js
+++ b/routes/_store/mixins/instanceMixins.js
@@ -1,25 +1,22 @@
 export function instanceMixins (Store) {
   Store.prototype.setComposeData = function (realm, obj) {
-    let composeData = this.get('composeData')
-    let instanceName = this.get('currentInstance')
-    let instanceNameData = composeData[instanceName] = composeData[instanceName] || {}
+    let { composeData, currentInstance } = this.get()
+    let instanceNameData = composeData[currentInstance] = composeData[currentInstance] || {}
     instanceNameData[realm] = Object.assign(instanceNameData[realm] || {}, obj)
     this.set({composeData})
   }
 
   Store.prototype.getComposeData = function (realm, key) {
-    let composeData = this.get('composeData')
-    let instanceName = this.get('currentInstance')
-    return composeData[instanceName] &&
-      composeData[instanceName][realm] &&
-      composeData[instanceName][realm][key]
+    let { composeData, currentInstance } = this.get()
+    return composeData[currentInstance] &&
+      composeData[currentInstance][realm] &&
+      composeData[currentInstance][realm][key]
   }
 
   Store.prototype.clearComposeData = function (realm) {
-    let composeData = this.get('composeData')
-    let instanceName = this.get('currentInstance')
-    if (composeData && composeData[instanceName]) {
-      delete composeData[instanceName][realm]
+    let { composeData, currentInstance } = this.get()
+    if (composeData && composeData[currentInstance]) {
+      delete composeData[currentInstance][realm]
     }
     this.set({composeData})
   }

--- a/routes/_store/mixins/statusMixins.js
+++ b/routes/_store/mixins/statusMixins.js
@@ -1,5 +1,5 @@
 function getStatusModifications (store, instanceName) {
-  let statusModifications = store.get('statusModifications')
+  let { statusModifications } = store.get()
   statusModifications[instanceName] = statusModifications[instanceName] || {
     favorites: {},
     reblogs: {}

--- a/routes/_store/mixins/timelineMixins.js
+++ b/routes/_store/mixins/timelineMixins.js
@@ -21,9 +21,8 @@ export function timelineMixins (Store) {
   }
 
   Store.prototype.getForCurrentTimeline = function (key) {
-    let instanceName = this.get('currentInstance')
-    let timelineName = this.get('currentTimeline')
-    return this.getForTimeline(instanceName, timelineName, key)
+    let { currentInstance, currentTimeline } = this.get()
+    return this.getForTimeline(currentInstance, currentTimeline, key)
   }
 
   Store.prototype.getAllTimelineData = function (instanceName, key) {
@@ -32,9 +31,8 @@ export function timelineMixins (Store) {
   }
 
   Store.prototype.setForCurrentTimeline = function (obj) {
-    let instanceName = this.get('currentInstance')
-    let timelineName = this.get('currentTimeline')
-    this.setForTimeline(instanceName, timelineName, obj)
+    let { currentInstance, currentTimeline } = this.get()
+    this.setForTimeline(currentInstance, currentTimeline, obj)
   }
 
   Store.prototype.getThreads = function (instanceName) {

--- a/routes/_store/observers/instanceObservers.js
+++ b/routes/_store/observers/instanceObservers.js
@@ -31,15 +31,16 @@ export function instanceObservers (store) {
     await updateInstanceInfo(currentInstance)
 
     let currentInstanceIsUnchanged = () => {
-      return store.get('currentInstance') === currentInstance
+      let { currentInstance: newCurrentInstance } = store.get()
+      return newCurrentInstance === currentInstance
     }
 
     if (!currentInstanceIsUnchanged()) {
       return
     }
 
-    let instanceInfo = store.get('currentInstanceInfo')
-    if (!instanceInfo) {
+    let { currentInstanceInfo } = store.get()
+    if (!currentInstanceInfo) {
       return
     }
 
@@ -74,8 +75,8 @@ export function instanceObservers (store) {
       ])
     }
 
-    let accessToken = store.get('accessToken')
-    let streamingApi = instanceInfo.urls.streaming_api
+    let { accessToken } = store.get()
+    let streamingApi = currentInstanceInfo.urls.streaming_api
     currentInstanceStream = createStream(streamingApi,
       currentInstance, accessToken, 'home', onOpenStream)
 

--- a/routes/_store/observers/timelineObservers.js
+++ b/routes/_store/observers/timelineObservers.js
@@ -39,14 +39,18 @@ export function timelineObservers (store) {
       return
     }
 
-    let currentInstance = store.get('currentInstance')
-    let accessToken = store.get('accessToken')
+    let { currentInstance } = store.get()
+    let { accessToken } = store.get()
     await updateInstanceInfo(currentInstance)
 
-    let currentTimelineIsUnchanged = () => (
-      store.get('currentInstance') === currentInstance &&
-      store.get('currentTimeline') === currentTimeline
-    )
+    let currentTimelineIsUnchanged = () => {
+      let {
+        currentInstance: newCurrentInstance,
+        currentTimeline: newCurrentTimeline
+      } = store.get()
+      return newCurrentInstance === currentInstance &&
+        newCurrentTimeline === currentTimeline
+    }
 
     if (!currentTimelineIsUnchanged()) {
       return
@@ -69,8 +73,8 @@ export function timelineObservers (store) {
       }
     }
 
-    let instanceInfo = store.get('currentInstanceInfo')
-    let streamingApi = instanceInfo.urls.streaming_api
+    let { currentInstanceInfo } = store.get()
+    let streamingApi = currentInstanceInfo.urls.streaming_api
     currentTimelineStream = createStream(streamingApi, currentInstance, accessToken,
       currentTimeline, onOpenStream)
 

--- a/routes/_utils/RealmStore.js
+++ b/routes/_utils/RealmStore.js
@@ -17,9 +17,9 @@ export class RealmStore extends Store {
   }
 
   setForRealm (obj) {
-    let realmName = this.get('currentRealm')
-    let realms = this.get('realms')
-    realms.set(realmName, Object.assign(realms.get(realmName) || {}, obj))
+    let { currentRealm } = this.get()
+    let { realms } = this.get()
+    realms.set(currentRealm, Object.assign(realms.get(currentRealm) || {}, obj))
     this.set({realms: realms})
   }
 
@@ -37,10 +37,10 @@ export class RealmStore extends Store {
    * to a plain old javascript object.
    */
   batchUpdateForRealm (key, subKey, value) {
-    let realm = this.get('currentRealm')
-    let realmBatches = this._batches[realm]
+    let { currentRealm } = this.get()
+    let realmBatches = this._batches[currentRealm]
     if (!realmBatches) {
-      realmBatches = this._batches[realm] = {}
+      realmBatches = this._batches[currentRealm] = {}
     }
     let batch = realmBatches[key]
     if (!batch) {
@@ -49,7 +49,7 @@ export class RealmStore extends Store {
     batch[subKey] = value
 
     requestAnimationFrame(() => {
-      let batch = this._batches[realm] && this._batches[realm][key]
+      let batch = this._batches[currentRealm] && this._batches[currentRealm][key]
       if (!batch) {
         return
       }
@@ -62,9 +62,9 @@ export class RealmStore extends Store {
       for (let otherKey of updatedKeys) {
         obj[otherKey] = batch[otherKey]
       }
-      delete this._batches[realm][key]
-      let realms = this.get('realms')
-      realms.set(realm, Object.assign(realms.get(realm) || {}, {[key]: obj}))
+      delete this._batches[currentRealm][key]
+      let { realms } = this.get()
+      realms.set(currentRealm, Object.assign(realms.get(currentRealm) || {}, {[key]: obj}))
       this.set({realms: realms})
       stop('batchUpdate')
     })


### PR DESCRIPTION
This has some odd failures that I'm currently working around (with `get() || {}`), but it's something we need to do because `get('foo')` is getting deprecated: https://github.com/sveltejs/svelte/pull/1347