### PR TITLE
perf: use terser for service worker too

### DIFF
--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -2,8 +2,7 @@ const webpack = require('webpack')
 const config = require('sapper/config/webpack.js')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
-const TerserWebpackPlugin = require('terser-webpack-plugin')
-
+const terser = require('./terser.config')
 const isDev = process.env.NODE_ENV === 'development'
 
 module.exports = {
@@ -35,22 +34,7 @@ module.exports = {
   },
   optimization: isDev ? {} : {
     minimizer: [
-      new TerserWebpackPlugin({
-        cache: true,
-        parallel: true,
-        sourceMap: true,
-        terserOptions: {
-          ecma: 6,
-          mangle: true,
-          compress: {
-            pure_funcs: ['console.log']
-          },
-          output: {
-            comments: false
-          },
-          safari10: true
-        }
-      })
+      terser()
     ],
     splitChunks: {
       chunks: 'async',

--- a/webpack/service-worker.config.js
+++ b/webpack/service-worker.config.js
@@ -1,4 +1,5 @@
 const config = require('sapper/config/webpack.js')
+const terser = require('./terser.config')
 const webpack = require('webpack')
 
 const isDev = config.dev
@@ -10,7 +11,10 @@ module.exports = {
   devtool: isDev ? 'inline-source-map' : 'source-map',
   plugins: [
     new webpack.DefinePlugin({
+      'process.browser': true,
+      'process.env.NODE_ENV': '"production"',
       'process.env.SAPPER_TIMESTAMP': process.env.SAPPER_TIMESTAMP || Date.now()
-    })
+    }),
+    terser()
   ]
 }

--- a/webpack/terser.config.js
+++ b/webpack/terser.config.js
@@ -1,0 +1,18 @@
+const TerserWebpackPlugin = require('terser-webpack-plugin')
+
+module.exports = () => new TerserWebpackPlugin({
+  cache: true,
+  parallel: true,
+  sourceMap: true,
+  terserOptions: {
+    ecma: 6,
+    mangle: true,
+    compress: {
+      pure_funcs: ['console.log']
+    },
+    output: {
+      comments: false
+    },
+    safari10: true
+  }
+})


### PR DESCRIPTION
we can make the SW js smaller, and we still have sourcemaps