### PR TITLE
fix(eventBus): increase event listeners to 1000

### DIFF
--- a/routes/_utils/eventBus.js
+++ b/routes/_utils/eventBus.js
@@ -4,7 +4,7 @@ const eventBus = new EventEmitter()
 
 // we need enough 'postedStatus' listeners for each
 // visible status in a timeline
-eventBus.setMaxListeners(100)
+eventBus.setMaxListeners(1000)
 
 if (process.browser && process.env.NODE_ENV !== 'production') {
   window.eventBus = eventBus


### PR DESCRIPTION
It seems we can occasionally go over the limit of 100, and it's not a memory leak AFAICT.