### PR TITLE
docs: remove mention of keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Compatible versions of each (Opera, Brave, Samsung, etc.) should be fine.
 - Serve as an alternative frontend tied to a particular instance
 - Support for non-English languages (i18n)
 - Offline search
-- Keyboard shortcuts
 
 ### Non-goals
 


### PR DESCRIPTION
We have keyboard shortcuts now, so it's no longer a "future goal"