### PR TITLE
fix incorrect toast notification for follow requests

### DIFF
--- a/routes/_actions/follow.js
+++ b/routes/_actions/follow.js
@@ -2,28 +2,19 @@ import { store } from '../_store/store'
 import { followAccount, unfollowAccount } from '../_api/follow'
 import { toast } from '../_utils/toast'
 import { updateProfileAndRelationship } from './accounts'
-import {
-  getRelationship as getRelationshipFromDatabase
-} from '../_database/relationships'
 
 export async function setAccountFollowed (accountId, follow, toastOnSuccess) {
   let { currentInstance, accessToken } = store.get()
   try {
-    let account
     if (follow) {
-      account = await followAccount(currentInstance, accessToken, accountId)
+      await followAccount(currentInstance, accessToken, accountId)
     } else {
-      account = await unfollowAccount(currentInstance, accessToken, accountId)
+      await unfollowAccount(currentInstance, accessToken, accountId)
     }
     await updateProfileAndRelationship(accountId)
-    let relationship = await getRelationshipFromDatabase(currentInstance, accountId)
     if (toastOnSuccess) {
       if (follow) {
-        if (account.locked && relationship.requested) {
-          toast.say('Requested to follow account')
-        } else {
-          toast.say('Followed account')
-        }
+        toast.say('Followed account')
       } else {
         toast.say('Unfollowed account')
       }


### PR DESCRIPTION
This code is nonsensical because the "account" object is actually a follow response and will never have a `locked` property. Also we'll never toast in this case because it's only for status options, and you can't see someone's status if their account is locked.