### PR TITLE
fix(firefox): fix firefox with blocked images

### DIFF
--- a/routes/_components/LazyImage.html
+++ b/routes/_components/LazyImage.html
@@ -20,7 +20,6 @@
 
   export default {
     async oncreate () {
-      let count = counter++
       try {
         await decodeImage(this.refs.node)
       } catch (e) {

--- a/routes/_components/LazyImage.html
+++ b/routes/_components/LazyImage.html
@@ -16,18 +16,16 @@
   }
 </style>
 <script>
-  import { mark, stop } from '../_utils/marks'
   import { decodeImage } from '../_utils/decodeImage'
 
   export default {
     async oncreate () {
-      mark('LazyImage oncreate()')
+      let count = counter++
       try {
         await decodeImage(this.refs.node)
       } catch (e) {
         this.set({ error: true })
       }
-      stop('LazyImage oncreate()')
     },
     data: () => ({
       error: false,

--- a/routes/_components/NonAutoplayImg.html
+++ b/routes/_components/NonAutoplayImg.html
@@ -30,7 +30,7 @@
         let image = new Image()
         image.src = currentSrc
         await decodeImage(image)
-        this.set({loaded: true})
+        this.set({ loaded: true })
         this.fire('imgLoad')
       } catch (e) {
         this.fire('imgLoadError', e)

--- a/routes/_components/NonAutoplayImg.html
+++ b/routes/_components/NonAutoplayImg.html
@@ -21,11 +21,16 @@
   import { mouseover } from '../_utils/events'
   import { decodeImage } from '../_utils/decodeImage'
   import { classname } from '../_utils/classname'
+  import { ONE_TRANSPARENT_PIXEL } from '../_static/media'
 
   export default {
     async oncreate () {
+      let { currentSrc } = this.get()
       try {
-        await decodeImage(this.refs.node)
+        let image = new Image()
+        image.src = currentSrc
+        await decodeImage(image)
+        this.set({loaded: true})
         this.fire('imgLoad')
       } catch (e) {
         this.fire('imgLoadError', e)
@@ -42,7 +47,8 @@
     data: () => ({
       alt: '',
       title: '',
-      mouseOver: false
+      mouseOver: false,
+      loaded: false
     }),
     computed: {
       computedClass: ({ className, src, staticSrc, isLink }) => (classname(
@@ -50,7 +56,9 @@
         src !== staticSrc && 'non-autoplay-zoom-in',
         isLink && 'is-link'
       )),
-      displaySrc: ({ src, staticSrc, mouseOver }) => (mouseOver ? src : staticSrc)
+      currentSrc: ({ mouseOver, src, staticSrc }) => mouseOver ? src : staticSrc,
+      // using a transparent pixel as placeholder ensures broken images don't have wrong sizes
+      displaySrc: ({ loaded, currentSrc }) => loaded ? currentSrc : ONE_TRANSPARENT_PIXEL
     }
   }
 </script>

--- a/routes/_utils/decodeImage.js
+++ b/routes/_utils/decodeImage.js
@@ -1,18 +1,10 @@
-import { mark, stop } from './marks'
-
-async function doDecodeImage (img) {
+export function decodeImage (img) {
   if (typeof img.decode === 'function') {
     return img.decode()
   }
+
   return new Promise((resolve, reject) => {
     img.onload = resolve
     img.onerror = reject
   })
-}
-
-export async function decodeImage (img) {
-  mark('decodeImage')
-  let res = await doDecodeImage(img)
-  stop('decodeImage')
-  return res
 }

--- a/routes/_utils/decodeImage.js
+++ b/routes/_utils/decodeImage.js
@@ -1,10 +1,18 @@
-export function decodeImage (img) {
+import { mark, stop } from './marks'
+
+async function doDecodeImage (img) {
   if (typeof img.decode === 'function') {
     return img.decode()
   }
-
   return new Promise((resolve, reject) => {
     img.onload = resolve
     img.onerror = reject
   })
+}
+
+export async function decodeImage (img) {
+  mark('decodeImage')
+  let res = await doDecodeImage(img)
+  stop('decodeImage')
+  return res
 }


### PR DESCRIPTION
If you turn on image blocking in Firefox for Android, then the timeline can get messed up because the heights are not calculated correctly for broken images. This fixes that.