### PR TITLE
perf: use lodash-lite for some functions

### DIFF
--- a/src/routes/_components/compose/ComposeAutosuggest.html
+++ b/src/routes/_components/compose/ComposeAutosuggest.html
@@ -40,7 +40,7 @@
 <script>
   import { store } from '../../_store/store'
   import ComposeAutosuggestionList from './ComposeAutosuggestionList.html'
-  import get from 'lodash-es/get'
+  import { get } from '../../_utils/lodash-lite'
   import { selectAutosuggestItem } from '../../_actions/autosuggest'
   import { observe } from 'svelte-extras'
   import { once } from '../../_utils/once'

--- a/src/routes/_store/computations/autosuggestComputations.js
+++ b/src/routes/_store/computations/autosuggestComputations.js
@@ -1,4 +1,4 @@
-import get from 'lodash-es/get'
+import { get } from '../../_utils/lodash-lite'
 
 const MIN_PREFIX_LENGTH = 1
 const ACCOUNT_SEARCH_REGEX = new RegExp(`(?:\\s|^)(@\\S{${MIN_PREFIX_LENGTH},})$`)

--- a/src/routes/_store/computations/timelineComputations.js
+++ b/src/routes/_store/computations/timelineComputations.js
@@ -1,4 +1,4 @@
-import get from 'lodash-es/get'
+import { get } from '../../_utils/lodash-lite'
 
 function computeForTimeline (store, key, defaultValue) {
   store.compute(key,

--- a/src/routes/_store/mixins/timelineMixins.js
+++ b/src/routes/_store/mixins/timelineMixins.js
@@ -1,5 +1,4 @@
-import pickBy from 'lodash-es/pickBy'
-import get from 'lodash-es/get'
+import { pickBy, get } from '../../_utils/lodash-lite'
 
 export function timelineMixins (Store) {
   Store.prototype.setForTimeline = function (instanceName, timelineName, obj) {
@@ -19,11 +18,6 @@ export function timelineMixins (Store) {
     let rootKey = `timelineData_${key}`
     let root = this.get()[rootKey]
     return get(root, [instanceName, timelineName])
-  }
-
-  Store.prototype.getForCurrentTimeline = function (key) {
-    let { currentInstance, currentTimeline } = this.get()
-    return this.getForTimeline(currentInstance, currentTimeline, key)
   }
 
   Store.prototype.getAllTimelineData = function (instanceName, key) {

--- a/src/routes/_utils/lodash-lite.js
+++ b/src/routes/_utils/lodash-lite.js
@@ -1,0 +1,23 @@
+// Some functions from Lodash that are a bit heavyweight and which
+// we can just do in idiomatic ES2015+
+
+export function get (obj, keys, defaultValue) {
+  for (let key of keys) {
+    if (obj && key in obj) {
+      obj = obj[key]
+    } else {
+      return defaultValue
+    }
+  }
+  return obj
+}
+
+export function pickBy (obj, predicate) {
+  let res = {}
+  for (let [key, value] of Object.entries(obj)) {
+    if (predicate(value, key)) {
+      res[key] = value
+    }
+  }
+  return res
+}

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -47,9 +47,7 @@ module.exports = {
       /\/_database\/database\.js$/, // this version plays nicer with IDEs
       './database.prod.js'
     ),
-    new LodashModuleReplacementPlugin({
-      paths: true
-    }),
+    new LodashModuleReplacementPlugin(),
     new CircularDependencyPlugin({
       exclude: /node_modules/,
       failOnError: true,


### PR DESCRIPTION
This removes 3kB from the size of all JS chunks by removing some Lodash functions we can write ourselves in ES2015+.