### PR TITLE
remove unnecessary item wrapping

### DIFF
--- a/routes/_components/pseudoVirtualList/PseudoVirtualList.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualList.html
@@ -1,15 +1,15 @@
 <div class="pseudo-virtual-list" on:initialized ref:node>
-  {#each wrappedItems as wrappedItem, i (wrappedItem.item)}
+  {#each safeItems as item, i (item)}
     <PseudoVirtualListLazyItem
       {component}
       index={i}
-      length={wrappedItems.length}
+      length={safeItems.length}
       {makeProps}
-      key={wrappedItem.item}
+      key={item}
       {intersectionObserver}
-      isIntersecting={isIntersecting(wrappedItem.item, $intersectionStates)}
-      isCached={isCached(wrappedItem.item, $intersectionStates)}
-      height={getHeight(wrappedItem.item, $intersectionStates)}
+      isIntersecting={isIntersecting(item, $intersectionStates)}
+      isCached={isCached(item, $intersectionStates)}
+      height={getHeight(item, $intersectionStates)}
     />
   {/each}
 </div>
@@ -110,7 +110,7 @@
       }
     },
     computed: {
-      wrappedItems: ({ items }) => items ? items.map(item => ({item})) : [],
+      safeItems: ({ items }) => items  || [],
       allItemsHaveHeight: ({ items, $intersectionStates }) => {
         if (!items) {
           return false

--- a/routes/_components/pseudoVirtualList/PseudoVirtualList.html
+++ b/routes/_components/pseudoVirtualList/PseudoVirtualList.html
@@ -110,7 +110,7 @@
       }
     },
     computed: {
-      safeItems: ({ items }) => items  || [],
+      safeItems: ({ items }) => items || [],
       allItemsHaveHeight: ({ items, $intersectionStates }) => {
         if (!items) {
           return false


### PR DESCRIPTION
In Svelte 2.0 this is no longer necessary because we can have arbitrary expressions in `#each` loops.