### PR TITLE
fix: fix unnecessary request for theme-undefined.css

### DIFF
--- a/src/routes/_utils/themeEngine.js
+++ b/src/routes/_utils/themeEngine.js
@@ -30,7 +30,7 @@ function loadCSS (href) {
   document.head.insertBefore(link, offlineStyle)
 }
 
-export function switchToTheme (themeName) {
+export function switchToTheme (themeName = 'default') {
   let themeColor = window.__themeColors[themeName]
   meta.content = themeColor || window.__themeColors['default']
   if (themeName !== 'default') {


### PR DESCRIPTION
Somehow we were accidentally making requests to `theme-undefined.css` for the default theme when switching to an instance that had not set its preferred theme yet.