### PR TITLE
perf: use webpack splitChunks defaults

### DIFF
--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -35,10 +35,6 @@ module.exports = {
       terser()
     ],
     splitChunks: {
-      chunks: 'async',
-      minSize: 5000,
-      maxAsyncRequests: Infinity,
-      maxInitialRequests: Infinity,
       name: false // these chunk names can be annoyingly long
     }
   },


### PR DESCRIPTION
I don't think there's much reason to override these defaults. This actually reduces the non-logged-in homepage JS bundle size by 5kB, although increasing the size of all chunks by 150kB. Doesn't seem to make much sense though to think we can beat the Webpack defaults, probably better to just use the defaults here.