### PR TITLE
fix requested view for follow requests

### DIFF
--- a/routes/_components/profile/AccountProfileFollow.html
+++ b/routes/_components/profile/AccountProfileFollow.html
@@ -65,8 +65,8 @@
         return relationship && relationship.following
       },
       blocking: ({ relationship }) => relationship && relationship.blocking,
-      followRequested: ({ relationship, account }) => {
-        return relationship && relationship.requested && account && account.locked
+      followRequested: ({ relationship }) => {
+        return relationship && relationship.requested
       },
       followLabel: ({ blocking, following, followRequested }) => {
         if (blocking) {


### PR DESCRIPTION
Non-locked accounts can also have a "follow request" if Sidekiq is backed up.