### PR TITLE
fix: use more consistent method for checking external links

### DIFF
--- a/src/routes/_components/status/StatusContent.html
+++ b/src/routes/_components/status/StatusContent.html
@@ -80,27 +80,25 @@
         mark('hydrateContent')
         let node = this.refs.node
         let { originalStatus, uuid } = this.get()
+        let { mentions, tags } = originalStatus
         let count = 0
-        let anchors = node.getElementsByTagName('A')
-        let mentions = originalStatus.mentions
-        let tags = originalStatus.tags
-        for (let i = 0, len = anchors.length; i < len; i++) {
-          let anchor = anchors[i]
-          let href = anchor.getAttribute('href')
+        let anchors = Array.from(node.getElementsByTagName('A'))
+
+        for (let anchor of anchors) {
+          // hydrate hashtag
           if (tags && anchor.classList.contains('hashtag')) {
-            for (let j = 0, jLen = tags.length; j < jLen; j++) {
-              let tag = tags[j]
-              if (href.endsWith(`/tags/${tag.name}`)) {
+            for (let tag of tags) {
+              if (anchor.getAttribute('href').endsWith(`/tags/${tag.name}`)) {
                 anchor.setAttribute('href', `/tags/${tag.name}`)
                 anchor.setAttribute('focus-key', `status-content-link-${uuid}-${++count}`)
                 anchor.removeAttribute('target')
                 anchor.removeAttribute('rel')
               }
             }
+          // hydrate mention
           } else if (mentions && anchor.classList.contains('mention')) {
-            for (let j = 0, jLen = mentions.length; j < jLen; j++) {
-              let mention = mentions[j]
-              if (href === mention.url) {
+            for (let mention of mentions) {
+              if (anchor.getAttribute('href') === mention.url) {
                 anchor.setAttribute('href', `/accounts/${mention.id}`)
                 anchor.setAttribute('title', `@${mention.acct}`)
                 anchor.setAttribute('focus-key', `status-content-link-${uuid}-${++count}`)
@@ -108,11 +106,13 @@
                 anchor.removeAttribute('rel')
               }
             }
-          } else if (anchor.getAttribute('rel') === 'nofollow noopener') {
-            anchor.setAttribute('title', href)
           }
-          if (anchor.getAttribute('href')[0] !== '/' || anchor.getAttribute('href')[1] === '/') {
+          // hydrate external links
+          let href = anchor.getAttribute('href')
+          if (new URL(href, location.href).origin !== location.origin) {
+            anchor.setAttribute('title', href)
             anchor.setAttribute('target', '_blank')
+            anchor.setAttribute('rel', 'nofollow noopener')
           }
         }
         stop('hydrateContent')


### PR DESCRIPTION
Follow-up to #892 - instead of checking whether the `href` starts with a `/`, it's safer to construct a `URL` and check its origin.