### PR TITLE
fix: fix port not defaulting to 4002, add server.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ EXPOSE 4002
 # Setting run-command, using explicit `node` command
 # rather than `yarn` or `npm` to use less memory
 # https://github.com/nolanlawson/pinafore/issues/971
-CMD PORT=4002 node __sapper__/build
+CMD PORT=4002 node server.js

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Then build:
 
 Then run:
 
-    PORT=4002 node __sapper__/build
+    PORT=4002 node server.js
 
 ### Docker
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "cross-env NODE_ENV=production run-s build-steps",
     "build-steps": "run-s before-build sapper-build",
     "sapper-build": "sapper build",
-    "start": "PORT=4002 node __sapper__/build",
+    "start": "node server.js",
     "build-and-start": "run-s build start",
     "build-template-html": "node -r esm ./bin/build-template-html.js",
     "build-template-html-watch": "node -r esm ./bin/build-template-html.js --watch",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+process.env.PORT = process.env.PORT || 4002
+
+require('./__sapper__/build')


### PR DESCRIPTION
Fixes #972 as well as a few other things:

- #973 exposed `node __sapper__/build` to self-hosters, which is ugly. This adds `node server.js` which is our wrapper to handle the port, and is also a lot cleaner
- those running Pinafore in production on Windows (if they exist) are unbroken by removing the `PORT=4002` from the npm script