### PR TITLE
perf: use keyed each for media

### DIFF
--- a/src/routes/_components/dialog/components/MediaDialog.html
+++ b/src/routes/_components/dialog/components/MediaDialog.html
@@ -7,7 +7,7 @@
 >
   <div class="media-container">
     <ul class="media-scroll" ref:scroller>
-      {#each mediaItems as media}
+      {#each mediaItems as media (media.id)}
         <li class="media-scroll-item">
           <div class="media-scroll-item-inner">
             <div class="media-scroll-item-inner-inner">


### PR DESCRIPTION
It feels better to use a key here so that Svelte can do less work when updating. I'm not seeing a big perf difference when testing, but it seems harmless to add.