### PR TITLE
feat: add hotkey help to settings

### DIFF
--- a/src/routes/_components/ShortcutHelpInfo.html
+++ b/src/routes/_components/ShortcutHelpInfo.html
@@ -1,0 +1,49 @@
+<div class="{inDialog ? 'in-dialog' : ''}">
+  <h1>Hotkeys</h1>
+
+  <ul>
+    <li><kbd>s</kbd> to search</li>
+    <li><kbd>g</kbd> + <kbd>h</kbd> to go home</li>
+    <li><kbd>g</kbd> + <kbd>n</kbd> to go to the notifications page</li>
+    <li><kbd>g</kbd> + <kbd>l</kbd> to go to the local stream page</li>
+    <li><kbd>g</kbd> + <kbd>t</kbd> to go to the federated stream page</li>
+    <li><kbd>g</kbd> + <kbd>c</kbd> to go to the community page</li>
+    <li><kbd>j</kbd> or <kbd>↓</kbd> to activate the next status</li>
+    <li><kbd>k</kbd> or <kbd>↑</kbd> to activate the previous status</li>
+    <li><kbd>o</kbd> to open the active status</li>
+    <li><kbd>f</kbd> to favorite the active status</li>
+    <li><kbd>b</kbd> to boost the active status</li>
+    <li><kbd>r</kbd> to reply to the active status</li>
+    <li><kbd>x</kbd> to show or hide text behind content warning in the active status</li>
+    <li><kbd>y</kbd> to show or hide sensitive media in the active status</li>
+    <li><kbd>h</kbd> or <kbd>?</kbd> to toggle the help dialog</li>
+    <li><kbd>Backspace</kbd> to go back, close dialogs</li>
+  </ul>
+</div>
+<style>
+  .in-dialog h1 {
+    color: var(--muted-modal-text);
+  }
+  li {
+    list-style-type: none;
+  }
+  .in-dialog li {
+    color: var(--muted-modal-text);
+  }
+  kbd {
+    color: #333;
+    display: inline-block;
+    border: 1px solid #333;
+    border-radius: 2px;
+    padding: 0.1em;
+    margin: 0.2em;
+    background-color: #dadada;
+  }
+</style>
+<script>
+  export default {
+    data: () => ({
+      inDialog: false
+    })
+  }
+</script>

--- a/src/routes/_components/dialog/components/ShortcutHelpDialog.html
+++ b/src/routes/_components/dialog/components/ShortcutHelpDialog.html
@@ -5,49 +5,13 @@
   muted="true"
   className="shortcut-help-modal-dialog">
   
-  <h1>Keyboard Shortcuts</h1>
-
-  <ul>
-    <li><kbd>s</kbd> to search</li>
-    <li><kbd>g</kbd> + <kbd>h</kbd> to go home</li>
-    <li><kbd>g</kbd> + <kbd>n</kbd> to go to the notifications page</li>
-    <li><kbd>g</kbd> + <kbd>l</kbd> to go to the local stream page</li>
-    <li><kbd>g</kbd> + <kbd>t</kbd> to go to the federated stream page</li>
-    <li><kbd>g</kbd> + <kbd>c</kbd> to go to the community page</li>
-    <li><kbd>j</kbd> or <kbd>↓</kbd> to activate the next status</li>
-    <li><kbd>k</kbd> or <kbd>↑</kbd> to activate the previous status</li>
-    <li><kbd>o</kbd> to open the active status</li>
-    <li><kbd>f</kbd> to favorite the active status</li>
-    <li><kbd>b</kbd> to boost the active status</li>
-    <li><kbd>r</kbd> to reply to the active status</li>
-    <li><kbd>x</kbd> to show or hide text behind content warning in the active status</li>
-    <li><kbd>y</kbd> to show or hide sensitive media in the active status</li>
-    <li><kbd>h</kbd> or <kbd>?</kbd> to toggle this dialog</li>
-    <li><kbd>Backspace</kbd> to go back, close dialogs</li>
-  </ul>
+  <ShortcutHelpInfo inDialog={true} />
 
   <Shortcut scope='modal' key='h|?' on:pressed='close()'/>
 </ModalDialog>
-<style>
-  h1 {
-    color: var(--muted-modal-text);
-  }
-  li {
-    list-style-type:none;
-    color: var(--muted-modal-text);
-  }
-  kbd {
-    color: #333;
-    display: inline-block;
-    border: 1px solid #333;
-    border-radius: 2px;
-    padding: 0.1em;
-    margin: 0.2em;
-    background-color: #dadada;
-  }
-</style>
 <script>
   import ModalDialog from './ModalDialog.html'
+  import ShortcutHelpInfo from '../../ShortcutHelpInfo.html'
   import Shortcut from '../../shortcut/Shortcut.html'
   import { show } from '../helpers/showDialog'
   import { close } from '../helpers/closeDialog'
@@ -57,7 +21,8 @@
     oncreate,
     components: {
       ModalDialog,
-      Shortcut
+      Shortcut,
+      ShortcutHelpInfo
     },
     methods: {
       show,

--- a/src/routes/_pages/settings/hotkeys.html
+++ b/src/routes/_pages/settings/hotkeys.html
@@ -1,0 +1,14 @@
+<SettingsLayout page='settings/hotkeys' label="Hotkeys">
+  <ShortcutHelpInfo />
+</SettingsLayout>
+<script>
+  import SettingsLayout from '../../_components/settings/SettingsLayout.html'
+  import ShortcutHelpInfo from '../../_components/ShortcutHelpInfo.html'
+
+  export default {
+    components: {
+      SettingsLayout,
+      ShortcutHelpInfo
+    }
+  }
+</script>

--- a/src/routes/_pages/settings/index.html
+++ b/src/routes/_pages/settings/index.html
@@ -4,6 +4,7 @@
   <SettingsList>
     <SettingsListItem href="/settings/general" label="General"/>
     <SettingsListItem href="/settings/instances" label="Instances"/>
+    <SettingsListItem href="/settings/hotkeys" label="Hotkeys"/>
     <SettingsListItem href="/settings/about" label="About Pinafore"/>
   </SettingsList>
 

--- a/src/routes/settings/hotkeys.html
+++ b/src/routes/settings/hotkeys.html
@@ -1,0 +1,20 @@
+<Title name="Hotkeys" settingsPage={true} />
+
+<LazyPage {pageComponent} {params} />
+
+<script>
+  import Title from '../_components/Title.html'
+  import LazyPage from '../_components/LazyPage.html'
+  import pageComponent from '../_pages/settings/hotkeys.html'
+
+  export default {
+    components: {
+
+      Title,
+      LazyPage
+    },
+    data: () => ({
+      pageComponent
+    })
+  }
+</script>


### PR DESCRIPTION
Follow up to #870 - adds the hotkey shortcuts to the settings menu, so it's a bit more discoverable:

![screenshot from 2019-01-13 10-44-13](https://user-images.githubusercontent.com/283842/51089320-32316100-1720-11e9-81e5-141a92772028.png)
