### PR TITLE
fix(picker): only focus picker search on desktop

### DIFF
--- a/src/routes/_components/dialog/components/EmojiDialog.html
+++ b/src/routes/_components/dialog/components/EmojiDialog.html
@@ -99,16 +99,7 @@
           define({ 'emoji-mart': Picker })
         }
         this.set({ loaded: true })
-        requestAnimationFrame(() => {
-          let container = this.refs.container
-          if (container) {
-            let searchInput = container.querySelector('emoji-mart .emoji-mart-search input')
-            if (searchInput) {
-              // do this manually because emoji-mart's built in autofocus doesn't work consistently
-              searchInput.focus()
-            }
-          }
-        })
+        this.focusIfNecessary()
       } catch (error) {
         this.set({ error }) // should never happen, but you never know
       }
@@ -137,8 +128,7 @@
         emoji: 'sailboat',
         title: 'Emoji',
         include: categoriesSort,
-        showPreview: true,
-        autoFocus: true
+        showPreview: true
       }),
       perLine: ({ $isSmallMobileSize, $isTinyMobileSize, $isMobileSize }) => (
         $isTinyMobileSize
@@ -161,7 +151,9 @@
           keywords: [emoji.shortcode],
           imageUrl: $autoplayGifs ? emoji.url : emoji.static_url
         }))
-      }
+      },
+      // it's jarring on mobile if the emoji picker automatically pops open the keyboard
+      autoFocus: ({ $isMobileSize }) => !$isMobileSize
     },
     methods: {
       show,
@@ -170,6 +162,22 @@
         let { realm } = this.get()
         insertEmoji(realm, emoji)
         this.close()
+      },
+      focusIfNecessary () {
+        let { autoFocus } = this.get()
+        if (!autoFocus) {
+          return
+        }
+        requestAnimationFrame(() => {
+          let container = this.refs.container
+          if (container) {
+            let searchInput = container.querySelector('emoji-mart .emoji-mart-search input')
+            if (searchInput) {
+              // do this manually because emoji-mart's built in autofocus doesn't work consistently
+              searchInput.focus()
+            }
+          }
+        })
       }
     }
   }

--- a/src/routes/_components/dialog/components/EmojiDialog.html
+++ b/src/routes/_components/dialog/components/EmojiDialog.html
@@ -153,7 +153,7 @@
         }))
       },
       // it's jarring on mobile if the emoji picker automatically pops open the keyboard
-      autoFocus: ({ $isMobileSize }) => !$isMobileSize
+      autoFocus: ({ $isUserTouching }) => !$isUserTouching
     },
     methods: {
       show,

--- a/src/routes/_store/observers/observers.js
+++ b/src/routes/_store/observers/observers.js
@@ -4,12 +4,14 @@ import { pageVisibilityObservers } from './pageVisibilityObservers'
 import { resizeObservers } from './resizeObservers'
 import { setupLoggedInObservers } from './setupLoggedInObservers'
 import { logOutObservers } from './logOutObservers'
+import { touchObservers } from './touchObservers'
 
 export function observers (store) {
   onlineObservers(store)
   navObservers(store)
   pageVisibilityObservers(store)
   resizeObservers(store)
+  touchObservers(store)
   logOutObservers(store)
   setupLoggedInObservers(store)
 }

--- a/src/routes/_store/observers/touchObservers.js
+++ b/src/routes/_store/observers/touchObservers.js
@@ -1,0 +1,12 @@
+export function touchObservers (store) {
+  if (!process.browser) {
+    return
+  }
+
+  let onTouch = () => {
+    store.set({ isUserTouching: true })
+    window.removeEventListener('touchstart', onTouch)
+  }
+
+  window.addEventListener('touchstart', onTouch, { passive: true })
+}


### PR DESCRIPTION
I find it jarring if the emoji picker dialog automatically pops open the soft keyboard; it causes two extra layouts and can cause part of the dialog to be hidden. We can't detect the existence of a soft vs hard keyboard, but we can sniff for it by checking for the mobile size.