### PR TITLE
Store IDB data for 1 week rather than 2 weeks

### DIFF
--- a/routes/_database/cleanup.js
+++ b/routes/_database/cleanup.js
@@ -18,7 +18,7 @@ import { deleteAll } from './utils'
 import { createPinnedStatusKeyRange, createThreadKeyRange } from './keys'
 
 const BATCH_SIZE = 20
-const TIME_AGO = 14 * 24 * 60 * 60 * 1000 // two weeks ago
+const TIME_AGO = 7 * 24 * 60 * 60 * 1000 // one week ago
 const DELAY = 5 * 60 * 1000 // five minutes
 
 function batchedGetAll (callGetAll, callback) {


### PR DESCRIPTION
Based on issues I'm seeing on iOS Safari, I'm guessing that my IDB caching is too aggressive and is hitting origin storage limits, which causes IDB transactions in safari to fail silently and never call any transaction callbacks (`onblocked`, `onerror`, `oncomplete`).

This is pretty bad and causes Pinafore to basically just not work unless you clear site data, which we should avoid. 2 weeks was probably unnecessary anyway; in a social network, who cares about content that's 2 weeks old?