### PR TITLE
chore(travis): no explicit npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ addons:
     - redis-tools
     - zlib1g-dev
 before_install:
-  - npm install -g npm@6
   - npm install -g greenkeeper-lockfile@1
   - ./bin/setup-mastodon-in-travis.sh
 before_script:


### PR DESCRIPTION
It seems Travis already has npm 6 installed, so this just adds 10 seconds to the build.