### PR TITLE
Make external links open in new tab

### DIFF
--- a/routes/_components/status/StatusContent.html
+++ b/routes/_components/status/StatusContent.html
@@ -114,6 +114,9 @@
           } else if (anchor.getAttribute('rel') === 'nofollow noopener') {
             anchor.setAttribute('title', href)
           }
+          if (anchor.getAttribute('href')[0] != '/' || anchor.getAttribute('href')[1] == '/') {
+            anchor.setAttribute('target', '_blank')
+          }
         }
         stop('hydrateContent')
       }


### PR DESCRIPTION
External links inside toots open up in a new tab (using target='_blank') instead of the same tab.