### PR TITLE
chore(travis): try explicit apt-get installs for faster scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty   # needed for chrome headless
 sudo: required # needed for various sudo operations
 addons:
   chrome: stable
+  postgresql: "10"
 before_install:
   - npm install -g greenkeeper-lockfile@1
   - ./bin/setup-mastodon-in-travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,6 @@ dist: trusty   # needed for chrome headless
 sudo: required # needed for various sudo operations
 addons:
   chrome: stable
-  postgresql: "10"
-  apt:
-    packages:
-    - autoconf
-    - bison
-    - build-essential
-    - file
-    - g++
-    - gcc
-    - imagemagick
-    - libffi-dev
-    - libgdbm-dev
-    - libgdbm3
-    - libicu-dev
-    - libidn11-dev
-    - libncurses5-dev
-    - libpq-dev
-    - libprotobuf-dev
-    - libreadline6-dev
-    - libssl-dev
-    - libxml2-dev
-    - libxslt1-dev
-    - libyaml-dev
-    - pkg-config nodejs
-    - postgresql-10
-    - postgresql-client-10
-    - postgresql-contrib-10
-    - protobuf-compiler
-    - redis-server
-    - redis-tools
-    - zlib1g-dev
 before_install:
   - npm install -g greenkeeper-lockfile@1
   - ./bin/setup-mastodon-in-travis.sh

--- a/bin/setup-mastodon-in-travis.sh
+++ b/bin/setup-mastodon-in-travis.sh
@@ -53,6 +53,10 @@ sudo mv redis.conf /etc/redis
 sudo service redis-server start
 echo PING | nc localhost 6379 # check redis running
 
+# run postgres
+sudo service postgresql start 10
+pg_isready -p "$PGPORT" # check postgres running
+
 # check versions
 ruby --version
 node --version

--- a/bin/setup-mastodon-in-travis.sh
+++ b/bin/setup-mastodon-in-travis.sh
@@ -11,9 +11,6 @@ source "$HOME/.rvm/scripts/rvm"
 rvm install 2.5.1
 rvm use 2.5.1
 
-# equivalent to addons: postgresql: 10
-sudo -E travis_setup_postgresql 10
-
 # install ffmpeg from PPA because it's not in Trusty
 sudo -E add-apt-repository -y ppa:mc3man/trusty-media
 sudo -E apt-get update

--- a/bin/setup-mastodon-in-travis.sh
+++ b/bin/setup-mastodon-in-travis.sh
@@ -11,17 +11,50 @@ source "$HOME/.rvm/scripts/rvm"
 rvm install 2.5.1
 rvm use 2.5.1
 
+# equivalent to addons: postgresql: 10
+sudo -E travis_setup_postgresql 10
+
+# install ffmpeg from PPA because it's not in Trusty
+sudo -E add-apt-repository -y ppa:mc3man/trusty-media
+sudo -E apt-get update
+sudo -E apt-get install \
+  -yq --no-install-suggests --no-install-recommends \
+  autoconf \
+  bison \
+  build-essential \
+  file \
+  ffmpeg \
+  g++ \
+  gcc \
+  imagemagick \
+  libffi-dev \
+  libgdbm-dev \
+  libgdbm3 \
+  libicu-dev \
+  libidn11-dev \
+  libncurses5-dev \
+  libpq-dev \
+  libprotobuf-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  libyaml-dev \
+  pkg-config nodejs \
+  postgresql-10 \
+  postgresql-client-10 \
+  postgresql-contrib-10 \
+  protobuf-compiler \
+  redis-server \
+  redis-tools \
+  zlib1g-dev
+
 # fix for redis IPv6 issue
 # https://travis-ci.community/t/trusty-environment-redis-server-not-starting-with-redis-tools-installed/650/2
 sudo sed -e 's/^bind.*/bind 127.0.0.1/' /etc/redis/redis.conf > redis.conf
 sudo mv redis.conf /etc/redis
 sudo service redis-server start
 echo PING | nc localhost 6379 # check redis running
-
-# install ffmpeg from PPA because it's not in Trusty
-sudo -E add-apt-repository -y ppa:mc3man/trusty-media
-sudo -E apt-get update
-sudo -E apt-get install -y ffmpeg
 
 # check versions
 ruby --version


### PR DESCRIPTION
I have a hunch this may be faster given 1) we have to manually install ffmpeg anyway, and 2) we don't want to run any of this stuff for the "deploy" job