### PR TITLE
fix: add label to dummy icon to prevent svelte warning

### DIFF
--- a/src/routes/_components/dialog/components/MediaDialog.html
+++ b/src/routes/_components/dialog/components/MediaDialog.html
@@ -23,6 +23,7 @@
       <IconButton
         className="media-control-button media-control-button-dummy-spacer"
         href="#fa-search"
+        label=""
       />
       {#if dots.length > 1}
         <div class="media-controls">


### PR DESCRIPTION
This just fixes a console warning in dev mode.