### PR TITLE
Fix #869: Allow logged out user to view content on default instance

### DIFF
--- a/src/routes/_actions/accounts.js
+++ b/src/routes/_actions/accounts.js
@@ -1,3 +1,4 @@
+import { registerDefaultInstance } from './addInstance'
 import { getAccount } from '../_api/user'
 import { getRelationship } from '../_api/relationships'
 import { database } from '../_database/database'
@@ -58,6 +59,9 @@ export async function clearProfileAndRelationship () {
 
 export async function updateProfileAndRelationship (accountId) {
   let { currentInstance, accessToken } = store.get()
+  if (currentInstance === undefined || currentInstance === null) {
+    currentInstance = await registerDefaultInstance()
+  }
 
   await Promise.all([
     _updateAccount(accountId, currentInstance, accessToken),
@@ -67,6 +71,9 @@ export async function updateProfileAndRelationship (accountId) {
 
 export async function updateRelationship (accountId) {
   let { currentInstance, accessToken } = store.get()
+  if (currentInstance === undefined || currentInstance === null) {
+    currentInstance = await registerDefaultInstance()
+  }
 
   await _updateRelationship(accountId, currentInstance, accessToken)
 }

--- a/src/routes/_actions/addInstance.js
+++ b/src/routes/_actions/addInstance.js
@@ -59,6 +59,20 @@ export async function logInToInstance () {
   }
 }
 
+export async function registerDefaultInstance () {
+  let currentRegisteredInstanceName = 'mastodon.social'
+  let { loggedInInstances, instanceThemes } = store.get()
+  instanceThemes[currentRegisteredInstanceName] = 'default'
+  loggedInInstances[currentRegisteredInstanceName] = {}
+  store.set({
+    currentInstance: currentRegisteredInstanceName,
+    instanceThemes: instanceThemes
+  })
+  store.save()
+  switchToTheme('default')
+  return currentRegisteredInstanceName
+}
+
 async function registerNewInstance (code) {
   let { currentRegisteredInstanceName, currentRegisteredInstance } = store.get()
   let instanceData = await getAccessTokenFromAuthCode(

--- a/src/routes/_actions/addInstance.js
+++ b/src/routes/_actions/addInstance.js
@@ -3,6 +3,7 @@ import { getInstanceInfo } from '../_api/instance'
 import { goto } from '../../../__sapper__/client'
 import { DEFAULT_THEME, switchToTheme } from '../_utils/themeEngine'
 import { store } from '../_store/store'
+import { DEFAULT_INSTANCE_HOSTNAME } from '../_static/config'
 import { updateVerifyCredentialsForInstance } from './instances'
 import { updateCustomEmojiForInstance } from './emoji'
 import { database } from '../_database/database'
@@ -60,7 +61,7 @@ export async function logInToInstance () {
 }
 
 export async function registerDefaultInstance () {
-  let currentRegisteredInstanceName = 'mastodon.social'
+  let currentRegisteredInstanceName = DEFAULT_INSTANCE_HOSTNAME
   let { loggedInInstances, instanceThemes } = store.get()
   instanceThemes[currentRegisteredInstanceName] = 'default'
   loggedInInstances[currentRegisteredInstanceName] = {}

--- a/src/routes/_actions/timeline.js
+++ b/src/routes/_actions/timeline.js
@@ -1,3 +1,4 @@
+import { registerDefaultInstance } from './addInstance'
 import { store } from '../_store/store'
 import { getTimeline } from '../_api/timelines'
 import { toast } from '../_components/toast/toast'
@@ -89,6 +90,9 @@ async function fetchTimelineItemsAndPossiblyFallBack () {
     lastTimelineItemId,
     online
   } = store.get()
+  if (currentInstance === undefined || currentInstance === null) {
+    currentInstance = await registerDefaultInstance()
+  }
 
   let { items, stale } = await fetchTimelineItems(currentInstance, accessToken, currentTimeline, lastTimelineItemId, online)
   addTimelineItems(currentInstance, currentTimeline, items, stale)

--- a/src/routes/_api/utils.js
+++ b/src/routes/_api/utils.js
@@ -10,6 +10,10 @@ export function basename (instanceName) {
 }
 
 export function auth (accessToken) {
+  if (accessToken === undefined || accessToken === null) {
+    return {}
+  }
+
   return {
     'Authorization': `Bearer ${accessToken}`
   }

--- a/src/routes/_components/profile/AccountProfile.html
+++ b/src/routes/_components/profile/AccountProfile.html
@@ -7,7 +7,9 @@
   <div class="account-profile-grid-wrapper">
     <div class="account-profile-grid">
       <AccountProfileHeader {account} {relationship} {verifyCredentials} />
+      {#if $isUserLoggedIn}
       <AccountProfileFollow {account} {relationship} {verifyCredentials} />
+      {/if}
       <AccountProfileNote {account} />
       <AccountProfileMeta {account} />
       <AccountProfileDetails {account} {relationship} {verifyCredentials} />

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -32,7 +32,7 @@
     <StatusDetails {...params} />
   {/if}
   <StatusToolbar {...params} on:recalculateHeight />
-  {#if replyShown}
+  {#if replyShown && $isUserLoggedIn}
     <StatusComposeBox {...params} on:recalculateHeight />
   {/if}
 </article>

--- a/src/routes/_pages/accounts/[accountId]/index.html
+++ b/src/routes/_pages/accounts/[accountId]/index.html
@@ -1,28 +1,16 @@
-{#if $isUserLoggedIn}
-  <TimelinePage timeline="account/{params.accountId}">
-    <DynamicPageBanner title="" ariaTitle="Profile page for {accountName}"/>
-    {#if $currentAccountProfile && $currentVerifyCredentials}
-    <AccountProfile account={$currentAccountProfile}
-                    relationship={$currentAccountRelationship}
-                    verifyCredentials={$currentVerifyCredentials}
-    />
-    {/if}
-    <PinnedStatuses accountId={params.accountId} />
-  </TimelinePage>
-{:else}
-  <HiddenFromSSR>
-    <FreeTextLayout>
-      <h1>Profile</h1>
-
-      <p>A user timeline will appear here when logged in.</p>
-    </FreeTextLayout>
-  </HiddenFromSSR>
-{/if}
+<TimelinePage timeline="account/{params.accountId}">
+  <DynamicPageBanner title="" ariaTitle="Profile page for {accountName}"/>
+  {#if $currentAccountProfile}
+  <AccountProfile account={$currentAccountProfile}
+                  relationship={$currentAccountRelationship}
+                  verifyCredentials={$currentVerifyCredentials}
+  />
+  {/if}
+  <PinnedStatuses accountId={params.accountId} />
+</TimelinePage>
 <script>
   import TimelinePage from '../../../_components/TimelinePage.html'
-  import FreeTextLayout from '../../../_components/FreeTextLayout.html'
   import { store } from '../../../_store/store.js'
-  import HiddenFromSSR from '../../../_components/HiddenFromSSR'
   import DynamicPageBanner from '../../../_components/DynamicPageBanner.html'
   import { updateProfileAndRelationship, clearProfileAndRelationship } from '../../../_actions/accounts'
   import AccountProfile from '../../../_components/profile/AccountProfile.html'
@@ -49,8 +37,6 @@
     },
     components: {
       TimelinePage,
-      FreeTextLayout,
-      HiddenFromSSR,
       DynamicPageBanner,
       AccountProfile,
       PinnedStatuses

--- a/src/routes/_pages/accounts/[accountId]/index.html
+++ b/src/routes/_pages/accounts/[accountId]/index.html
@@ -1,16 +1,29 @@
-<TimelinePage timeline="account/{params.accountId}">
-  <DynamicPageBanner title="" ariaTitle="Profile page for {accountName}"/>
-  {#if $currentAccountProfile}
-  <AccountProfile account={$currentAccountProfile}
-                  relationship={$currentAccountRelationship}
-                  verifyCredentials={$currentVerifyCredentials}
-  />
-  {/if}
-  <PinnedStatuses accountId={params.accountId} />
-</TimelinePage>
+{#if $isUserLoggedIn || defaultInstance}
+  <TimelinePage timeline="account/{params.accountId}">
+    <DynamicPageBanner title="" ariaTitle="Profile page for {accountName}"/>
+    {#if $currentAccountProfile && ($currentVerifyCredentials || defaultInstance)}
+    <AccountProfile account={$currentAccountProfile}
+                    relationship={$currentAccountRelationship}
+                    verifyCredentials={$currentVerifyCredentials}
+    />
+    {/if}
+    <PinnedStatuses accountId={params.accountId} />
+  </TimelinePage>
+{:else}
+  <HiddenFromSSR>
+    <FreeTextLayout>
+      <h1>Profile</h1>
+
+      <p>A user timeline will appear here when logged in.</p>
+    </FreeTextLayout>
+  </HiddenFromSSR>
+{/if}
 <script>
   import TimelinePage from '../../../_components/TimelinePage.html'
+  import FreeTextLayout from '../../../_components/FreeTextLayout.html'
   import { store } from '../../../_store/store.js'
+  import { DEFAULT_INSTANCE_HOSTNAME } from '../../../_static/config.js'
+  import HiddenFromSSR from '../../../_components/HiddenFromSSR'
   import DynamicPageBanner from '../../../_components/DynamicPageBanner.html'
   import { updateProfileAndRelationship, clearProfileAndRelationship } from '../../../_actions/accounts'
   import AccountProfile from '../../../_components/profile/AccountProfile.html'
@@ -20,6 +33,7 @@
     oncreate () {
       let { params } = this.get()
       let { accountId } = params
+      this.set({ defaultInstance: DEFAULT_INSTANCE_HOSTNAME })
       clearProfileAndRelationship()
       updateProfileAndRelationship(accountId)
     },
@@ -37,6 +51,8 @@
     },
     components: {
       TimelinePage,
+      FreeTextLayout,
+      HiddenFromSSR,
       DynamicPageBanner,
       AccountProfile,
       PinnedStatuses

--- a/src/routes/_pages/federated.html
+++ b/src/routes/_pages/federated.html
@@ -1,4 +1,4 @@
-{#if $isUserLoggedIn}
+{#if $isUserLoggedIn || defaultInstance}
   <TimelinePage timeline="federated">
     {#if $pinnedPage !== '/federated'}
       <DynamicPageBanner title="Federated Timeline" icon="#fa-globe"/>
@@ -17,10 +17,14 @@
   import TimelinePage from '../_components/TimelinePage.html'
   import FreeTextLayout from '../_components/FreeTextLayout.html'
   import { store } from '../_store/store.js'
+  import { DEFAULT_INSTANCE_HOSTNAME } from '../_static/config.js'
   import HiddenFromSSR from '../_components/HiddenFromSSR'
   import DynamicPageBanner from '../_components/DynamicPageBanner.html'
 
   export default {
+    oncreate () {
+      this.set({ defaultInstance: DEFAULT_INSTANCE_HOSTNAME })
+    },
     store: () => store,
     components: {
       TimelinePage,

--- a/src/routes/_pages/statuses/[statusId]/index.html
+++ b/src/routes/_pages/statuses/[statusId]/index.html
@@ -1,28 +1,14 @@
-{#if $isUserLoggedIn}
-  <TimelinePage timeline="status/{params.statusId}">
-    <DynamicPageBanner title="" ariaTitle="Status thread page" />
-  </TimelinePage>
-{:else}
-  <HiddenFromSSR>
-    <FreeTextLayout>
-      <h1>Status</h1>
-
-      <p>A status thread will appear here when logged in.</p>
-    </FreeTextLayout>
-  </HiddenFromSSR>
-{/if}
+<TimelinePage timeline="status/{params.statusId}">
+  <DynamicPageBanner title="" ariaTitle="Status thread page" />
+</TimelinePage>
 <script>
-  import FreeTextLayout from '../../../_components/FreeTextLayout.html'
   import { store } from '../../../_store/store.js'
-  import HiddenFromSSR from '../../../_components/HiddenFromSSR'
   import DynamicPageBanner from '../../../_components/DynamicPageBanner.html'
   import TimelinePage from '../../../_components/TimelinePage.html'
 
   export default {
     store: () => store,
     components: {
-      FreeTextLayout,
-      HiddenFromSSR,
       DynamicPageBanner,
       TimelinePage
     }

--- a/src/routes/_pages/statuses/[statusId]/index.html
+++ b/src/routes/_pages/statuses/[statusId]/index.html
@@ -1,14 +1,32 @@
-<TimelinePage timeline="status/{params.statusId}">
-  <DynamicPageBanner title="" ariaTitle="Status thread page" />
-</TimelinePage>
+{#if $isUserLoggedIn || defaultInstance}
+  <TimelinePage timeline="status/{params.statusId}">
+    <DynamicPageBanner title="" ariaTitle="Status thread page" />
+  </TimelinePage>
+{:else}
+  <HiddenFromSSR>
+    <FreeTextLayout>
+      <h1>Status</h1>
+
+      <p>A status thread will appear here when logged in.</p>
+    </FreeTextLayout>
+  </HiddenFromSSR>
+{/if}
 <script>
+  import FreeTextLayout from '../../../_components/FreeTextLayout.html'
   import { store } from '../../../_store/store.js'
+  import { DEFAULT_INSTANCE_HOSTNAME } from '../../../_static/config.js'
+  import HiddenFromSSR from '../../../_components/HiddenFromSSR'
   import DynamicPageBanner from '../../../_components/DynamicPageBanner.html'
   import TimelinePage from '../../../_components/TimelinePage.html'
 
   export default {
+    oncreate () {
+      this.set({ defaultInstance: DEFAULT_INSTANCE_HOSTNAME })
+    },
     store: () => store,
     components: {
+      FreeTextLayout,
+      HiddenFromSSR,
       DynamicPageBanner,
       TimelinePage
     }

--- a/src/routes/_static/config.js
+++ b/src/routes/_static/config.js
@@ -1,0 +1,1 @@
+export const DEFAULT_INSTANCE_HOSTNAME = false


### PR DESCRIPTION
(Re-opening #872 since the stated reason for closure was addressed before it was closed).

I guess this still needs tests. The configuration variable for the default instance lives in `src/route/_static/config.js`. I'm not sure if that's the right place for it. The default value for it is "`false`" which maintains the existing experience for logged out users. This avoids Pinafore even unintentionally privileging a certain instance by making it the default default instance.