### PR TITLE
fix: drop CSP support from the exported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ You can export Pinafore as a static site. Run:
     npm run export
 
 Static files will be written to `__sapper__/export`.
-Be sure to add the [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) header printed out in the console to
-your server config!
+
+Note that this is not the recommended method, because
+[CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) headers are not 
+currently supported for the exported version.
 
 ## Developing and testing
 

--- a/bin/print-export-info.js
+++ b/bin/print-export-info.js
@@ -1,15 +1,3 @@
-const fs = require('fs')
-const path = require('path')
-
-const checksum = require('../inline-script-checksum').checksum
-const html = fs.readFileSync(path.join(__dirname, '../__sapper__/export/index.html'), 'utf8')
-const nonce = html.match(/<script nonce=([^>]+)>/)[1]
-
-const csp = `add_header Content-Security-Policy "script-src 'self' 'sha256-${checksum}' 'nonce-${nonce}'; ` +
-`worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self';`
-
-fs.writeFileSync(path.join(__dirname, '../__sapper__/export/.csp.nginx'), csp, 'utf8')
-
 console.log(`                                                                                             
 
                ,((*
@@ -35,14 +23,6 @@ console.log(`
 Export successful! Static files are in:
 
     __sapper__/export/
-
-Be sure to add the CSP header to your nginx config:
-
-    server {
-        include ${path.resolve(__dirname, '..')}/__sapper__/export/.csp.nginx;
-    }
-
-This file will be updated whenever you do \`npm run export\`.
 
 Enjoy Pinafore!
 `)


### PR DESCRIPTION
It just occurred to me that we can't handle nonces correctly when the site is exported. So for now let's just not support it, and add a note about the lack of CSP support in the README.