### PR TITLE
feat(a11y): add option to disable tappable toots

### DIFF
--- a/routes/_components/status/Status.html
+++ b/routes/_components/status/Status.html
@@ -122,7 +122,8 @@
   export default {
     oncreate () {
       let { delegateKey, isStatusInOwnThread, showContent } = this.get()
-      if (!isStatusInOwnThread) {
+      let { disableTapOnStatus } = this.store.get()
+      if (!isStatusInOwnThread && !disableTapOnStatus) {
         // the whole <article> is clickable in this case
         registerClickDelegate(this, delegateKey, (e) => this.onClickOrKeydown(e))
       }

--- a/routes/_pages/settings/general.html
+++ b/routes/_pages/settings/general.html
@@ -33,6 +33,11 @@
       <label for="choice-reduce-motion">Reduce motion in UI animations</label>
     </div>
     <div class="setting-group">
+      <input type="checkbox" id="choice-disable-tap-on-status"
+             bind:checked="$disableTapOnStatus" on:change="onChange(event)">
+      <label for="choice-disable-tap-on-status">Disable tappable area on entire toot</label>
+    </div>
+    <div class="setting-group">
       <input type="checkbox" id="choice-omit-emoji-in-display-names"
              bind:checked="$omitEmojiInDisplayNames" on:change="onChange(event)">
       <label for="choice-omit-emoji-in-display-names">Remove emoji from user display names</label>

--- a/routes/_store/store.js
+++ b/routes/_store/store.js
@@ -12,6 +12,7 @@ const persistedState = {
   currentRegisteredInstance: undefined,
   disableCustomScrollbars: false,
   disableLongAriaLabels: false,
+  disableTapOnStatus: false,
   instanceNameInSearch: '',
   instanceThemes: {},
   loggedInInstances: {},

--- a/routes/_utils/delegate.js
+++ b/routes/_utils/delegate.js
@@ -14,6 +14,13 @@ function onEvent (e) {
     // we're not interested in any non-click or non-Enter events
     return
   }
+  if (type === 'click') {
+    let selection = window.getSelection()
+    let selectionStr = selection && selection.toString()
+    if (selectionStr && selection.toString().length && target.contains(selection.anchorNode)) {
+      return // ignore if the user is selecting text inside the clickable area
+    }
+  }
   mark('delegate onEvent')
   let key
   let element = target


### PR DESCRIPTION
fixes #163. also fixed the issue where selecting text would cause the toot to be tapped