### PR TITLE
implement custom virtual list repeater

### DIFF
--- a/routes/_components/LazyImage.html
+++ b/routes/_components/LazyImage.html
@@ -22,34 +22,46 @@
 </style>
 <script>
   import { mark, stop } from '../_utils/marks'
+  import { observe } from 'svelte-extras'
 
   export default {
     oncreate () {
-      mark('LazyImage oncreate()')
-      let img = new Image()
-      let { src } = this.get()
-      let { fallback } = this.get()
-      img.onload = () => {
-        requestAnimationFrame(() => {
-          this.set({
-            displaySrc: src,
-            hidden: true
-          })
-          requestAnimationFrame(() => {
-            this.set({hidden: false})
-          })
+      this.observe('src', src => {
+        if (!src) {
+          return
+        }
+        mark('LazyImage observe()')
+        this.set({
+          displaySrc: void 0,
+          hidden: false
         })
-      }
-      img.onerror = () => {
-        this.set({displaySrc: fallback})
-      }
-      img.src = src
-      stop('LazyImage oncreate()')
+        let { fallback } = this.get()
+        let img = new Image()
+        img.onload = () => {
+          requestAnimationFrame(() => {
+            this.set({
+              displaySrc: src,
+              hidden: true
+            })
+            requestAnimationFrame(() => {
+              this.set({hidden: false})
+            })
+          })
+        }
+        img.onerror = () => {
+          this.set({displaySrc: fallback})
+        }
+        img.src = src
+        stop('LazyImage observe()')
+      })
     },
     data: () => ({
       displaySrc: void 0,
       hidden: false,
       ariaHidden: false
-    })
+    }),
+    methods: {
+      observe
+    }
   }
 </script>

--- a/routes/_components/status/Media.html
+++ b/routes/_components/status/Media.html
@@ -105,19 +105,23 @@
   import { store } from '../../_store/store'
   import LazyImage from '../LazyImage.html'
   import AutoplayVideo from '../AutoplayVideo.html'
-  import { registerClickDelegate } from '../../_utils/delegate'
+  import { addClickDelegate, removeClickDelegate } from '../../_utils/delegate'
+  import { observe } from 'svelte-extras'
 
   export default {
     oncreate () {
-      let { delegateKey } = this.get()
-      registerClickDelegate(this, delegateKey, () => {
-        let { type } = this.get()
-        if (type === 'video') {
-          this.onClickPlayVideoButton()
-        } else {
-          this.onClickShowImageButton()
+      this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
+        if (!delegateKey) {
+          return
         }
+        if (oldDelegateKey) {
+          removeClickDelegate(oldDelegateKey)
+        }
+        addClickDelegate(delegateKey, () => this.onClick())
       })
+    },
+    ondestroy () {
+      removeClickDelegate(this.get().delegateKey)
     },
     computed: {
       // width/height to show inline
@@ -141,6 +145,15 @@
       type: ({ media }) => media.type
     },
     methods: {
+      observe,
+      onClick () {
+        let { type } = this.get()
+        if (type === 'video') {
+          this.onClickPlayVideoButton()
+        } else {
+          this.onClickShowImageButton()
+        }
+      },
       async onClickPlayVideoButton () {
         let { previewUrl, url, modalWidth, modalHeight, description } = this.get()
         let showVideoDialog = await importShowVideoDialog()

--- a/routes/_components/status/Media.html
+++ b/routes/_components/status/Media.html
@@ -110,18 +110,19 @@
 
   export default {
     oncreate () {
+      this.onClick = this.onClick.bind(this)
       this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
         if (!delegateKey) {
           return
         }
         if (oldDelegateKey) {
-          removeClickDelegate(oldDelegateKey)
+          removeClickDelegate(oldDelegateKey, this.onClick)
         }
-        addClickDelegate(delegateKey, () => this.onClick())
+        addClickDelegate(delegateKey, this.onClick)
       })
     },
     ondestroy () {
-      removeClickDelegate(this.get().delegateKey)
+      removeClickDelegate(this.get().delegateKey, this.onClick)
     },
     computed: {
       // width/height to show inline

--- a/routes/_components/status/Status.html
+++ b/routes/_components/status/Status.html
@@ -119,18 +119,19 @@
 
   export default {
     oncreate () {
+      this.onClickOrKeydown = this.onClickOrKeydown.bind(this)
       this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
         if (!delegateKey) {
           return
         }
         if (oldDelegateKey) {
-          removeClickDelegate(oldDelegateKey)
+          removeClickDelegate(oldDelegateKey, this.onClickOrKeydown)
         }
-        addClickDelegate(delegateKey, (e) => this.onClickOrKeydown(e))
+        addClickDelegate(delegateKey, this.onClickOrKeydown)
       })
     },
     ondestroy () {
-      removeClickDelegate(this.get().delegateKey)
+      removeClickDelegate(this.get().delegateKey, this.onClickOrKeydown)
     },
     components: {
       StatusSidebar,

--- a/routes/_components/status/Status.html
+++ b/routes/_components/status/Status.html
@@ -21,7 +21,7 @@
   {#if !showContent}
     <StatusMentions {...params} />
   {/if}
-  {#if content && (showContent || contentPreloaded)}
+  {#if content}
     <StatusContent {...params} shown={showContent}/>
   {/if}
   {#if showMedia }
@@ -106,11 +106,11 @@
   import StatusMentions from './StatusMentions.html'
   import { store } from '../../_store/store'
   import { goto } from 'sapper/runtime.js'
-  import { registerClickDelegate } from '../../_utils/delegate'
+  import { addClickDelegate, removeClickDelegate } from '../../_utils/delegate'
   import { classname } from '../../_utils/classname'
   import { checkDomAncestors } from '../../_utils/checkDomAncestors'
-  import { scheduleIdleTask } from '../../_utils/scheduleIdleTask'
   import { removeEmoji } from '../../_utils/removeEmoji'
+  import { observe } from 'svelte-extras'
 
   const INPUT_TAGS = new Set(['a', 'button', 'input', 'textarea'])
   const isUserInputElement = node => INPUT_TAGS.has(node.localName)
@@ -119,18 +119,18 @@
 
   export default {
     oncreate () {
-      let { delegateKey, isStatusInOwnThread, showContent } = this.get()
-      if (!isStatusInOwnThread) {
-        // the whole <article> is clickable in this case
-        registerClickDelegate(this, delegateKey, (e) => this.onClickOrKeydown(e))
-      }
-      if (!showContent) {
-        scheduleIdleTask(() => {
-          // Perf optimization: lazily load the StatusContent when the user is idle so that
-          // it's fast when they click the "show more" button
-          this.set({contentPreloaded: true})
-        })
-      }
+      this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
+        if (!delegateKey) {
+          return
+        }
+        if (oldDelegateKey) {
+          removeClickDelegate(oldDelegateKey)
+        }
+        addClickDelegate(delegateKey, (e) => this.onClickOrKeydown(e))
+      })
+    },
+    ondestroy () {
+      removeClickDelegate(this.get().delegateKey)
     },
     components: {
       StatusSidebar,
@@ -148,17 +148,20 @@
     },
     data: () => ({
       notification: void 0,
-      replyVisibility: void 0,
-      contentPreloaded: false
+      replyVisibility: void 0
     }),
     store: () => store,
     methods: {
+      observe,
       onClickOrKeydown (e) {
         let { type, keyCode, target } = e
 
         let isClick = type === 'click'
         let isEnter = type === 'keydown' && keyCode === 13
         if (!isClick && !isEnter) {
+          return
+        }
+        if (this.get().isStatusInOwnThread) {
           return
         }
         if (checkDomAncestors(target, isUserInputElement, isStatusArticle)) {

--- a/routes/_components/status/StatusContent.html
+++ b/routes/_components/status/StatusContent.html
@@ -56,10 +56,16 @@
   import { store } from '../../_store/store'
   import { classname } from '../../_utils/classname'
   import { emojifyText } from '../../_utils/emojifyText'
+  import { observe } from 'svelte-extras'
 
   export default {
     oncreate () {
-      this.hydrateContent()
+      this.observe('uuid', uuid => {
+        if (!uuid) {
+          return
+        }
+        this.hydrateContent()
+      })
     },
     store: () => store,
     computed: {
@@ -84,6 +90,7 @@
       }
     },
     methods: {
+      observe,
       hydrateContent () {
         if (!this.refs.node) {
           return

--- a/routes/_components/status/StatusContent.html
+++ b/routes/_components/status/StatusContent.html
@@ -64,7 +64,9 @@
         if (!uuid) {
           return
         }
-        this.hydrateContent()
+        requestAnimationFrame(() => {
+          this.hydrateContent()
+        })
       })
     },
     store: () => store,

--- a/routes/_components/status/StatusMediaAttachments.html
+++ b/routes/_components/status/StatusMediaAttachments.html
@@ -126,12 +126,23 @@
 <script>
   import MediaAttachments from './MediaAttachments.html'
   import { store } from '../../_store/store'
-  import { registerClickDelegate } from '../../_utils/delegate'
+  import { addClickDelegate, removeClickDelegate } from '../../_utils/delegate'
+  import { observe } from 'svelte-extras'
 
   export default {
     oncreate () {
-      let { delegateKey } = this.get()
-      registerClickDelegate(this, delegateKey, () => this.onClickSensitiveMediaButton())
+      this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
+        if (!delegateKey) {
+          return
+        }
+        if (oldDelegateKey) {
+          removeClickDelegate(oldDelegateKey)
+        }
+        addClickDelegate(delegateKey, (e) => this.onClickSensitiveMediaButton())
+      })
+    },
+    ondestroy () {
+      removeClickDelegate(this.get().delegateKey)
     },
     components: {
       MediaAttachments
@@ -144,6 +155,7 @@
       delegateKey: ({ uuid }) => `sensitive-${uuid}`
     },
     methods: {
+      observe,
       onClickSensitiveMediaButton () {
         let { uuid } = this.get()
         let { sensitivesShown } = this.store.get()

--- a/routes/_components/status/StatusMediaAttachments.html
+++ b/routes/_components/status/StatusMediaAttachments.html
@@ -131,18 +131,19 @@
 
   export default {
     oncreate () {
+      this.onClickSensitiveMediaButton = this.onClickSensitiveMediaButton.bind(this)
       this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
         if (!delegateKey) {
           return
         }
         if (oldDelegateKey) {
-          removeClickDelegate(oldDelegateKey)
+          removeClickDelegate(oldDelegateKey, this.onClickSensitiveMediaButton)
         }
-        addClickDelegate(delegateKey, (e) => this.onClickSensitiveMediaButton())
+        addClickDelegate(delegateKey, this.onClickSensitiveMediaButton)
       })
     },
     ondestroy () {
-      removeClickDelegate(this.get().delegateKey)
+      removeClickDelegate(this.get().delegateKey, this.onClickSensitiveMediaButton)
     },
     components: {
       MediaAttachments

--- a/routes/_components/status/StatusSpoiler.html
+++ b/routes/_components/status/StatusSpoiler.html
@@ -40,15 +40,26 @@
 </style>
 <script>
   import { store } from '../../_store/store'
-  import { registerClickDelegate } from '../../_utils/delegate'
+  import { addClickDelegate, removeClickDelegate } from '../../_utils/delegate'
   import { mark, stop } from '../../_utils/marks'
   import { emojifyText } from '../../_utils/emojifyText'
   import escapeHtml from 'escape-html'
+  import { observe } from 'svelte-extras'
 
   export default {
     oncreate () {
-      let { delegateKey } = this.get()
-      registerClickDelegate(this, delegateKey, () => this.onClickSpoilerButton())
+      this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
+        if (!delegateKey) {
+          return
+        }
+        if (oldDelegateKey) {
+          removeClickDelegate(oldDelegateKey)
+        }
+        addClickDelegate(delegateKey, () => this.onClickSpoilerButton())
+      })
+    },
+    ondestroy () {
+      removeClickDelegate(this.get().delegateKey)
     },
     store: () => store,
     computed: {
@@ -61,6 +72,7 @@
       delegateKey: ({ uuid }) => `spoiler-${uuid}`
     },
     methods: {
+      observe,
       onClickSpoilerButton () {
         requestAnimationFrame(() => {
           mark('clickSpoilerButton')

--- a/routes/_components/status/StatusSpoiler.html
+++ b/routes/_components/status/StatusSpoiler.html
@@ -48,18 +48,19 @@
 
   export default {
     oncreate () {
+      this.onClickSpoilerButton = this.onClickSpoilerButton.bind(this)
       this.observe('delegateKey', (delegateKey, oldDelegateKey) => {
         if (!delegateKey) {
           return
         }
         if (oldDelegateKey) {
-          removeClickDelegate(oldDelegateKey)
+          removeClickDelegate(oldDelegateKey, this.onClickSpoilerButton)
         }
-        addClickDelegate(delegateKey, () => this.onClickSpoilerButton())
+        addClickDelegate(delegateKey, this.onClickSpoilerButton)
       })
     },
     ondestroy () {
-      removeClickDelegate(this.get().delegateKey)
+      removeClickDelegate(this.get().delegateKey, this.onClickSpoilerButton)
     },
     store: () => store,
     computed: {

--- a/routes/_components/status/StatusToolbar.html
+++ b/routes/_components/status/StatusToolbar.html
@@ -51,35 +51,60 @@
 <script>
   import IconButton from '../IconButton.html'
   import { store } from '../../_store/store'
-  import { registerClickDelegates } from '../../_utils/delegate'
+  import { addClickDelegate, removeClickDelegate } from '../../_utils/delegate'
   import { setFavorited } from '../../_actions/favorite'
   import { setReblogged } from '../../_actions/reblog'
   import { importShowStatusOptionsDialog } from '../dialog/asyncDialogs'
   import { updateProfileAndRelationship } from '../../_actions/accounts'
   import { FAVORITE_ANIMATION, REBLOG_ANIMATION } from '../../_static/animations'
   import { on } from '../../_utils/eventBus'
+  import { observe } from 'svelte-extras'
+
+  const delegateKeys = [
+    'favoriteKey',
+    'reblogKey',
+    'replyKey',
+    'optionsKey'
+  ]
 
   export default {
     oncreate () {
-      let {
-        favoriteKey,
-        reblogKey,
-        replyKey,
-        optionsKey
-      } = this.get()
-      registerClickDelegates(this, {
-        [favoriteKey]: (e) => this.onFavoriteClick(e),
-        [reblogKey]: (e) => this.onReblogClick(e),
-        [replyKey]: (e) => this.onReplyClick(e),
-        [optionsKey]: (e) => this.onOptionsClick(e)
+      delegateKeys.forEach(key => {
+        this.observe(key, (delegateKey, oldDelegateKey) => {
+          if (!delegateKey) {
+            return
+          }
+          if (oldDelegateKey) {
+            removeClickDelegate(oldDelegateKey)
+          }
+          addClickDelegate(delegateKey, this.getDelegateKeyCallback(key))
+        })
       })
       on('postedStatus', this, this.onPostedStatus)
+    },
+    ondestroy () {
+      delegateKeys.forEach(key => {
+        removeClickDelegate(this.get()[key])
+      })
     },
     components: {
       IconButton
     },
     store: () => store,
     methods: {
+      observe,
+      getDelegateKeyCallback (key) {
+        switch (key) {
+          case 'favoriteKey':
+            return e => this.onFavoriteClick(e)
+          case 'reblogKey':
+            return e => this.onReblogClick(e)
+          case 'replyKey':
+            return e => this.onReplyClick(e)
+          case 'optionsKey':
+            return e => this.onOptionsClick(e)
+        }
+      },
       onFavoriteClick (e) {
         e.preventDefault()
         e.stopPropagation()

--- a/routes/_components/status/StatusToolbar.html
+++ b/routes/_components/status/StatusToolbar.html
@@ -69,13 +69,18 @@
 
   export default {
     oncreate () {
+      this.onFavoriteClick = this.onFavoriteClick.bind(this)
+      this.onReblogClick = this.onReblogClick.bind(this)
+      this.onReplyClick = this.onReplyClick.bind(this)
+      this.onOptionsClick = this.onOptionsClick.bind(this)
+
       delegateKeys.forEach(key => {
         this.observe(key, (delegateKey, oldDelegateKey) => {
           if (!delegateKey) {
             return
           }
           if (oldDelegateKey) {
-            removeClickDelegate(oldDelegateKey)
+            removeClickDelegate(oldDelegateKey, this.getDelegateKeyCallback(key))
           }
           addClickDelegate(delegateKey, this.getDelegateKeyCallback(key))
         })
@@ -84,7 +89,7 @@
     },
     ondestroy () {
       delegateKeys.forEach(key => {
-        removeClickDelegate(this.get()[key])
+        removeClickDelegate(this.get()[key], this.getDelegateKeyCallback(key))
       })
     },
     components: {
@@ -96,13 +101,13 @@
       getDelegateKeyCallback (key) {
         switch (key) {
           case 'favoriteKey':
-            return e => this.onFavoriteClick(e)
+            return this.onFavoriteClick
           case 'reblogKey':
-            return e => this.onReblogClick(e)
+            return this.onReblogClick
           case 'replyKey':
-            return e => this.onReplyClick(e)
+            return this.onReplyClick
           case 'optionsKey':
-            return e => this.onOptionsClick(e)
+            return this.onOptionsClick
         }
       },
       onFavoriteClick (e) {

--- a/routes/_components/virtualList/VirtualList.html
+++ b/routes/_components/virtualList/VirtualList.html
@@ -3,16 +3,8 @@
        style="height: {$height}px;"
        ref:node >
     <VirtualListHeader component={headerComponent} virtualProps={headerProps} shown={$showHeader}/>
-    {#if $visibleItems}
-      {#each $visibleItems as visibleItem (visibleItem.key)}
-        <VirtualListLazyItem {component}
-                             offset={visibleItem.offset}
-                             {makeProps}
-                             key={visibleItem.key}
-                             index={visibleItem.index}
-        />
-      {/each}
-    {/if}
+
+    <VirtualListRepeater {component} {makeProps} visibleItems={$visibleItems} />
     {#if $showFooter}
       <VirtualListFooter component={footerComponent} />
     {/if}
@@ -25,7 +17,7 @@
 </style>
 <script>
   import VirtualListContainer from './VirtualListContainer.html'
-  import VirtualListLazyItem from './VirtualListLazyItem'
+  import VirtualListRepeater from './VirtualListRepeater.html'
   import VirtualListFooter from './VirtualListFooter.html'
   import VirtualListHeader from './VirtualListHeader.html'
   import { virtualListStore } from './virtualListStore'
@@ -90,13 +82,10 @@
         this.calculateListOffset()
       })
     },
-    data: () => ({
-      component: null
-    }),
     store: () => virtualListStore,
     components: {
       VirtualListContainer,
-      VirtualListLazyItem,
+      VirtualListRepeater,
       VirtualListFooter,
       VirtualListHeader
     },

--- a/routes/_components/virtualList/VirtualListItem.html
+++ b/routes/_components/virtualList/VirtualListItem.html
@@ -26,23 +26,29 @@
   import { virtualListStore } from './virtualListStore'
   import { registerResizeListener, unregisterResizeListener } from '../../_utils/resize'
   import { mark, stop } from '../../_utils/marks'
+  import { observe } from 'svelte-extras'
 
   export default {
     oncreate () {
-      let { key } = this.get()
-      let node = this.refs.node
-      requestAnimationFrame(() => {
-        if (!node || !key) {
-          return
-        }
-        mark('VirtualListItem gBCR')
-        let rect = node.getBoundingClientRect()
-        stop('VirtualListItem gBCR')
-        // update all item heights in one batch for better perf
-        this.store.batchUpdateForRealm('itemHeights', key, rect.height)
-      })
       this.doRecalculateHeight = this.doRecalculateHeight.bind(this)
       registerResizeListener(this.doRecalculateHeight)
+
+      this.observe('key', key => {
+        if (!key) {
+          return
+        }
+        requestAnimationFrame(() => {
+          let node = this.refs.node
+          if (!node) {
+            return
+          }
+          mark('VirtualListItem gBCR')
+          let rect = node.getBoundingClientRect()
+          stop('VirtualListItem gBCR')
+          // update all item heights in one batch for better perf
+          this.store.batchUpdateForRealm('itemHeights', key, rect.height)
+        })
+      })
     },
     ondestroy () {
       unregisterResizeListener(this.doRecalculateHeight)
@@ -52,6 +58,7 @@
       'shown': ({ $itemHeights, key }) => $itemHeights[key] > 0
     },
     methods: {
+      observe,
       doRecalculateHeight () {
         // Recalculate immediately because this is done on-demand, e.g.
         // when clicking the "More" button on a spoiler.

--- a/routes/_components/virtualList/VirtualListItem.html
+++ b/routes/_components/virtualList/VirtualListItem.html
@@ -45,8 +45,10 @@
           mark('VirtualListItem gBCR')
           let rect = node.getBoundingClientRect()
           stop('VirtualListItem gBCR')
+          mark('VirtualListItem batchUpdateForRealm')
           // update all item heights in one batch for better perf
           this.store.batchUpdateForRealm('itemHeights', key, rect.height)
+          stop('VirtualListItem batchUpdateForRealm')
         })
       })
     },

--- a/routes/_components/virtualList/VirtualListLazyItem.html
+++ b/routes/_components/virtualList/VirtualListLazyItem.html
@@ -1,11 +1,21 @@
-{#if props && shown}
-  <VirtualListItem {component}
-                   {offset}
-                   {props}
-                   {key}
-                   {index}
-  />
-{/if}
+<div class="virtual-list-lazy-item {shown ? 'shown' : ''}">
+  {#if props}
+    <VirtualListItem {component}
+                     {offset}
+                     {props}
+                     {key}
+                     {index}
+    />
+  {/if}
+</div>
+<style>
+  .virtual-list-lazy-item {
+    display: none;
+  }
+  .virtual-list-lazy-item.shown {
+    display: block;
+  }
+</style>
 <script>
   import VirtualListItem from './VirtualListItem'
   import { mark, stop } from '../../_utils/marks'

--- a/routes/_components/virtualList/VirtualListLazyItem.html
+++ b/routes/_components/virtualList/VirtualListLazyItem.html
@@ -1,4 +1,4 @@
-{#if props}
+{#if props && shown}
   <VirtualListItem {component}
                    {offset}
                    {props}
@@ -9,20 +9,30 @@
 <script>
   import VirtualListItem from './VirtualListItem'
   import { mark, stop } from '../../_utils/marks'
+  import { observe } from 'svelte-extras'
 
   export default {
-    async oncreate () {
-      let { makeProps, key } = this.get()
-      if (makeProps) {
+    oncreate () {
+      this.observe('key', async key => {
+        let { makeProps } = this.get()
+        if (!key || !makeProps) {
+          return
+        }
+        this.set({shown: false})
         let props = await makeProps(key)
+        this.set({shown: true})
         mark('VirtualListLazyItem set props')
         this.set({props: props})
         stop('VirtualListLazyItem set props')
-      }
+      })
     },
     data: () => ({
-      props: void 0
+      props: void 0,
+      shown: false
     }),
+    methods: {
+      observe
+    },
     components: {
       VirtualListItem
     }

--- a/routes/_components/virtualList/VirtualListRepeater.html
+++ b/routes/_components/virtualList/VirtualListRepeater.html
@@ -70,11 +70,14 @@
         let itemComponent
 
         if (this._recycledItems.length) {
+          mark('recycle v-item')
           let recycledItem = this._recycledItems.pop()
           target = recycledItem.target
           itemComponent = recycledItem.itemComponent
           itemComponent.set(item)
+          stop('recycle v-item')
         } else {
+          mark('create v-item')
           target = document.createElement('div')
           let { component, makeProps } = this.get()
           let { offset, key, index } = item
@@ -88,6 +91,7 @@
               index
             }
           })
+          stop('create v-item')
         }
 
         this.refs.node.appendChild(target)

--- a/routes/_components/virtualList/VirtualListRepeater.html
+++ b/routes/_components/virtualList/VirtualListRepeater.html
@@ -1,0 +1,98 @@
+<div ref:node></div>
+<script>
+  import VirtualListLazyItem from './VirtualListLazyItem.html'
+  import { observe } from 'svelte-extras'
+  import { mark, stop } from '../../_utils/marks'
+  import { scheduleIdleTask } from '../../_utils/scheduleIdleTask'
+
+  const getKey = _ => _.key
+
+  export default {
+    oncreate () {
+      this._itemMap = new Map()
+      this.observe('visibleItems', (newVisibleItems, oldVisibleItems) => {
+        newVisibleItems = newVisibleItems || []
+        oldVisibleItems = oldVisibleItems || []
+
+        let newVisibleItemsSet = new Set(newVisibleItems.map(getKey))
+        let oldVisibleItemsSet = new Set(oldVisibleItems.map(getKey))
+
+        for (let i = 0; i < newVisibleItems.length; i++) {
+          let visibleItem = newVisibleItems[i]
+          if (!oldVisibleItemsSet.has(visibleItem.key)) {
+            this.addItem(visibleItem)
+          } else {
+            this.updateItem(visibleItem)
+          }
+        }
+
+        for (let i = 0; i < oldVisibleItems.length; i++) {
+          let visibleItem = oldVisibleItems[i]
+          if (!newVisibleItemsSet.has(visibleItem.key)) {
+            this.removeItem(visibleItem)
+          }
+        }
+      }, {init: false})
+    },
+    ondestroy () {
+      this._itemMap.forEach(cachedItem => {
+        scheduleIdleTask(() => { // this work is non-critical
+          mark('destroy v-item')
+          cachedItem.itemComponent.destroy()
+          stop('destroy v-item')
+        })
+      })
+    },
+    data: () => ({
+      component: void 0,
+      visibleItems: void 0
+    }),
+    methods: {
+      observe,
+      removeItem (item) {
+        let cachedItem = this._itemMap.get(item.key)
+        if (cachedItem) {
+          this._itemMap.delete(item.key)
+          mark('remove v-item')
+          this.refs.node.removeChild(cachedItem.target)
+          stop('remove v-item')
+          scheduleIdleTask(() => { // this work is non-critical
+            mark('destroy v-item')
+            cachedItem.itemComponent.destroy()
+            stop('destroy v-item')
+          })
+        }
+      },
+      addItem (item) {
+        mark('add v-item')
+        let target = document.createElement('div')
+        this.refs.node.appendChild(target)
+        let { component, makeProps } = this.get()
+        let { offset, key, index } = item
+        let itemComponent = new VirtualListLazyItem({
+          target,
+          data: {
+            component,
+            makeProps,
+            offset,
+            key,
+            index
+          }
+        })
+        this._itemMap.set(item.key, {
+          target,
+          itemComponent
+        })
+        stop('add v-item')
+      },
+      updateItem (item) {
+        let cachedItem = this._itemMap.get(item.key)
+        if (cachedItem) {
+          mark('update v-item')
+          cachedItem.itemComponent.set(item)
+          stop('update v-item')
+        }
+      }
+    }
+  }
+</script>

--- a/routes/_components/virtualList/VirtualListRepeater.html
+++ b/routes/_components/virtualList/VirtualListRepeater.html
@@ -1,3 +1,7 @@
+<!--
+  Much of this is inspired by https://valdrinkoshi.github.io/virtual-scroller/
+  The idea is to recycle DOM nodes and Svelte components by keeping a pool of them around.
+-->
 <div ref:node></div>
 <script>
   import VirtualListLazyItem from './VirtualListLazyItem.html'

--- a/routes/_components/virtualList/VirtualListRepeater.html
+++ b/routes/_components/virtualList/VirtualListRepeater.html
@@ -10,6 +10,7 @@
   export default {
     oncreate () {
       this._itemMap = new Map()
+      this._recycledItems = []
       this.observe('visibleItems', (newVisibleItems, oldVisibleItems) => {
         newVisibleItems = newVisibleItems || []
         oldVisibleItems = oldVisibleItems || []
@@ -36,11 +37,10 @@
     },
     ondestroy () {
       this._itemMap.forEach(cachedItem => {
-        scheduleIdleTask(() => { // this work is non-critical
-          mark('destroy v-item')
-          cachedItem.itemComponent.destroy()
-          stop('destroy v-item')
-        })
+        this.lazilyDestroy(cachedItem.itemComponent)
+      })
+      this._recycledItems.forEach(recycledItem => {
+        this.lazilyDestroy(recycledItem.itemComponent)
       })
     },
     data: () => ({
@@ -56,29 +56,38 @@
           mark('remove v-item')
           this.refs.node.removeChild(cachedItem.target)
           stop('remove v-item')
-          scheduleIdleTask(() => { // this work is non-critical
-            mark('destroy v-item')
-            cachedItem.itemComponent.destroy()
-            stop('destroy v-item')
-          })
+          this._recycledItems.push(cachedItem)
         }
       },
       addItem (item) {
         mark('add v-item')
-        let target = document.createElement('div')
+
+        let target
+        let itemComponent
+
+        if (this._recycledItems.length) {
+          let recycledItem = this._recycledItems.pop()
+          target = recycledItem.target
+          itemComponent = recycledItem.itemComponent
+          itemComponent.set(item)
+        } else {
+          target = document.createElement('div')
+          let { component, makeProps } = this.get()
+          let { offset, key, index } = item
+          itemComponent = new VirtualListLazyItem({
+            target,
+            data: {
+              component,
+              makeProps,
+              offset,
+              key,
+              index
+            }
+          })
+        }
+
         this.refs.node.appendChild(target)
-        let { component, makeProps } = this.get()
-        let { offset, key, index } = item
-        let itemComponent = new VirtualListLazyItem({
-          target,
-          data: {
-            component,
-            makeProps,
-            offset,
-            key,
-            index
-          }
-        })
+
         this._itemMap.set(item.key, {
           target,
           itemComponent
@@ -92,6 +101,13 @@
           cachedItem.itemComponent.set(item)
           stop('update v-item')
         }
+      },
+      lazilyDestroy (itemComponent) {
+        scheduleIdleTask(() => { // this work is non-critical
+          mark('destroy v-item')
+          itemComponent.destroy()
+          stop('destroy v-item')
+        })
       }
     }
   }

--- a/routes/_utils/delegate.js
+++ b/routes/_utils/delegate.js
@@ -23,18 +23,36 @@ function onEvent (e) {
     }
     element = element.parentElement
   }
-  if (key && callbacks[key]) {
-    callbacks[key](e)
+  let cbs = key && callbacks[key]
+  if (cbs) {
+    for (let i = 0; i < cbs.length; i++) {
+      cbs[i](e)
+    }
   }
   stop('delegate onEvent')
 }
 
 export function addClickDelegate (key, callback) {
-  callbacks[key] = callback
+  callbacks[key] = callbacks[key] || []
+  callbacks[key].push(callback)
 }
 
-export function removeClickDelegate (key) {
-  delete callbacks[key]
+export function removeClickDelegate (key, callback) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (!callback) {
+      throw new Error('callback must be non-null')
+    }
+  }
+  let cbs = callbacks[key]
+  if (cbs) {
+    let idx = cbs.indexOf(callback)
+    if (idx !== -1) {
+      cbs.splice(idx, 1)
+    }
+  }
+  if (!cbs.length) {
+    delete callbacks[key]
+  }
 }
 
 if (process.browser) {

--- a/routes/_utils/delegate.js
+++ b/routes/_utils/delegate.js
@@ -29,18 +29,12 @@ function onEvent (e) {
   stop('delegate onEvent')
 }
 
-export function registerClickDelegates (component, delegates) {
-  Object.assign(callbacks, delegates)
-
-  component.on('destroy', () => {
-    Object.keys(delegates).forEach(key => {
-      delete callbacks[key]
-    })
-  })
+export function addClickDelegate (key, callback) {
+  callbacks[key] = callback
 }
 
-export function registerClickDelegate (component, key, callback) {
-  registerClickDelegates(component, {[key]: callback})
+export function removeClickDelegate (key) {
+  delete callbacks[key]
 }
 
 if (process.browser) {

--- a/routes/_utils/eventBus.js
+++ b/routes/_utils/eventBus.js
@@ -2,9 +2,10 @@ import EventEmitter from 'events'
 
 const eventBus = new EventEmitter()
 
-// we need enough 'postedStatus' listeners for each
-// visible status in a timeline
-eventBus.setMaxListeners(100)
+// We need enough 'postedStatus' listeners for each
+// visible status in a timeline. Some statuses may hang around
+// for a bit because they're destroyed lazily via rIC.
+eventBus.setMaxListeners(200)
 
 if (process.browser && process.env.NODE_ENV !== 'production') {
   window.eventBus = eventBus


### PR DESCRIPTION
This is the first step in getting a more performant virtual list. I would like to get to where we are recycling DOM nodes and Svelte components inside of the virtual list (ala https://valdrinkoshi.github.io/virtual-scroller/), but as a first step I am basically reimplementing the Svelte `#each` loop and making a modest adjustment to defer `component.destroy()` work which based on my measurements is fairly expensive.

My measurements indicate that removing a component is most expensive, followed by adding a component, followed by updating. Updating is so cheap it's almost free. So this validates my assumption that moving to a model where we re-use all components rather than destroying/recreating would be a big perf win.