### PR TITLE
explicitly install ruby 2.5.0 in travis

### DIFF
--- a/bin/setup-mastodon-in-travis.sh
+++ b/bin/setup-mastodon-in-travis.sh
@@ -7,6 +7,10 @@ if [[ "$COMMAND" = deploy-dev-travis ]]; then
   exit 0 # no need to setup mastodon in this case
 fi
 
+source "$HOME/.rvm/scripts/rvm"
+rvm install 2.5.0
+rvm use 2.5.0
+
 sudo -E add-apt-repository -y ppa:mc3man/trusty-media
 sudo -E apt-get update
 sudo -E apt-get install -y ffmpeg


### PR DESCRIPTION
On second thought, it's probably smarter long-term to nail down the Ruby version instead of trusting whatever Travis has.