### PR TITLE
chore(package): use events-lights instead of events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,8 +514,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -4218,10 +4217,45 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+    "events-light": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
+      "integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
+      "requires": {
+        "chai": "^3.5.0"
+      },
+      "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "deep-eql": "^0.1.3",
+            "type-detect": "^1.0.0"
+          }
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+        }
+      }
     },
     "evp_bytestokey": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "emoji-regex": "^7.0.1",
     "escape-html": "^1.0.3",
     "esm": "^3.0.84",
-    "events": "^3.0.0",
+    "events-light": "^1.0.5",
     "express": "^4.16.4",
     "file-api": "^0.10.4",
     "font-awesome-svg-png": "^1.2.2",

--- a/routes/_utils/eventBus.js
+++ b/routes/_utils/eventBus.js
@@ -1,10 +1,6 @@
-import EventEmitter from 'events'
+import EventEmitter from 'events-light'
 
 const eventBus = new EventEmitter()
-
-// we need enough 'postedStatus' listeners for each
-// visible status in a timeline
-eventBus.setMaxListeners(1000)
 
 if (process.browser && process.env.NODE_ENV !== 'production') {
   window.eventBus = eventBus


### PR DESCRIPTION
I don't see any reason not to switch. It's slightly smaller than the other events library and does everything we need.