### PR TITLE
fix(deps): remove timeago.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,6 @@
       "integrity": "sha1-4ByfjIXKg7YQMgxiJYsMkCat4Pc=",
       "dev": true
     },
-    "@types/jquery": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.51.tgz",
-      "integrity": "sha512-+vtCjz+pzr5KkaX/GMnVF0YtQqkm+oVcdBH0Q7zCxdwk42c71xJ9hT1b6Mbn4Kf7CAxSHvkWF1LRdpYwUM+pcg=="
-    },
     "@types/lodash": {
       "version": "4.14.118",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
@@ -2044,14 +2039,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "optional": true
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2066,20 +2059,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "optional": true
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "optional": true
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "optional": true
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2196,8 +2186,7 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "optional": true
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "ini": {
               "version": "1.3.5",
@@ -2209,7 +2198,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2224,7 +2212,6 @@
               "version": "3.0.4",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -2232,14 +2219,12 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "optional": true
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             },
             "minipass": {
               "version": "2.2.4",
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -2258,7 +2243,6 @@
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2339,8 +2323,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "optional": true
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2352,7 +2335,6 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2474,7 +2456,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10274,14 +10255,6 @@
       "resolved": "https://registry.npmjs.org/time-limit-promise/-/time-limit-promise-1.0.4.tgz",
       "integrity": "sha512-FLHDDsIDducw7MBcRWlFtW2Tm50DoKOSFf0Nzx17qwXj8REXCte0eUkHrJl9QU3Bl9arG3XNYX0PcHpZ9xyuLw==",
       "dev": true
-    },
-    "timeago.js": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.0-beta.1.tgz",
-      "integrity": "sha512-4nqHcIbOwiB9q28rHowuIjjxQHBUDO2nHb4Hb3OOtaIhmzYWqNOZjIZkSTiRf0Ch7YzFw4t1bXsQA6prpKSfag==",
-      "requires": {
-        "@types/jquery": "^2.0.40"
-      }
     },
     "timeout-as-promise": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "svelte-transitions": "^1.2.0",
     "svgo": "^1.1.1",
     "terser-webpack-plugin": "^1.1.0",
-    "timeago.js": "^4.0.0-beta.1",
     "tiny-queue": "^0.2.1",
     "web-animations-js": "^2.3.1",
     "webpack": "^4.26.0",

--- a/routes/_intl/formatTimeagoDate.js
+++ b/routes/_intl/formatTimeagoDate.js
@@ -1,11 +1,9 @@
-import timeago from 'timeago.js'
+import { format } from '../_thirdparty/timeago/timeago'
 import { mark, stop } from '../_utils/marks'
-
-const timeagoInstance = timeago()
 
 export function formatTimeagoDate (date) {
   mark('formatTimeagoDate')
-  let res = timeagoInstance.format(date)
+  let res = format(date)
   stop('formatTimeagoDate')
   return res
 }

--- a/routes/_thirdparty/timeago/LICENSE
+++ b/routes/_thirdparty/timeago/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Hust.cc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/routes/_thirdparty/timeago/timeago.js
+++ b/routes/_thirdparty/timeago/timeago.js
@@ -1,0 +1,78 @@
+// adapted from https://unpkg.com/timeago.js@4.0.0-beta.1/lib/index.js
+/**
+ * Created by hustcc on 18/5/20.
+ * Contract: i@hust.cc
+ */
+
+var IndexMapEn = 'second_minute_hour_day_week_month_year'.split('_')
+var SEC_ARRAY = [60, 60, 24, 7, 365 / 7 / 12, 12]
+
+/**
+ * Created by hustcc on 18/5/20.
+ * Contract: i@hust.cc
+ */
+
+function en (number, index) {
+  if (index === 0) {
+    return ['just now', 'right now']
+  }
+  var unit = IndexMapEn[Math.floor(index / 2)]
+  if (number > 1) {
+    unit += 's'
+  }
+  return [number + ' ' + unit + ' ago', 'in ' + number + ' ' + unit]
+}
+
+/**
+ * Created by hustcc on 18/5/20.
+ * Contract: i@hust.cc
+ */
+
+/**
+ * format the diff second to *** time ago, with setting locale
+ * @param diff
+ * @param locale
+ * @param defaultLocale
+ * @returns {string | void | *}
+ */
+function formatDiff (diff) {
+  // if locale is not exist, use defaultLocale.
+  // if defaultLocale is not exist, use build-in `en`.
+  // be sure of no error when locale is not exist.
+  var i = 0
+
+  var agoin = diff < 0 ? 1 : 0
+
+  // timein or timeago
+
+  var totalSec = diff = Math.abs(diff)
+
+  for (; diff >= SEC_ARRAY[i] && i < SEC_ARRAY.length; i++) {
+    diff /= SEC_ARRAY[i]
+  }
+  diff = Math.floor(diff)
+  i *= 2
+
+  if (diff > (i === 0 ? 9 : 1)) i += 1
+  return en(diff, i, totalSec)[agoin].replace('%s', diff)
+}
+
+/**
+ * calculate the diff second between date to be formatted an now date.
+ * @param date
+ * @param nowDate
+ * @returns {number}
+ */
+function diffSec (date) {
+  var nowDate = new Date()
+  var otherDate = new Date(date)
+  return (nowDate - otherDate) / 1000
+}
+
+/**
+ * Created by hustcc on 18/5/20.
+ * Contract: i@hust.cc
+ */
+export function format (date) {
+  return formatDiff(diffSec(date))
+}


### PR DESCRIPTION
This dependency was doing much more than we needed (including containing Chinese formatters), so I moved it to `_thirdparty` and stripped it down. As a result, it seems to be much more performant at runtime as well as smaller.