### PR TITLE
fix: fix SettingsListItem missing className dev warning

### DIFF
--- a/src/routes/_components/settings/SettingsListButton.html
+++ b/src/routes/_components/settings/SettingsListButton.html
@@ -17,7 +17,8 @@
 <script>
   export default {
     data: () => ({
-      ariaLabel: void 0
+      ariaLabel: void 0,
+      className: void 0
     })
   }
 </script>


### PR DESCRIPTION
This just fixes a dev warning.