### PR TITLE
Make external links open in new tab

### DIFF
--- a/src/routes/_components/status/StatusContent.html
+++ b/src/routes/_components/status/StatusContent.html
@@ -111,6 +111,9 @@
           } else if (anchor.getAttribute('rel') === 'nofollow noopener') {
             anchor.setAttribute('title', href)
           }
+          if (anchor.getAttribute('href')[0] !== '/' || anchor.getAttribute('href')[1] === '/') {
+            anchor.setAttribute('target', '_blank')
+          }
         }
         stop('hydrateContent')
       }


### PR DESCRIPTION
(Reopening #543 since the bug still persists for Pleroma instances)

External links inside toots (when using a Pleroma instance) opens up in a new tab (using target='_blank') instead of the same tab.