### PR TITLE
chore: add prop-types to deps to unbreak now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5841,8 +5841,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -6055,7 +6054,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
       }
@@ -7421,7 +7419,6 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "page-lifecycle": "^0.1.1",
     "performance-now": "^2.1.0",
     "pify": "^4.0.1",
+    "prop-types": "^15.6.2",
     "quick-lru": "^2.0.0",
     "remount": "^0.9.3",
     "requestidlecallback": "^0.3.0",


### PR DESCRIPTION
I tried to remove prop-types from emoji-mart but it proved too hard. Also it breaks `now` not to have this in the deps for some reason