### PR TITLE
perf: use prefetch instead of preload for svgs

### DIFF
--- a/templates/2xx.html
+++ b/templates/2xx.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" >
   <meta id='theThemeColor' name='theme-color' content='#4169e1' >
   <meta name="description" content="An alternative web client for Mastodon, focused on speed and simplicity." >
-  <link rel="preload" as="image" href="/icons.svg" >
+  <link rel="prefetch" href="/icons.svg" >
   <link id='theManifest' rel='manifest' href='/manifest.json' >
   <link id='theFavicon' rel='icon' type='image/png' href='/favicon.png' >
   <link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120.png" >


### PR DESCRIPTION
I believe prefetch is a better choice here, and Chrome is warning about it in the console anyway