### PR TITLE
feat: add setting to disable hotkeys

### DIFF
--- a/src/routes/_components/ShortcutHelpInfo.html
+++ b/src/routes/_components/ShortcutHelpInfo.html
@@ -1,6 +1,4 @@
 <div class="{inDialog ? 'in-dialog' : ''}">
-  <h1>Hotkeys</h1>
-
   <ul>
     <li><kbd>s</kbd> to search</li>
     <li><kbd>g</kbd> + <kbd>h</kbd> to go home</li>
@@ -21,9 +19,6 @@
   </ul>
 </div>
 <style>
-  .in-dialog h1 {
-    color: var(--muted-modal-text);
-  }
   li {
     list-style-type: none;
   }

--- a/src/routes/_components/dialog/components/ShortcutHelpDialog.html
+++ b/src/routes/_components/dialog/components/ShortcutHelpDialog.html
@@ -4,11 +4,18 @@
   background="var(--muted-modal-bg)"
   muted="true"
   className="shortcut-help-modal-dialog">
-  
+
+  <h1>Hotkeys</h1>
+
   <ShortcutHelpInfo inDialog={true} />
 
   <Shortcut scope='modal' key='h|?' on:pressed='close()'/>
 </ModalDialog>
+<style>
+  h1 {
+    color: var(--muted-modal-text);
+  }
+</style>
 <script>
   import ModalDialog from './ModalDialog.html'
   import ShortcutHelpInfo from '../../ShortcutHelpInfo.html'

--- a/src/routes/_pages/settings/hotkeys.html
+++ b/src/routes/_pages/settings/hotkeys.html
@@ -1,11 +1,44 @@
 <SettingsLayout page='settings/hotkeys' label="Hotkeys">
+  <h1>Hotkeys</h1>
+
+  <h2 class="sr-only">Preferences</h2>
+  <form class="ui-settings" aria-label="Hotkey settings">
+    <div class="setting-group">
+      <input type="checkbox" id="choice-disable-hotkeys"
+             bind:checked="$disableHotkeys" on:change="onChange()">
+      <label for="choice-disable-hotkeys">Disable hotkeys</label>
+    </div>
+  </form>
+
+  <h2 class="sr-only">Guide</h2>
+
   <ShortcutHelpInfo />
 </SettingsLayout>
+<style>
+  .ui-settings {
+    background: var(--form-bg);
+    border: 1px solid var(--main-border);
+    border-radius: 4px;
+    padding: 20px;
+    line-height: 2em;
+    margin-bottom: 20px;
+  }
+  .setting-group {
+    padding: 5px 0;
+  }
+</style>
 <script>
   import SettingsLayout from '../../_components/settings/SettingsLayout.html'
   import ShortcutHelpInfo from '../../_components/ShortcutHelpInfo.html'
+  import { store } from '../../_store/store'
 
   export default {
+    store: () => store,
+    methods: {
+      onChange () {
+        this.store.save()
+      }
+    },
     components: {
       SettingsLayout,
       ShortcutHelpInfo

--- a/src/routes/_store/store.js
+++ b/src/routes/_store/store.js
@@ -11,6 +11,7 @@ const persistedState = {
   currentRegisteredInstanceName: undefined,
   currentRegisteredInstance: undefined,
   disableCustomScrollbars: false,
+  disableHotkeys: false,
   disableLongAriaLabels: false,
   disableTapOnStatus: false,
   largeInlineMedia: false,

--- a/src/routes/_utils/shortcuts.js
+++ b/src/routes/_utils/shortcuts.js
@@ -1,3 +1,5 @@
+import { store } from '../_store/store'
+
 // A map of scopeKey to KeyMap
 let scopeKeyMaps
 
@@ -119,6 +121,9 @@ function handleEvent (scopeKey, keyMap, key, event) {
 }
 
 function onKeyDown (event) {
+  if (store.get().disableHotkeys) {
+    return
+  }
   if (!acceptShortcutEvent(event)) {
     return
   }


### PR DESCRIPTION
Follow-up to #870 - add an option to disable hotkeys (hotkeys are enabled by default).

I can't think of why someone would want to disable these, but accessibility is tricky, and it's hard to predict how people are going to use a website, so I want to give them the option.