### PR TITLE
Fixing Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ADD . /app
 
 # Install updates and NodeJS+Dependencies
 RUN apk update && apk upgrade
-RUN apk add nodejs git python build-base clang
+RUN apk add nodejs npm git python build-base clang
 
 # Upgrading NPM
 RUN npm i npm@latest -g


### PR DESCRIPTION
This fixes the Dockerfile where Docker is exiting with the error, that the npm binary couldn't be found