### PR TITLE
reduce limit of stored data to 5 days

### DIFF
--- a/routes/_database/cleanup.js
+++ b/routes/_database/cleanup.js
@@ -17,7 +17,7 @@ import { createPinnedStatusKeyRange, createThreadKeyRange } from './keys'
 import { getKnownInstances } from './knownInstances'
 
 const BATCH_SIZE = 20
-const TIME_AGO = 7 * 24 * 60 * 60 * 1000 // one week ago
+const TIME_AGO = 5 * 24 * 60 * 60 * 1000 // five days ago
 const DELAY = 5 * 60 * 1000 // five minutes
 
 function batchedGetAll (callGetAll, callback) {


### PR DESCRIPTION
Comments from heavy Mastodon users (like my wife) are that Pinafore just randomly stops working entirely, which I suspect is due to reaching database limits. It's kind of silly to store so much data, and it probably shouldn't even be limited based on time but rather on quantity, but for now reducing from 7 days to 5 days seems reasonable.