### PR TITLE
fix(scrollbars): use standard CSS for scrollbars

### DIFF
--- a/scss/themes/_scrollbars.scss
+++ b/scss/themes/_scrollbars.scss
@@ -1,6 +1,10 @@
 html {
-  scrollbar-face-color: $scrollbar-face;
-  scrollbar-track-color: $scrollbar-track;
+  // Firefox with scrollbar config changes as of 2018-11
+  scrollbar-face-color: #{$scrollbar-face};
+  scrollbar-track-color: #{$scrollbar-track};
+  // Firefox nightly as of 2018-11, new standard version
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color
+  scrollbar-color: #{$scrollbar-face $scrollbar-track};
 }
 
 ::-webkit-scrollbar {
@@ -9,20 +13,20 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: $scrollbar-face;
+  background: #{$scrollbar-face};
   border-radius: 0;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: $scrollbar-face-hover;
+  background: #{$scrollbar-face-hover};
 }
 
 ::-webkit-scrollbar-thumb:active {
-  background: $scrollbar-face-active;
+  background: #{$scrollbar-face-active};
 }
 
 ::-webkit-scrollbar-track, ::-webkit-scrollbar-track:hover, ::-webkit-scrollbar-track:active {
-  background: $scrollbar-track
+  background: #{$scrollbar-track};
 }
 
 ::-webkit-scrollbar-corner {


### PR DESCRIPTION
Also use correct SCSS escaping everywhere, and fix a missing semicolon. Fixes #691