### PR TITLE
chore(travis): try travis sudo:false infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "8"
 dist: trusty   # needed for chrome headless
-sudo: required # needed for various sudo operations
+sudo: false
 addons:
   chrome: stable
   postgresql: "10"
@@ -38,6 +38,7 @@ addons:
     - zlib1g-dev
 before_install:
   - npm install -g greenkeeper-lockfile@1
+  - export PATH=$PATH:/home/travis/ffmpeg-static
   - ./bin/setup-mastodon-in-travis.sh
 before_script:
   - npm run lint

--- a/bin/setup-mastodon-in-travis.sh
+++ b/bin/setup-mastodon-in-travis.sh
@@ -11,13 +11,6 @@ source "$HOME/.rvm/scripts/rvm"
 rvm install 2.5.1
 rvm use 2.5.1
 
-# fix for redis IPv6 issue
-# https://travis-ci.community/t/trusty-environment-redis-server-not-starting-with-redis-tools-installed/650/2
-sudo sed -e 's/^bind.*/bind 127.0.0.1/' /etc/redis/redis.conf > redis.conf
-sudo mv redis.conf /etc/redis
-sudo service redis-server start
-echo PING | nc localhost 6379 # check redis running
-
 # install ffmpeg because it's not in Trusty
 if [ ! -f /home/travis/ffmpeg-static/ffmpeg ]; then
   rm -fr /home/travis/ffmpeg-static
@@ -28,8 +21,6 @@ if [ ! -f /home/travis/ffmpeg-static/ffmpeg ]; then
     'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz'
   tar -x -C /home/travis/ffmpeg-static --strip-components 1 -f ffmpeg.tar.xz --wildcards '*/ffmpeg' --wildcards '*/ffprobe'
 fi
-sudo ln -s /home/travis/ffmpeg-static/ffmpeg /usr/local/bin/ffmpeg
-sudo ln -s /home/travis/ffmpeg-static/ffprobe /usr/local/bin/ffprobe
 
 # check versions
 ruby --version


### PR DESCRIPTION
Supposedly these boot faster and have IPv6, which should avoid the Redis issue.