### PR TITLE
Add class names for notification/status types

### DIFF
--- a/routes/_components/status/Notification.html
+++ b/routes/_components/status/Notification.html
@@ -3,7 +3,7 @@
           {status} {notification} on:recalculateHeight
   />
 {:else}
-  <article class="notification-article"
+  <article class={"notification-article notification-" + notification.type}
            tabindex="0"
            aria-posinset={index}
            aria-setsize={length} >

--- a/routes/_components/status/Status.html
+++ b/routes/_components/status/Status.html
@@ -226,11 +226,12 @@
         status.reblog ||
         timelineType === 'pinned'
       ),
-      className: ({ visibility, timelineType, isStatusInOwnThread }) => (classname(
+      className: ({ visibility, timelineType, isStatusInOwnThread, notification }) => (classname(
         'status-article',
         visibility === 'direct' && 'status-direct',
         timelineType !== 'search' && 'status-in-timeline',
-        isStatusInOwnThread && 'status-in-own-thread'
+        isStatusInOwnThread && 'status-in-own-thread',
+        notification && notification.type && 'status-' + notification.type
       )),
       content: ({ originalStatus }) => originalStatus.content || '',
       showContent: ({ spoilerText, spoilerShown }) => !spoilerText || spoilerShown,


### PR DESCRIPTION
I wanted to add user styles that hide certain notifications, so having class names by type is a big help for that. This commit simply appends the notification type to a "status-" class or a "notification-" class, depending on if it's a Status or Notification component. As a result you get classes like "status-mention", "status-favourite", and "notification-follow".

This could also eventually help with adding a Mastodon-style "filter your notifications by type" feature.