### PR TITLE
chore(travis); use npm ci || npm i

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_script:
   - greenkeeper-lockfile-update
 after_script:
   - greenkeeper-lockfile-upload
+install:
+  - npm ci || npm i
 script: travis_retry npm run $COMMAND
 env:
   global:


### PR DESCRIPTION
I don't know why I thought it would be a good idea to remove this. Greenkeeper is failing because of it.