### PR TITLE
fix: add better browser notification badges

### DIFF
--- a/src/routes/_components/NavItem.html
+++ b/src/routes/_components/NavItem.html
@@ -205,7 +205,7 @@
           res += ' (current page)'
         }
         if (name === 'notifications' && $numberOfNotifications) {
-          res += ` (${$numberOfNotifications})`
+          res += ` (${$numberOfNotifications} notification${$numberOfNotifications === 1 ? '' : 's'})`
         }
         return res
       },

--- a/src/routes/_components/Title.html
+++ b/src/routes/_components/Title.html
@@ -1,5 +1,5 @@
 <svelte:head>
-  <title>{instanceIndicator} · {name}{notificationsIndicator}</title>
+  <title>{notificationsIndicator} {instanceIndicator} · {name}</title>
 </svelte:head>
 <script>
   import { store } from '../_store/store'
@@ -17,7 +17,7 @@
         `${($isUserLoggedIn && !settingsPage && $currentInstance) ? $currentInstance : 'Pinafore'}`
       ),
       notificationsIndicator: ({ $hasNotifications, $numberOfNotifications }) => (
-        $hasNotifications ? ` (${$numberOfNotifications})` : ''
+        $hasNotifications ? `(${$numberOfNotifications}) ` : ''
       )
     }
   }

--- a/src/routes/_components/Title.html
+++ b/src/routes/_components/Title.html
@@ -1,5 +1,5 @@
 <svelte:head>
-  <title>{notificationsIndicator} {instanceIndicator} · {name}</title>
+  <title>{notificationsIndicator}{instanceIndicator} · {name}</title>
 </svelte:head>
 <script>
   import { store } from '../_store/store'

--- a/tests/spec/102-notifications.js
+++ b/tests/spec/102-notifications.js
@@ -15,8 +15,8 @@ test('shows unread notifications', async t => {
     .expect(getTitleText()).eql('localhost:3000 · Home')
   await favoriteStatusAs('admin', id)
   await t
-    .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications (1)')
-    .expect(getTitleText()).eql('localhost:3000 · Home (1)')
+    .expect(notificationsNavButton.getAttribute('aria-label')).eql('(1) Notifications')
+    .expect(getTitleText()).eql('(1) localhost:3000 · Home')
     .click(notificationsNavButton)
     .expect(getUrl()).contains('/notifications')
     .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications (current page)')

--- a/tests/spec/102-notifications.js
+++ b/tests/spec/102-notifications.js
@@ -1,21 +1,26 @@
 import { loginAsFoobar } from '../roles'
 import {
-  getNthStatus, getTitleText, getUrl, homeNavButton, notificationsNavButton
+  getNthStatus, getNthStatusContent, getTitleText, getUrl, homeNavButton, notificationsNavButton
 } from '../utils'
 import { favoriteStatusAs, postAs } from '../serverActions'
 
 fixture`102-notifications.js`
   .page`http://localhost:4002`
 
-test('shows unread notifications', async t => {
+test('shows unread notification', async t => {
   let { id } = await postAs('foobar', 'somebody please favorite this to validate me')
   await loginAsFoobar(t)
   await t
     .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications')
     .expect(getTitleText()).eql('localhost:3000 · Home')
+    .expect(getNthStatusContent(0).innerText).contains('somebody please favorite this to validate me', {
+      timeout: 20000
+    })
   await favoriteStatusAs('admin', id)
   await t
-    .expect(notificationsNavButton.getAttribute('aria-label')).eql('(1) Notifications')
+    .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications (1 notification)', {
+      timeout: 20000
+    })
     .expect(getTitleText()).eql('(1) localhost:3000 · Home')
     .click(notificationsNavButton)
     .expect(getUrl()).contains('/notifications')
@@ -23,6 +28,33 @@ test('shows unread notifications', async t => {
     .expect(getTitleText()).eql('localhost:3000 · Notifications')
     .expect(getNthStatus(0).innerText).contains('somebody please favorite this to validate me')
     .expect(getNthStatus(0).innerText).match(/admin\s+favorited your status/)
+  await t
+    .click(homeNavButton)
+    .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications')
+    .expect(getTitleText()).eql('localhost:3000 · Home')
+})
+
+test('shows unread notifications, more than one', async t => {
+  let { id } = await postAs('foobar', 'I need lots of favorites on this one')
+  await loginAsFoobar(t)
+  await t
+    .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications')
+    .expect(getTitleText()).eql('localhost:3000 · Home')
+    .expect(getNthStatusContent(0).innerText).contains('I need lots of favorites on this one', {
+      timeout: 20000
+    })
+  await favoriteStatusAs('admin', id)
+  await favoriteStatusAs('quux', id)
+  await t
+    .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications (2 notifications)', {
+      timeout: 20000
+    })
+    .expect(getTitleText()).eql('(2) localhost:3000 · Home')
+    .click(notificationsNavButton)
+    .expect(getUrl()).contains('/notifications')
+    .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications (current page)')
+    .expect(getTitleText()).eql('localhost:3000 · Notifications')
+    .expect(getNthStatus(0).innerText).contains('I need lots of favorites on this one')
   await t
     .click(homeNavButton)
     .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications')

--- a/tests/spec/105-deletes.js
+++ b/tests/spec/105-deletes.js
@@ -61,7 +61,7 @@ test('deleted statuses result in deleted notifications', async t => {
     .hover(getNthStatus(0))
     .expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications')
   let status = await postAs('admin', "@foobar yo yo foobar what's up")
-  await t.expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications (1)', { timeout })
+  await t.expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications (1 notification)', { timeout })
   await deleteAs('admin', status.id)
   await t.expect(notificationsNavButton.getAttribute('aria-label')).eql('Notifications', { timeout })
 })

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -97,7 +97,7 @@ export const getActiveElementInsideNthStatus = exec(() => {
   return ''
 })
 
-export const getTitleText = exec(() => document.head.querySelector('title').innerHTML)
+export const getTitleText = exec(() => document.head.querySelector('title') && document.head.querySelector('title').innerHTML)
 
 export const goBack = exec(() => window.history.back())
 


### PR DESCRIPTION
It just occurred to me that Youtube and Twitter both put the `(1)` notification indicator at the beginning of the tab title, and the Vivaldi browser at least uses this as a hint that it's a "badge". This PR fixes that by aligning with Youtube/Twitter:

![screenshot from 2018-12-24 10-16-12](https://user-images.githubusercontent.com/283842/50405130-27a92a80-0765-11e9-8b46-cd07e00d8cd0.png)
