### PR TITLE
fix: use intrinsicsize for images/videos

### DIFF
--- a/src/routes/_components/dialog/components/MediaInDialog.html
+++ b/src/routes/_components/dialog/components/MediaInDialog.html
@@ -50,7 +50,7 @@
           let { width, height } = media.meta.original
           return `${width} x ${height}`
         }
-        return ''
+        return '' // pleroma does not give us original width/height
       }
     },
     ondestroy () {

--- a/src/routes/_components/dialog/components/MediaInDialog.html
+++ b/src/routes/_components/dialog/components/MediaInDialog.html
@@ -5,6 +5,7 @@
     src={url}
     {poster}
     controls
+    {intrinsicsize}
     ref:video
   />
 {:elseif type === 'gifv'}
@@ -18,6 +19,7 @@
     loop
     webkit-playsinline
     playsinline
+    {intrinsicsize}
   />
 {:else}
   <img
@@ -25,6 +27,7 @@
     alt={description}
     title={description}
     src={url}
+    {intrinsicsize}
   />
 {/if}
 <style>
@@ -41,7 +44,14 @@
       url: ({ media }) => media.url,
       description: ({ media }) => media.description || '',
       poster: ({ media }) => media.poster,
-      static_url: ({ media }) => media.static_url
+      static_url: ({ media }) => media.static_url,
+      intrinsicsize: ({ media }) => {
+        if (media.meta && media.meta.original && media.meta.original.width && media.meta.original.height) {
+          let { width, height } = media.meta.original
+          return `${width} x ${height}`
+        }
+        return ''
+      }
     },
     ondestroy () {
       if (this.refs.video && !this.refs.video.paused) {


### PR DESCRIPTION
This is an emerging web standard, but it would avoid an extra reflow for these images while they're being loaded. I tested it in Chromium with the "experimental web platform features" flag on, and it indeed does prevent the reflow if image loading is slow.

Pleroma does not have width/height for images, so we skip it in that case.

Details: https://www.chromestatus.com/feature/4704436815396864