### PR TITLE
fix: do not add duplicates to threads

### DIFF
--- a/src/routes/_actions/timeline.js
+++ b/src/routes/_actions/timeline.js
@@ -147,7 +147,11 @@ export async function showMoreItemsForThread (instanceName, timelineName) {
   let itemIdsToAdd = store.getForTimeline(instanceName, timelineName, 'itemIdsToAdd')
   let timelineItemIds = store.getForTimeline(instanceName, timelineName, 'timelineItemIds')
   // TODO: update database and do the thread merge correctly
-  timelineItemIds = timelineItemIds.concat(itemIdsToAdd)
+  for (let itemIdToAdd of itemIdsToAdd) {
+    if (!timelineItemIds.includes(itemIdToAdd)) {
+      timelineItemIds.push(itemIdToAdd)
+    }
+  }
   store.setForTimeline(instanceName, timelineName, {
     itemIdsToAdd: [],
     timelineItemIds: timelineItemIds


### PR DESCRIPTION
attempt to fix #943

This is a pretty brute-force way to do this, but hopefully it will work well enough for the moment, until we add filtering logic and be more intelligent about knowing what ID is a reply to what other ID.