### PR TITLE
implement custom virtual list repeater

### DIFF
--- a/routes/_components/virtualList/VirtualList.html
+++ b/routes/_components/virtualList/VirtualList.html
@@ -3,16 +3,8 @@
        style="height: {$height}px;"
        ref:node >
     <VirtualListHeader component={headerComponent} virtualProps={headerProps} shown={$showHeader}/>
-    {#if $visibleItems}
-      {#each $visibleItems as visibleItem (visibleItem.key)}
-        <VirtualListLazyItem {component}
-                             offset={visibleItem.offset}
-                             {makeProps}
-                             key={visibleItem.key}
-                             index={visibleItem.index}
-        />
-      {/each}
-    {/if}
+
+    <VirtualListRepeater {component} {makeProps} visibleItems={$visibleItems} />
     {#if $showFooter}
       <VirtualListFooter component={footerComponent} />
     {/if}
@@ -25,7 +17,7 @@
 </style>
 <script>
   import VirtualListContainer from './VirtualListContainer.html'
-  import VirtualListLazyItem from './VirtualListLazyItem'
+  import VirtualListRepeater from './VirtualListRepeater.html'
   import VirtualListFooter from './VirtualListFooter.html'
   import VirtualListHeader from './VirtualListHeader.html'
   import { virtualListStore } from './virtualListStore'
@@ -90,13 +82,10 @@
         this.calculateListOffset()
       })
     },
-    data: () => ({
-      component: null
-    }),
     store: () => virtualListStore,
     components: {
       VirtualListContainer,
-      VirtualListLazyItem,
+      VirtualListRepeater,
       VirtualListFooter,
       VirtualListHeader
     },

--- a/routes/_components/virtualList/VirtualListRepeater.html
+++ b/routes/_components/virtualList/VirtualListRepeater.html
@@ -1,0 +1,98 @@
+<div ref:node></div>
+<script>
+  import VirtualListLazyItem from './VirtualListLazyItem.html'
+  import { observe } from 'svelte-extras'
+  import { mark, stop } from '../../_utils/marks'
+  import { scheduleIdleTask } from '../../_utils/scheduleIdleTask'
+
+  const getKey = _ => _.key
+
+  export default {
+    oncreate () {
+      this._itemMap = new Map()
+      this.observe('visibleItems', (newVisibleItems, oldVisibleItems) => {
+        newVisibleItems = newVisibleItems || []
+        oldVisibleItems = oldVisibleItems || []
+
+        let newVisibleItemsSet = new Set(newVisibleItems.map(getKey))
+        let oldVisibleItemsSet = new Set(oldVisibleItems.map(getKey))
+
+        for (let i = 0; i < newVisibleItems.length; i++) {
+          let visibleItem = newVisibleItems[i]
+          if (!oldVisibleItemsSet.has(visibleItem.key)) {
+            this.addItem(visibleItem)
+          } else {
+            this.updateItem(visibleItem)
+          }
+        }
+
+        for (let i = 0; i < oldVisibleItems.length; i++) {
+          let visibleItem = oldVisibleItems[i]
+          if (!newVisibleItemsSet.has(visibleItem.key)) {
+            this.removeItem(visibleItem)
+          }
+        }
+      }, {init: false})
+    },
+    ondestroy () {
+      this._itemMap.forEach(cachedItem => {
+        scheduleIdleTask(() => { // this work is non-critical
+          mark('destroy v-item')
+          cachedItem.itemComponent.destroy()
+          stop('destroy v-item')
+        })
+      })
+    },
+    data: () => ({
+      component: void 0,
+      visibleItems: void 0
+    }),
+    methods: {
+      observe,
+      removeItem (item) {
+        let cachedItem = this._itemMap.get(item.key)
+        if (cachedItem) {
+          this._itemMap.delete(item.key)
+          mark('remove v-item')
+          this.refs.node.removeChild(cachedItem.target)
+          stop('remove v-item')
+          scheduleIdleTask(() => { // this work is non-critical
+            mark('destroy v-item')
+            cachedItem.itemComponent.destroy()
+            stop('destroy v-item')
+          })
+        }
+      },
+      addItem (item) {
+        mark('add v-item')
+        let target = document.createElement('div')
+        this.refs.node.appendChild(target)
+        let { component, makeProps } = this.get()
+        let { offset, key, index } = item
+        let itemComponent = new VirtualListLazyItem({
+          target,
+          data: {
+            component,
+            makeProps,
+            offset,
+            key,
+            index
+          }
+        })
+        this._itemMap.set(item.key, {
+          target,
+          itemComponent
+        })
+        stop('add v-item')
+      },
+      updateItem (item) {
+        let cachedItem = this._itemMap.get(item.key)
+        if (cachedItem) {
+          mark('update v-item')
+          cachedItem.itemComponent.set(item)
+          stop('update v-item')
+        }
+      }
+    }
+  }
+</script>

--- a/routes/_utils/eventBus.js
+++ b/routes/_utils/eventBus.js
@@ -2,9 +2,10 @@ import EventEmitter from 'events'
 
 const eventBus = new EventEmitter()
 
-// we need enough 'postedStatus' listeners for each
-// visible status in a timeline
-eventBus.setMaxListeners(100)
+// We need enough 'postedStatus' listeners for each
+// visible status in a timeline. Some statuses may hang around
+// for a bit because they're destroyed lazily via rIC.
+eventBus.setMaxListeners(200)
 
 if (process.browser && process.env.NODE_ENV !== 'production') {
   window.eventBus = eventBus


### PR DESCRIPTION
less ambitious version of #458. instead of fully recycling nodes/components, for now we are just delaying the `destroy()` method in a requestIdleCallback to move some non-critical work out of the critical path.