### PR TITLE
Make image use max-width and max-height in dialog

### DIFF
--- a/routes/_components/dialog/components/ImageDialog.html
+++ b/routes/_components/dialog/components/ImageDialog.html
@@ -10,14 +10,10 @@
       ariaLabel="Animated GIF: {description || ''}"
       {poster}
       {src}
-      {width}
-      {height}
     />
   {:else}
     <img
       {src}
-      {width}
-      {height}
       alt={description || ''}
       title={description || ''}
     />


### PR DESCRIPTION
Every time I click on an image to see the full version, it gets resized down to 300x200.

This PR fixes that :)
