### PR TITLE
perf: reduce size of emoji-mart dep using fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3522,9 +3522,8 @@
       }
     },
     "emoji-mart": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-2.9.2.tgz",
-      "integrity": "sha512-5S743OpjFb9nBbbx5F4APWgcp2IOjdT7gLLzu2OBh0k44C3ZoCm+wuIN1llOtj5eosUa3lYqrZWtU/ZiaCULrg=="
+      "version": "github:nolanlawson/emoji-mart#10dc04023031d3b3eebb4e58ddc4a6f33ffa03eb",
+      "from": "github:nolanlawson/emoji-mart#for-pinafore-1"
     },
     "emoji-regex": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "compression": "^1.7.3",
     "cross-env": "^5.2.0",
     "css-loader": "^2.0.1",
-    "emoji-mart": "^2.9.2",
+    "emoji-mart": "github:nolanlawson/emoji-mart#for-pinafore-1",
     "emoji-regex": "^7.0.1",
     "encoding": "^0.1.12",
     "escape-html": "^1.0.3",

--- a/src/routes/_components/dialog/components/EmojiDialog.html
+++ b/src/routes/_components/dialog/components/EmojiDialog.html
@@ -37,10 +37,6 @@
     background-repeat: no-repeat;
     background-position: center center;
   }
-  :global(.emoji-container .emoji-mart-emoji-native) {
-    /* remove if/when https://github.com/missive/emoji-mart/pull/256 is merged */
-    font-family: PinaforeEmoji, sans-serif;
-  }
 </style>
 <script>
   import ModalDialog from './ModalDialog.html'

--- a/src/routes/_react/createEmojiMartPickerFromData.js
+++ b/src/routes/_react/createEmojiMartPickerFromData.js
@@ -3,7 +3,7 @@
 // using `remount` to pass in functions as attributes, since everything is stringified. So
 // I just fire a global event here when an emoji is clicked.
 
-import NimblePicker from 'emoji-mart/dist-es/components/picker/nimble-picker'
+import NimblePicker from 'emoji-mart/dist-modern/components/picker/nimble-picker'
 import React from 'react'
 import { emit } from '../_utils/eventBus'
 


### PR DESCRIPTION
This reduces the size of `emoji-mart` pretty substantially using these PRs:

- https://github.com/missive/emoji-mart/pull/260
- https://github.com/missive/emoji-mart/pull/258/

Also to fix a Linux emoji issue, I went ahead and added this as well:

- https://github.com/missive/emoji-mart/pull/256