### PR TITLE
emoji style fixes

### DIFF
--- a/routes/_components/compose/ComposeAutosuggestionList.html
+++ b/routes/_components/compose/ComposeAutosuggestionList.html
@@ -69,6 +69,7 @@
     grid-area: icon;
     width: 48px;
     height: 48px;
+    object-fit: contain;
   }
   .compose-autosuggest-list-display-name {
     grid-area: display-name;

--- a/routes/_components/status/StatusContent.html
+++ b/routes/_components/status/StatusContent.html
@@ -22,9 +22,11 @@
   }
 
   :global(.status-content .status-emoji) {
-    width: 20px;
-    height: 20px;
-    margin: -3px 0;
+    width: 1.4em;
+    height: 1.4em;
+    margin-top: -0.1em;
+    object-fit: contain;
+    vertical-align: middle;
   }
 
   :global(.status-content p) {

--- a/routes/_components/status/StatusSpoiler.html
+++ b/routes/_components/status/StatusSpoiler.html
@@ -17,9 +17,11 @@
   }
 
   :global(.status-spoiler .status-emoji) {
-    width: 20px;
-    height: 20px;
-    margin: -3px 0;
+    width: 1.4em;
+    height: 1.4em;
+    margin-top: -0.1em;
+    object-fit: contain;
+    vertical-align: middle;
   }
 
   .status-spoiler.status-in-own-thread {


### PR DESCRIPTION
* fixes non-square emoji being stretched to fit a square, both in
  statuses and in autosuggestions
* sizes emoji proportionally to text, so emoji won't look all tiny in
  expanded statuses
* emoji sizing and positioning similar to mastodon web

![before-after comparison](https://user-images.githubusercontent.com/315139/39355068-7a8dfcce-4a0c-11e8-91bd-e0bfd3ee2436.png)
