### PR TITLE
second attempt at modal back button

### DIFF
--- a/routes/_components/dialog/components/ImageDialog.html
+++ b/routes/_components/dialog/components/ImageDialog.html
@@ -35,15 +35,25 @@
   import ModalDialog from './ModalDialog.html'
   import AutoplayVideo from '../../AutoplayVideo.html'
   import { show } from '../helpers/showDialog'
-  import { oncreate } from '../helpers/onCreateDialog'
+  import { oncreate as onCreateDialog } from '../helpers/onCreateDialog'
+  import { close } from '../helpers/closeDialog'
 
   export default {
-    oncreate,
+    oncreate () {
+      onCreateDialog.call(this)
+      this.close = this.close.bind(this)
+      history.pushState({type: 'image-dialog'}, null, location.pathname)
+      window.addEventListener('popstate', this.close)
+    },
+    ondestroy () {
+      window.removeEventListener('popstate', this.close)
+    },
     components: {
       ModalDialog,
       AutoplayVideo
     },
     methods: {
+      close,
       show
     }
   }

--- a/routes/_components/dialog/components/VideoDialog.html
+++ b/routes/_components/dialog/components/VideoDialog.html
@@ -24,14 +24,24 @@
 <script>
   import ModalDialog from './ModalDialog.html'
   import { show } from '../helpers/showDialog'
-  import { oncreate } from '../helpers/onCreateDialog'
+  import { oncreate as onCreateDialog } from '../helpers/onCreateDialog'
+  import { close } from '../helpers/closeDialog'
 
   export default {
-    oncreate,
+    oncreate () {
+      onCreateDialog.call(this)
+      this.close = this.close.bind(this)
+      history.pushState({type: 'video-dialog'}, null, location.pathname)
+      window.addEventListener('popstate', this.close)
+    },
+    ondestroy () {
+      window.removeEventListener('popstate', this.close)
+    },
     components: {
       ModalDialog
     },
     methods: {
+      close,
       show
     }
   }


### PR DESCRIPTION
second attempt, here are the bugs with this approach:

- keeps adding entries to the history for every dialog you click, assuming you use something other than the back button to close them
- causes a re-render of the whole timeline component when you press the back button

overall this is just really not working. I guess I need to use the router that is actually built into Sapper.