### PR TITLE
chore: give "now" the yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,10 +171,10 @@
       "src-build",
       "static",
       "package.json",
-      "package-lock.json",
       "thirdparty",
       "webpack",
-      "webpack.config.js"
+      "webpack.config.js",
+      "yarn.lock"
     ],
     "engines": {
       "node": "^10.0.0"


### PR DESCRIPTION
This is something I forgot in the Yarn migration (#927)