### PR TITLE
fix: calculate status aria-label in rIC

### DIFF
--- a/src/routes/_a11y/getAccessibleLabelForStatus.js
+++ b/src/routes/_a11y/getAccessibleLabelForStatus.js
@@ -34,10 +34,10 @@ function cleanupText (text) {
   return text.replace(/\s+/g, ' ').trim()
 }
 
-export function getAccessibleLabelForStatus (originalAccount, account, content,
+export function getAccessibleLabelForStatus ({ originalAccount, account, content,
   timeagoFormattedDate, spoilerText, showContent,
   reblog, notification, visibility, omitEmojiInDisplayNames,
-  disableLongAriaLabels) {
+  disableLongAriaLabels }) {
   let originalAccountDisplayName = getAccountAccessibleName(originalAccount, omitEmojiInDisplayNames)
   let contentTextToShow = (showContent || !spoilerText)
     ? cleanupText(htmlToPlainText(content))

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -137,10 +137,12 @@
           this.set({ contentPreloaded: true })
         })
       }
-      this.observe('showContent', () => {
-        // Calculate this whenever content changes, in a rIC because it's a bit expensive.
-        // Useful for screen readers.
-        scheduleIdleTask(() => this.calculateAriaLabel())
+      this.observe('ariaLabelInputs', ariaLabelInputs => {
+        // Calculate this whenever any of the aria-label inputs change. Do so
+        // in a rIC because it's a bit expensive.
+        scheduleIdleTask(() => {
+          this.set({ ariaLabel: getAccessibleLabelForStatus(ariaLabelInputs) })
+        })
       })
     },
     components: {
@@ -188,17 +190,6 @@
         e.stopPropagation()
         let { originalStatusId } = this.get()
         goto(`/statuses/${originalStatusId}`)
-      },
-      calculateAriaLabel () {
-        let {
-          originalAccount, account, content, timeagoFormattedDate, spoilerText,
-          showContent, reblog, notification, visibility, $omitEmojiInDisplayNames,
-          $disableLongAriaLabels
-        } = this.get()
-        let ariaLabel = getAccessibleLabelForStatus(originalAccount, account, content,
-          timeagoFormattedDate, spoilerText, showContent,
-          reblog, notification, visibility, $omitEmojiInDisplayNames, $disableLongAriaLabels)
-        this.set({ ariaLabel })
       }
     },
     computed: {
@@ -254,6 +245,23 @@
       )),
       content: ({ originalStatus }) => originalStatus.content || '',
       showContent: ({ spoilerText, spoilerShown }) => !spoilerText || spoilerShown,
+      ariaLabelInputs: ({
+        originalAccount, account, content, timeagoFormattedDate, spoilerText,
+        showContent, reblog, notification, visibility, $omitEmojiInDisplayNames,
+        $disableLongAriaLabels
+      }) => ({
+        originalAccount,
+        account,
+        content,
+        timeagoFormattedDate,
+        spoilerText,
+        showContent,
+        reblog,
+        notification,
+        visibility,
+        $omitEmojiInDisplayNames,
+        $disableLongAriaLabels
+      }),
       params: ({ notification, notificationId, status, statusId, timelineType,
         account, accountId, uuid, isStatusInNotification, isStatusInOwnThread,
         originalAccount, originalAccountId, spoilerShown, visibility, replyShown,

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -115,6 +115,7 @@
   import { getAccountAccessibleName } from '../../_a11y/getAccountAccessibleName'
   import { getAccessibleLabelForStatus } from '../../_a11y/getAccessibleLabelForStatus'
   import { formatTimeagoDate } from '../../_intl/formatTimeagoDate'
+  import { observe } from 'svelte-extras'
 
   const INPUT_TAGS = new Set(['a', 'button', 'input', 'textarea'])
   const isUserInputElement = node => INPUT_TAGS.has(node.localName)
@@ -136,6 +137,11 @@
           this.set({ contentPreloaded: true })
         })
       }
+      this.observe('showContent', () => {
+        // Calculate this whenever content changes, in a rIC because it's a bit expensive.
+        // Useful for screen readers.
+        scheduleIdleTask(() => this.calculateAriaLabel())
+      })
     },
     components: {
       StatusSidebar,
@@ -154,10 +160,12 @@
     data: () => ({
       notification: void 0,
       replyVisibility: void 0,
-      contentPreloaded: false
+      contentPreloaded: false,
+      ariaLabel: void 0
     }),
     store: () => store,
     methods: {
+      observe,
       onClickOrKeydown (e) {
         let { type, keyCode, target } = e
 
@@ -180,6 +188,17 @@
         e.stopPropagation()
         let { originalStatusId } = this.get()
         goto(`/statuses/${originalStatusId}`)
+      },
+      calculateAriaLabel () {
+        let {
+          originalAccount, account, content, timeagoFormattedDate, spoilerText,
+          showContent, reblog, notification, visibility, $omitEmojiInDisplayNames,
+          $disableLongAriaLabels
+        } = this.get()
+        let ariaLabel = getAccessibleLabelForStatus(originalAccount, account, content,
+          timeagoFormattedDate, spoilerText, showContent,
+          reblog, notification, visibility, $omitEmojiInDisplayNames, $disableLongAriaLabels)
+        this.set({ ariaLabel })
       }
     },
     computed: {
@@ -222,12 +241,6 @@
       createdAtDate: ({ originalStatus }) => originalStatus.created_at,
       timeagoFormattedDate: ({ createdAtDate }) => formatTimeagoDate(createdAtDate),
       reblog: ({ status }) => status.reblog,
-      ariaLabel: ({ originalAccount, account, content, timeagoFormattedDate, spoilerText,
-        showContent, reblog, notification, visibility, $omitEmojiInDisplayNames, $disableLongAriaLabels }) => (
-        getAccessibleLabelForStatus(originalAccount, account, content,
-          timeagoFormattedDate, spoilerText, showContent,
-          reblog, notification, visibility, $omitEmojiInDisplayNames, $disableLongAriaLabels)
-      ),
       showHeader: ({ notification, status, timelineType }) => (
         (notification && (notification.type === 'reblog' || notification.type === 'favourite')) ||
         status.reblog ||


### PR DESCRIPTION
fixes #752

I think using `innerText` is too risky for this (since it could cause a style recalc), but we can at least move the `aria-label` calculations to a `requestIdleCallback`, where they're out of the critical rendering path.