### PR TITLE
use single transform:translate in virtual list

### DIFF
--- a/routes/_components/virtualList/VirtualList.html
+++ b/routes/_components/virtualList/VirtualList.html
@@ -2,17 +2,21 @@
   <div class="virtual-list"
        style="height: {$height}px;"
        ref:node >
-    <VirtualListHeader component={headerComponent} virtualProps={headerProps} shown={$showHeader}/>
-    {#if $visibleItems}
-      {#each $visibleItems as visibleItem (visibleItem.key)}
-        <VirtualListLazyItem {component}
-                             offset={visibleItem.offset}
-                             {makeProps}
-                             key={visibleItem.key}
-                             index={visibleItem.index}
+    <VirtualListHeader component={headerComponent} virtualProps={headerProps} shown={$showHeader} />
+    <div
+      class="virtual-list-items"
+      style="transform: translateY({firstOffset}px)"
+    >
+      {#each safeVisibleItems as visibleItem (visibleItem.key)}
+        <VirtualListLazyItem
+          {component}
+          offset={visibleItem.offset}
+          {makeProps}
+          key={visibleItem.key}
+          index={visibleItem.index}
         />
       {/each}
-    {/if}
+    </div>
     {#if $showFooter}
       <VirtualListFooter component={footerComponent} />
     {/if}
@@ -21,6 +25,10 @@
 <style>
   .virtual-list {
     position: relative;
+  }
+  .virtual-list-items {
+    position: absolute;
+    top: 0;
   }
 </style>
 <script>
@@ -106,7 +114,11 @@
       },
       scrollTop: ({ $scrollTop }) => $scrollTop,
       // TODO: bug in svelte store, shouldn't need to do this
-      allVisibleItemsHaveHeight: ({ $allVisibleItemsHaveHeight }) => $allVisibleItemsHaveHeight
+      allVisibleItemsHaveHeight: ({ $allVisibleItemsHaveHeight }) => $allVisibleItemsHaveHeight,
+      safeVisibleItems: ({ $visibleItems }) => $visibleItems || [],
+      firstOffset: ({ safeVisibleItems }) => (
+        (safeVisibleItems[0] && safeVisibleItems[0].offset) || 0
+      )
     },
     methods: {
       observe,

--- a/routes/_components/virtualList/VirtualListItem.html
+++ b/routes/_components/virtualList/VirtualListItem.html
@@ -2,7 +2,7 @@
      aria-hidden={!shown}
      virtual-list-key={key}
      ref:node
-     style="transform: translateY({offset}px);" >
+>
   <svelte:component this={component}
               virtualProps={props}
               virtualIndex={index}
@@ -11,8 +11,6 @@
 </div>
 <style>
   .virtual-list-item {
-    position: absolute;
-    top: 0;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.333s linear;


### PR DESCRIPTION
This fixes an issue with the autosuggestion overflow sometimes being rendered "under" the status underneath it, and it also makes the DOM do less work since we only have to update the `transform` on one DOM node instead of multiple.