### PR TITLE
switch timeline batch size back to 20

### DIFF
--- a/routes/_static/timelines.js
+++ b/routes/_static/timelines.js
@@ -1,4 +1,4 @@
-export const TIMELINE_BATCH_SIZE = 10
+export const TIMELINE_BATCH_SIZE = 20
 
 export const timelines = {
   home: { name: 'home', label: 'Home' },


### PR DESCRIPTION
If your screen is large and your notifications are mostly follows, then the timeline can fail to load.

TODO: fix that core problem instead