### PR TITLE
remove sleep while restoring mastodon test data

### DIFF
--- a/bin/restore-mastodon-data.js
+++ b/bin/restore-mastodon-data.js
@@ -46,7 +46,6 @@ export async function restoreMastodonData () {
   let internalIdsToIds = {}
   for (let action of actions) {
     console.log(JSON.stringify(action))
-    await new Promise(resolve => setTimeout(resolve, 200)) // sleep because otherwise order may not be preserved
     let accessToken = users[action.user].accessToken
 
     if (action.post) {


### PR DESCRIPTION
I have a strong suspicion this doesn't actually make the tests less flaky.