### PR TITLE
avoid delaying when inserting every post in tests

### DIFF
--- a/bin/restore-mastodon-data.js
+++ b/bin/restore-mastodon-data.js
@@ -45,7 +45,11 @@ export async function restoreMastodonData () {
   console.log('Restoring mastodon data...')
   let internalIdsToIds = {}
   for (let action of actions) {
-    await new Promise(resolve => setTimeout(resolve, 1000)) // delay so that notifications have proper order
+    if (!action.post) {
+      // If the action is a boost, favorite, etc., then it needs to
+      // be delayed, otherwise it may appear in an unpredictable order and break the tests.
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    }
     console.log(JSON.stringify(action))
     let accessToken = users[action.user].accessToken
 


### PR DESCRIPTION
This should speed up the tests by avoiding artificial delays. But I'm going to do 10 runs to make sure it actually doesn't introduce flakiness.