### PR TITLE
Wrap LONG posts with spoilers

### DIFF
--- a/src/routes/_a11y/getAccessibleLabelForStatus.js
+++ b/src/routes/_a11y/getAccessibleLabelForStatus.js
@@ -1,6 +1,5 @@
 import { getAccountAccessibleName } from './getAccountAccessibleName'
 import { POST_PRIVACY_OPTIONS } from '../_static/statuses'
-import { htmlToPlainText } from '../_utils/htmlToPlainText'
 
 function getNotificationText (notification, omitEmojiInDisplayNames) {
   if (!notification) {
@@ -34,13 +33,13 @@ function cleanupText (text) {
   return text.replace(/\s+/g, ' ').trim()
 }
 
-export function getAccessibleLabelForStatus (originalAccount, account, content,
+export function getAccessibleLabelForStatus (originalAccount, account, plainTextContent,
   timeagoFormattedDate, spoilerText, showContent,
   reblog, notification, visibility, omitEmojiInDisplayNames,
   disableLongAriaLabels) {
   let originalAccountDisplayName = getAccountAccessibleName(originalAccount, omitEmojiInDisplayNames)
   let contentTextToShow = (showContent || !spoilerText)
-    ? cleanupText(htmlToPlainText(content))
+    ? cleanupText(plainTextContent)
     : `Content warning: ${cleanupText(spoilerText)}`
   let privacyText = getPrivacyText(visibility)
 

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -116,6 +116,8 @@
   import { getAccessibleLabelForStatus } from '../../_a11y/getAccessibleLabelForStatus'
   import { formatTimeagoDate } from '../../_intl/formatTimeagoDate'
 
+  const LONG_POST_LENGTH = 1024
+  const LONG_POST_TEXT = 'Long'
   const INPUT_TAGS = new Set(['a', 'button', 'input', 'textarea'])
   const isUserInputElement = node => INPUT_TAGS.has(node.localName)
   const isToolbar = node => node.classList.contains('status-toolbar')
@@ -194,7 +196,9 @@
       originalAccount: ({ originalStatus }) => originalStatus.account,
       originalAccountId: ({ originalAccount }) => originalAccount.id,
       visibility: ({ originalStatus }) => originalStatus.visibility,
-      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || ((originalStatus.content || '').length > 1024 ? "LONG" : undefined),
+      spoilerText: ({ originalStatus, content }) => (
+        originalStatus.spoiler_text || (content.length > LONG_POST_LENGTH && LONG_POST_TEXT)
+      ),
       inReplyToId: ({ originalStatus }) => originalStatus.in_reply_to_id,
       uuid: ({ $currentInstance, timelineType, timelineValue, notificationId, statusId }) => (
         `${$currentInstance}/${timelineType}/${timelineValue}/${notificationId || ''}/${statusId}`

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -115,6 +115,8 @@
   import { getAccountAccessibleName } from '../../_a11y/getAccountAccessibleName'
   import { getAccessibleLabelForStatus } from '../../_a11y/getAccessibleLabelForStatus'
   import { formatTimeagoDate } from '../../_intl/formatTimeagoDate'
+  import { htmlToPlainText } from '../../_utils/htmlToPlainText'
+  import { measureText } from '../../_utils/measureText'
   import { LONG_POST_LENGTH, LONG_POST_TEXT } from '../../_static/statuses'
 
   const INPUT_TAGS = new Set(['a', 'button', 'input', 'textarea'])
@@ -195,8 +197,11 @@
       originalAccount: ({ originalStatus }) => originalStatus.account,
       originalAccountId: ({ originalAccount }) => originalAccount.id,
       visibility: ({ originalStatus }) => originalStatus.visibility,
-      spoilerText: ({ originalStatus, content }) => (
-        originalStatus.spoiler_text || (content.length > LONG_POST_LENGTH && LONG_POST_TEXT)
+      plainTextContent: ({ content }) => htmlToPlainText(content),
+      plainTextContentLength: ({ plainTextContent }) => measureText(plainTextContent),
+      plainTextContentOverLength: ({ plainTextContentLength }) => plainTextContentLength > LONG_POST_LENGTH,
+      spoilerText: ({ originalStatus, plainTextContentOverLength }) => (
+        originalStatus.spoiler_text || (plainTextContentOverLength && LONG_POST_TEXT)
       ),
       inReplyToId: ({ originalStatus }) => originalStatus.in_reply_to_id,
       uuid: ({ $currentInstance, timelineType, timelineValue, notificationId, statusId }) => (
@@ -225,9 +230,9 @@
       createdAtDate: ({ originalStatus }) => originalStatus.created_at,
       timeagoFormattedDate: ({ createdAtDate }) => formatTimeagoDate(createdAtDate),
       reblog: ({ status }) => status.reblog,
-      ariaLabel: ({ originalAccount, account, content, timeagoFormattedDate, spoilerText,
+      ariaLabel: ({ originalAccount, account, plainTextContent, timeagoFormattedDate, spoilerText,
         showContent, reblog, notification, visibility, $omitEmojiInDisplayNames, $disableLongAriaLabels }) => (
-        getAccessibleLabelForStatus(originalAccount, account, content,
+        getAccessibleLabelForStatus(originalAccount, account, plainTextContent,
           timeagoFormattedDate, spoilerText, showContent,
           reblog, notification, visibility, $omitEmojiInDisplayNames, $disableLongAriaLabels)
       ),

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -194,7 +194,7 @@
       originalAccount: ({ originalStatus }) => originalStatus.account,
       originalAccountId: ({ originalAccount }) => originalAccount.id,
       visibility: ({ originalStatus }) => originalStatus.visibility,
-      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text,
+      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || ((originalStatus.content || '').length > 1024 ? "LONG" : undefined),
       inReplyToId: ({ originalStatus }) => originalStatus.in_reply_to_id,
       uuid: ({ $currentInstance, timelineType, timelineValue, notificationId, statusId }) => (
         `${$currentInstance}/${timelineType}/${timelineValue}/${notificationId || ''}/${statusId}`

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -115,9 +115,8 @@
   import { getAccountAccessibleName } from '../../_a11y/getAccountAccessibleName'
   import { getAccessibleLabelForStatus } from '../../_a11y/getAccessibleLabelForStatus'
   import { formatTimeagoDate } from '../../_intl/formatTimeagoDate'
+  import { LONG_POST_LENGTH, LONG_POST_TEXT } from '../../_static/statuses'
 
-  const LONG_POST_LENGTH = 1024
-  const LONG_POST_TEXT = 'Long'
   const INPUT_TAGS = new Set(['a', 'button', 'input', 'textarea'])
   const isUserInputElement = node => INPUT_TAGS.has(node.localName)
   const isToolbar = node => node.classList.contains('status-toolbar')

--- a/src/routes/_components/status/StatusSpoiler.html
+++ b/src/routes/_components/status/StatusSpoiler.html
@@ -44,6 +44,7 @@
   import { mark, stop } from '../../_utils/marks'
   import { emojifyText } from '../../_utils/emojifyText'
   import escapeHtml from 'escape-html'
+  import { LONG_POST_TEXT } from '../../_static/statuses'
 
   export default {
     oncreate () {
@@ -52,7 +53,7 @@
     },
     store: () => store,
     computed: {
-      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || 'LONG',
+      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || LONG_POST_TEXT,
       emojis: ({ originalStatus }) => originalStatus.emojis,
       massagedSpoilerText: ({ spoilerText, emojis, $autoplayGifs }) => {
         spoilerText = escapeHtml(spoilerText)

--- a/src/routes/_components/status/StatusSpoiler.html
+++ b/src/routes/_components/status/StatusSpoiler.html
@@ -52,7 +52,7 @@
     },
     store: () => store,
     computed: {
-      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || "LONG",
+      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || 'LONG',
       emojis: ({ originalStatus }) => originalStatus.emojis,
       massagedSpoilerText: ({ spoilerText, emojis, $autoplayGifs }) => {
         spoilerText = escapeHtml(spoilerText)

--- a/src/routes/_components/status/StatusSpoiler.html
+++ b/src/routes/_components/status/StatusSpoiler.html
@@ -44,6 +44,7 @@
   import { mark, stop } from '../../_utils/marks'
   import { emojifyText } from '../../_utils/emojifyText'
   import escapeHtml from 'escape-html'
+  import { LONG_POST_TEXT } from '../../_static/statuses'
 
   export default {
     oncreate () {
@@ -52,6 +53,7 @@
     },
     store: () => store,
     computed: {
+      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || LONG_POST_TEXT,
       emojis: ({ originalStatus }) => originalStatus.emojis,
       massagedSpoilerText: ({ spoilerText, emojis, $autoplayGifs }) => {
         spoilerText = escapeHtml(spoilerText)

--- a/src/routes/_components/status/StatusSpoiler.html
+++ b/src/routes/_components/status/StatusSpoiler.html
@@ -44,7 +44,6 @@
   import { mark, stop } from '../../_utils/marks'
   import { emojifyText } from '../../_utils/emojifyText'
   import escapeHtml from 'escape-html'
-  import { LONG_POST_TEXT } from '../../_static/statuses'
 
   export default {
     oncreate () {
@@ -53,7 +52,6 @@
     },
     store: () => store,
     computed: {
-      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || LONG_POST_TEXT,
       emojis: ({ originalStatus }) => originalStatus.emojis,
       massagedSpoilerText: ({ spoilerText, emojis, $autoplayGifs }) => {
         spoilerText = escapeHtml(spoilerText)

--- a/src/routes/_components/status/StatusSpoiler.html
+++ b/src/routes/_components/status/StatusSpoiler.html
@@ -52,7 +52,7 @@
     },
     store: () => store,
     computed: {
-      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text,
+      spoilerText: ({ originalStatus }) => originalStatus.spoiler_text || "LONG",
       emojis: ({ originalStatus }) => originalStatus.emojis,
       massagedSpoilerText: ({ spoilerText, emojis, $autoplayGifs }) => {
         spoilerText = escapeHtml(spoilerText)

--- a/src/routes/_static/statuses.js
+++ b/src/routes/_static/statuses.js
@@ -20,3 +20,6 @@ export const POST_PRIVACY_OPTIONS = [
     icon: '#fa-envelope'
   }
 ]
+
+export const LONG_POST_LENGTH = 1024
+export const LONG_POST_TEXT = 'Long'

--- a/src/routes/_static/statuses.js
+++ b/src/routes/_static/statuses.js
@@ -22,4 +22,4 @@ export const POST_PRIVACY_OPTIONS = [
 ]
 
 export const LONG_POST_LENGTH = 1024
-export const LONG_POST_TEXT = 'Long'
+export const LONG_POST_TEXT = 'Long post'

--- a/tests/spec/112-status-links.js
+++ b/tests/spec/112-status-links.js
@@ -1,7 +1,7 @@
 import {
   composeButton,
   composeInput,
-  getNthStatus, getNthStatusSelector, getNthShowOrHideButton
+  getNthStatus, getNthStatusSelector
 } from '../utils'
 import { loginAsFoobar } from '../roles'
 import { Selector as $ } from 'testcafe'
@@ -21,7 +21,6 @@ test('External links, hashtags, and mentions have correct attributes', async t =
   await t
     .typeText(composeInput, text, { paste: true })
     .click(composeButton)
-    .click(getNthShowOrHideButton(0))
     .expect(getNthStatus(0).innerText).contains('Why hello there', { timeout: 20000 })
     .expect(nthAnchor(0).getAttribute('href')).eql('/accounts/1')
     .expect(nthAnchor(0).hasAttribute('rel')).notOk()

--- a/tests/spec/112-status-links.js
+++ b/tests/spec/112-status-links.js
@@ -1,7 +1,7 @@
 import {
   composeButton,
   composeInput,
-  getNthStatus, getNthStatusSelector
+  getNthStatus, getNthStatusSelector, getNthShowOrHideButton
 } from '../utils'
 import { loginAsFoobar } from '../roles'
 import { Selector as $ } from 'testcafe'
@@ -21,6 +21,7 @@ test('External links, hashtags, and mentions have correct attributes', async t =
   await t
     .typeText(composeInput, text, { paste: true })
     .click(composeButton)
+    .click(getNthShowOrHideButton(0))
     .expect(getNthStatus(0).innerText).contains('Why hello there', { timeout: 20000 })
     .expect(nthAnchor(0).getAttribute('href')).eql('/accounts/1')
     .expect(nthAnchor(0).hasAttribute('rel')).notOk()


### PR DESCRIPTION
Some ActivityPub software facilitates long form blog posts being pushed
out onto timelines.
Some ActivityPub software have toot lengths which are much larger than
Mastodon's default of 500.

This wraps spoiler tags around those statuses.