### PR TITLE
Add labels to theme groups

### DIFF
--- a/src/routes/_components/settings/instance/ThemeSettings.html
+++ b/src/routes/_components/settings/instance/ThemeSettings.html
@@ -2,6 +2,11 @@
   <div class="theme-groups">
     {#each themeGroups as themeGroup}
     <div class="theme-group">
+      {#if themeGroup.dark}
+        <h2>Dark Background</h2>
+      {:else}
+        <h2>Light Background</h2>
+      {/if}
       {#each themeGroup.themes as theme}
       <div class="theme-picker">
         <input type="radio" id="choice-theme-{theme.name}"


### PR DESCRIPTION
Adds a label to each theme group (light vs dark) as referenced in #848:

![theme_labels](https://user-images.githubusercontent.com/14966249/50670882-e5b58b00-0f93-11e9-9195-cf8ed37b36d3.gif)
