### PR TITLE
fix: fix rounding of scroll math on Safari

### DIFF
--- a/src/routes/_components/dialog/components/MediaDialog.html
+++ b/src/routes/_components/dialog/components/MediaDialog.html
@@ -189,7 +189,7 @@
       onScroll () {
         let { length } = this.get()
         let { scrollWidth, scrollLeft } = this.refs.scroller
-        let scrolledItem = Math.floor((scrollLeft / scrollWidth) * length)
+        let scrolledItem = Math.round((scrollLeft / scrollWidth) * length)
         this.set({ scrolledItem })
       },
       onClick (i) {


### PR DESCRIPTION
On iOS Safari, Math.round works better than Math.floor