### PR TITLE
Revert "perf: use webpack splitChunks defaults (#855)"

### DIFF
--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -35,6 +35,10 @@ module.exports = {
       terser()
     ],
     splitChunks: {
+      chunks: 'async',
+      minSize: 5000,
+      maxAsyncRequests: Infinity,
+      maxInitialRequests: Infinity,
       name: false // these chunk names can be annoyingly long
     }
   },


### PR DESCRIPTION
This reverts commit 49b85623d5cf3e3334d5bc86f81671621a8e898a.

After running the numbers in https://github.com/nolanlawson/pinafore/pull/855#issuecomment-449657191 I actually decided it doesn't make much sense to change this. I like the overall JS chunk size being less than 1MB. Who cares if there are slightly more files or if it saves ~5kB on the non-logged-in homepage.