### PR TITLE
use `npm ci || npm i` in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
 after_script:
   - greenkeeper-lockfile-upload
 install:
-  - npm install
+  - npm ci || npm i
 script: travis_retry npm run $COMMAND
 env:
   global:


### PR DESCRIPTION
let's be clever and prefer `npm ci` but if that fails because of greenkeeper not updating the lockfile, we fall back to `npm i`.