### PR TITLE
fix autosuggest for dark themes

### DIFF
--- a/scss/themes/_dark.scss
+++ b/scss/themes/_dark.scss
@@ -25,4 +25,8 @@
   --muted-modal-hover: #{rgba(255, 255, 255, 0.2)};
 
   --compose-button-halo: #{rgba(255, 255, 255, 0.1)};
+
+  --compose-autosuggest-item-hover: #{lighten($main-bg-color, 10%)};
+  --compose-autosuggest-item-active: #{lighten($main-bg-color, 15%)};
+  --compose-autosuggest-outline: #{lighten($border-color, 20%)};
 }


### PR DESCRIPTION
this makes the colors way easier to see on the autosuggest background in the dark themes