### PR TITLE
disable manifest.json for iOS

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,6 +48,17 @@ app.use(nonDebugOnly(helmet({
   }
 })))
 
+// TODO: remove this hack when Safari works with cross-origin window.open()
+// in a PWA: https://github.com/nolanlawson/pinafore/issues/45
+app.get('/manifest.json', (req, res, next) => {
+  if (/iP(?:hone|ad|od)/.test(req.headers['user-agent'])) {
+    return res.status(404).send({
+      error: 'manifest.json is disabled for iOS. see https://github.com/nolanlawson/pinafore/issues/45'
+    })
+  }
+  return next()
+})
+
 app.use(serveStatic('assets', {
   setHeaders: (res) => {
     res.setHeader('Cache-Control', 'public,max-age=600')


### PR DESCRIPTION
fixes #45

This PR UA sniffs for iOS devices and sends a 404 for `/manifest.json`. It's an unfortunate workaround for this problem, but I've confirmed that it allows "add to homescreen" to work on iOS. When you tap the homescreen icon, it just opens Pinafore in Safari.