### PR TITLE
fix: fix media in grouped mode in focused threads

### DIFF
--- a/routes/_components/AutoplayVideo.html
+++ b/routes/_components/AutoplayVideo.html
@@ -1,8 +1,8 @@
-<div class="autoplay-wrapper  {$largeInlineMedia ? '' : 'fixed-size'}"
+<div class="autoplay-wrapper  {$largeInlineMedia ? '' : 'autoplay-video-fixed-size'}"
      style="width: {width}px; height: {height}px;"
 >
     <video
-    class="autoplay-video {$largeInlineMedia ? '' : 'fixed-size'}"
+    class="autoplay-video {$largeInlineMedia ? '' : 'autoplay-video-fixed-size'}"
     aria-label={ariaLabel || ''}
     style="{focusStyle} background-image: url({poster}); "
     {poster}
@@ -30,18 +30,11 @@
     display: flex;
   }
 
-  .fixed-size {
+  .autoplay-video-fixed-size {
     position: absolute;
     width: 100%;
     height: 100%;
     overflow: hidden;
-  }
-
-
-  .fixed-size {
-    overflow: hidden;
-    width: 100%;
-    height: 100%;
   }
 </style>
 <script>

--- a/routes/_components/LazyImage.html
+++ b/routes/_components/LazyImage.html
@@ -1,4 +1,4 @@
-<div class="lazy-image {fillFixSize ? 'fixed-size': ''}" style={computedStyle} >
+<div class="lazy-image {fillFixSize ? 'lazy-image-fixed-size': ''}" style={computedStyle} >
   <img
     class="{fillFixSize ? 'fixed-size-img': ''}"
     aria-hidden={ariaHidden}
@@ -23,7 +23,7 @@
     width: 100%;
     height: 100%;
   }
-  .fixed-size {
+  .lazy-image-fixed-size {
     position: absolute;
     width: 100%;
     height: 100%;

--- a/routes/_components/NonAutoplayGifv.html
+++ b/routes/_components/NonAutoplayGifv.html
@@ -1,4 +1,4 @@
-<div class="non-autoplay-gifv  {$largeInlineMedia ? '' : 'fixed-size'}"
+<div class="non-autoplay-gifv  {$largeInlineMedia ? '' : 'non-autoplay-gifv-fixed-size'}"
      style="width: {width}px; height: {height}px;"
      on:mouseover="onMouseOver(event)"
      ref:node
@@ -35,7 +35,7 @@
     padding: 0;
   }
 
-  .fixed-size {
+  .non-autoplay-gifv-fixed-size {
     position: absolute;
     width: 100%;
     height: 100%;

--- a/routes/_components/status/Status.html
+++ b/routes/_components/status/Status.html
@@ -74,6 +74,7 @@
       "spoiler-btn spoiler-btn"
       "mentions    mentions"
       "content     content"
+      "media-grp   media-grp"
       "media       media"
       "details     details"
       "toolbar     toolbar"


### PR DESCRIPTION
I couldn't figure out how to fix the issue #771 so I settled for
fixing the images shown in a focused "thread" view, as well as fixing
some style leakages from the `.fixed-size` class (I disable Svelte's
CSS encapsulation, so we need to be careful with class names).