### PR TITLE
fix: fix question mark hotkey

### DIFF
--- a/src/routes/_utils/shortcuts.js
+++ b/src/routes/_utils/shortcuts.js
@@ -170,6 +170,7 @@ function acceptShortcutEvent (event) {
   return !(
     event.metaKey ||
     event.ctrlKey ||
+    (event.shiftKey && event.key !== '?') || // '?' is a special case - it is allowed
     (target && (
       target.isContentEditable ||
         ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)

--- a/src/routes/_utils/shortcuts.js
+++ b/src/routes/_utils/shortcuts.js
@@ -166,16 +166,13 @@ function unmapKeys (keyMap, keys, component) {
 }
 
 function acceptShortcutEvent (event) {
-  if (event.metaKey || event.ctrlKey || event.shiftKey) {
-    return
-  }
-
-  let target = event.target
-  if (target && (target.isContentEditable ||
-                 target.tagName === 'INPUT' ||
-                 target.tagName === 'TEXTAREA' ||
-                 target.tagName === 'SELECT')) {
-    return false
-  }
-  return true
+  let { target } = event
+  return !(
+    event.metaKey ||
+    event.ctrlKey ||
+    (target && (
+      target.isContentEditable ||
+        ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)
+    ))
+  )
 }

--- a/tests/unit/test-shortcuts.js
+++ b/tests/unit/test-shortcuts.js
@@ -116,6 +116,17 @@ describe('test-shortcuts.js', function () {
     assert.ok(component.notPressed())
   })
 
+  it('does not skip events for ?', function () {
+    let component = new Component()
+
+    addToShortcutScope('global', '?', component)
+
+    let qEvent = new KeyDownEvent('?')
+    qEvent.shiftKey = true
+    eventListener(qEvent)
+    assert.ok(component.pressed())
+  })
+
   it('skips events for editable elements', function () {
     let component = new Component()
 


### PR DESCRIPTION
Follow-up to #870 - the "?" key should open up the help menu.