### PR TITLE
Revert "use "npm ci" in travis (#337)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ before_script:
   - greenkeeper-lockfile-update
 after_script:
   - greenkeeper-lockfile-upload
-install:
-  - npm ci
 script: travis_retry npm run $COMMAND
 env:
   global:


### PR DESCRIPTION
This seems to break greenkeeper-lockfile-update.