### PR TITLE
chore(travis): use travis to deploy to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ matrix:
   include:
     - env: BROWSER=chrome:headless COMMAND=test-browser-suite0
     - env: BROWSER=chrome:headless COMMAND=test-browser-suite1
-    - env: COMMAND=deploy-dev-travis
+    - env: COMMAND=deploy-all-travis
   allow_failures:
-    - env: COMMAND=deploy-dev-travis
+    - env: COMMAND=deploy-all-travis
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -37,13 +37,16 @@
     "launch": "now -e SAPPER_TIMESTAMP=$(date +%s%3N) --team nolanlawson && sleep 60",
     "launch-travis": "now -e SAPPER_TIMESTAMP=$(date +%s%3N) --team nolanlawson --token $NOW_TOKEN && sleep 60",
     "alias-prod": "now alias pinafore.social --team nolanlawson",
+    "alias-prod-travis": "now alias pinafore.social --team nolanlawson --token $NOW_TOKEN",
     "alias-dev": "now alias dev.pinafore.social --team nolanlawson",
     "alias-dev-travis": "now alias dev.pinafore.social --team nolanlawson --token $NOW_TOKEN",
     "cleanup": "now rm pinafore --safe --yes --team nolanlawson",
     "cleanup-travis": "now rm pinafore --safe --yes --team nolanlawson --token $NOW_TOKEN",
     "deploy-prod": "run-s stage-prod launch alias-prod cleanup",
     "deploy-dev": "run-s stage-dev launch alias-dev cleanup",
-    "deploy-dev-travis": "if [ $TRAVIS_BRANCH = master -a $TRAVIS_PULL_REQUEST = false ]; then run-s stage-dev launch-travis alias-dev-travis cleanup-travis; fi",
+    "deploy-dev-travis": "run-s stage-dev launch-travis alias-dev-travis cleanup-travis; fi",
+    "deploy-prod-travis": "if echo $TRAVIS_COMMIT_MESSAGE | grep -q -E '\\d+\\.\\d+\\.\\d+'; then run-s stage-prod launch-travis alias-prod-travis cleanup-travis; fi",
+    "deploy-all-travis": "if [ $TRAVIS_BRANCH = master -a $TRAVIS_PULL_REQUEST = false ]; then run-s deploy-dev-travis deploy-prod-travis; fi",
     "backup-mastodon-data": "PGPASSWORD=pinafore pg_dump -U pinafore -w pinafore_development > fixtures/dump.sql && cd mastodon/public/system && tar -czf ../../../fixtures/system.tgz ."
   },
   "dependencies": {


### PR DESCRIPTION
Instead of deploying to production manually, just grep the commit message and if it looks like a version number, deploy immediately to production.