### PR TITLE
fix: fix legibility of settings text in dark themes

### DIFF
--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -32,4 +32,9 @@
   --compose-autosuggest-outline: #{lighten($border-color, 20%)};
 
   --file-drop-mask: #{rgba(30, 30, 30, 0.8)};
+
+  --settings-list-item-text: #{$main-text-color};
+  --settings-list-item-text-hover: #{$main-text-color};
+  --settings-list-item-bg-active: #{lighten($main-bg-color, 7%)};
+  --settings-list-item-bg-hover: #{lighten($main-bg-color, 3%)};
 }


### PR DESCRIPTION
This makes the settings text much easier to read, e.g. in the Ozark theme.

Before:

![screenshot from 2019-02-11 19-10-57](https://user-images.githubusercontent.com/283842/52609065-dba76780-2e30-11e9-8d7b-0ffba33317f2.png)

After:

![screenshot from 2019-02-11 19-10-22](https://user-images.githubusercontent.com/283842/52609077-e530cf80-2e30-11e9-9931-0c20cb5b338f.png)
