### PR TITLE
fix: allow right-click to save image

### DIFF
--- a/src/routes/_components/dialog/components/MediaDialog.html
+++ b/src/routes/_components/dialog/components/MediaDialog.html
@@ -11,8 +11,8 @@
         <li class="media-scroll-item">
           <div class="media-scroll-item-inner">
             <div class="media-scroll-item-inner-inner">
-                {#if canPinchZoom}
-                  <PinchZoomable className='media-pinch-zoom' disabled={!pinchZoomMode} >
+                {#if canPinchZoom && pinchZoomMode}
+                  <PinchZoomable className='media-pinch-zoom' >
                     <MediaInDialog {media} />
                   </PinchZoomable>
                 {:else}

--- a/src/routes/_components/dialog/components/PinchZoomable.html
+++ b/src/routes/_components/dialog/components/PinchZoomable.html
@@ -1,4 +1,4 @@
-<div class="pinch-zoom {disabled ? 'pinch-zoom-disabled' : ''} {className ? className : ''}" >
+<div class="pinch-zoom {className ? className : ''}" >
   <pinch-zoom class="pinch-zoom-inner" ref:node>
     <slot></slot>
   </pinch-zoom>
@@ -8,7 +8,6 @@
     label="Zoom out"
     href="#fa-search-minus"
     on:click="zoomOut()"
-    ariaHidden={disabled}
   />
   <IconButton
     className="pinch-zoom-button pinch-zoom-button-zoom-in"
@@ -16,15 +15,11 @@
     label="Zoom in"
     href="#fa-search-plus"
     on:click="zoomIn()"
-    ariaHidden={disabled}
   />
 </div>
 <style>
   .pinch-zoom {
     position: relative;
-  }
-  .pinch-zoom-disabled {
-    pointer-events: none;
   }
   .pinch-zoom-inner {
     width: 100%;
@@ -62,34 +57,18 @@
       padding-right: 5px;
     }
   }
-
-  :global(.pinch-zoom-disabled .pinch-zoom-button) {
-    visibility: hidden;
-  }
 </style>
 <script>
   import IconButton from '../../IconButton.html'
   import 'pinch-zoom-element/dist/pinch-zoom.js'
-  import { observe } from 'svelte-extras'
 
   const ZOOM_INCREMENT = 0.1
 
   export default {
-    oncreate () {
-      this.observe('disabled', disabled => {
-        if (disabled) {
-          this.resetZoom()
-        }
-      }, { init: false })
-    },
-    data: () => ({
-      disabled: false
-    }),
     components: {
       IconButton
     },
     methods: {
-      observe,
       zoomIn () {
         this.zoomBy(ZOOM_INCREMENT)
       },
@@ -102,14 +81,6 @@
         node.scaleTo(scale + increment, {
           originX: '50%',
           originY: '50%'
-        })
-      },
-      resetZoom () {
-        let { node } = this.refs
-        node.setTransform({
-          scale: 1,
-          x: 0,
-          y: 0
         })
       }
     }


### PR DESCRIPTION
fixes #961

I was trying to avoid unnecessary DOM operations and re-layouts by just setting `pointer-events: none`, but this disables right-click-to-save.

I think it's simpler to just swap out `<pinch-zoom>` entirely. I measured the cost of tapping the magnifying glass at 4x slowdown in Chrome and it's around ~60ms which is reasonable.