### PR TITLE
fix: fix sensitive content warning on mobile

### DIFF
--- a/src/routes/_components/status/StatusMediaAttachments.html
+++ b/src/routes/_components/status/StatusMediaAttachments.html
@@ -20,7 +20,7 @@
             delegate-key={delegateKey} >
 
       <div class="status-sensitive-media-warning">
-        <span>Sensitive content. Click to show.</span>
+        Sensitive content. Click to show.
       </div>
       <div class="svg-wrapper">
         <svg class="status-sensitive-media-svg">
@@ -107,6 +107,7 @@
     justify-content: center;
     color: var(--deemphasized-text-color);
     z-index: 60;
+    padding: 0 10px;
   }
 
   .status-sensitive-media-container .svg-wrapper {


### PR DESCRIPTION
This fixes the padding and allows the warning to overflow.