### PR TITLE
Inherit colors for input and textarea

### DIFF
--- a/scss/global.scss
+++ b/scss/global.scss
@@ -82,6 +82,12 @@ input {
   box-sizing: border-box;
 }
 
+// Fixes gray/black background when using a dark GTK theme
+input, textarea {
+  background: inherit;
+  color: inherit;
+}
+
 button, .button {
   font-size: 1.2em;
   background: var(--button-bg);


### PR DESCRIPTION
When using a dark GTK theme `input` and `textarea` use the theme's colors by default. This makes sure that they inherit the page's colors.

# Current behavior with the Arc GTK theme
![screenshot from 2018-09-07 00-00-09](https://user-images.githubusercontent.com/2109702/45188063-378f1400-b233-11e8-8e88-8b18956296e9.png)

Inheriting the page's color might not be desirable (see following screenshot). If that is the case we can just set it to white background with black text.

# Behavior with this patch (Arc GTK theme, Ozark Pinafore theme)
![image](https://user-images.githubusercontent.com/2109702/45188253-dd428300-b233-11e8-9fc9-5b80ff84a28c.png) 
