### PR TITLE
fix: increase custom scrollbar width

### DIFF
--- a/src/scss/themes/_scrollbars.scss
+++ b/src/scss/themes/_scrollbars.scss
@@ -4,7 +4,7 @@
   --scrollbar-border-radius: 0;
   --scrollbar-face-color-hover: #{$scrollbar-face-hover};
   --scrollbar-face-color-active: #{$scrollbar-face-active};
-  --scrollbar-width: 12px;
-  --scrollbar-height: 12px;
+  --scrollbar-width: calc(20px + .25em);
+  --scrollbar-height: calc(20px + .25em);
   --scrollbar-background-color: transparent;
 }


### PR DESCRIPTION
Based on http://adrianroselli.com/2019/01/baseline-rules-for-scrollbar-usability.html it seems the WCAG-approved width would be 44px, but setting it to that size is comically huge from my perspective. css-tricks uses a width of 30px, and even that looks too large to my eye. But I like the suggestion of having it scale with the `em` so that users can zoom in and make it larger, so I'm using `calc(20px * 0.25em)`.

Note this only applies to Chrome/Safari (since Firefox doesn't let us set the scrollbar width), and users can disable custom scrollbars in the settings anyway.