### PR TITLE
perf: prefetch all internal links

### DIFF
--- a/src/routes/_components/NavItem.html
+++ b/src/routes/_components/NavItem.html
@@ -2,6 +2,7 @@
    aria-label={ariaLabel}
    aria-current={selected}
    on:click="onClick(event)"
+   rel="prefetch"
    {href} >
   <div class="nav-icon-and-label">
     {#if name === 'notifications'}

--- a/src/routes/_components/NotLoggedInHome.html
+++ b/src/routes/_components/NotLoggedInHome.html
@@ -11,7 +11,7 @@
 
       <p>Read the <ExternalLink href="https://nolanlawson.com/2018/04/09/introducing-pinafore-for-mastodon/">introductory blog post</ExternalLink>, or get started by logging in to an instance:</p>
 
-      <p style="text-align: right;"><a class="button primary" href="/settings/instances/add">Add instance</a></p>
+      <p style="text-align: right;"><a class="button primary" rel="prefetch" href="/settings/instances/add">Add instance</a></p>
     </div>
   </FreeTextLayout>
 </HiddenFromSSR>

--- a/src/routes/_components/community/PageListItem.html
+++ b/src/routes/_components/community/PageListItem.html
@@ -1,5 +1,5 @@
 <li class="page-list-item">
-  <a {href}>
+  <a {href} rel="prefetch">
     <svg class="page-list-item-svg">
       <use xlink:href={icon} />
     </svg>

--- a/src/routes/_components/compose/ComposeAuthor.html
+++ b/src/routes/_components/compose/ComposeAuthor.html
@@ -1,9 +1,10 @@
 <a href="/accounts/{verifyCredentials.id}"
+   rel="prefetch"
    class="compose-box-avatar"
    aria-label="Profile for {accessibleName}">
   <Avatar account={verifyCredentials} size="small"/>
 </a>
-<a class="compose-box-display-name" href="/accounts/{verifyCredentials.id}">
+<a class="compose-box-display-name" href="/accounts/{verifyCredentials.id}" rel="prefetch">
   <AccountDisplayName account={verifyCredentials} />
 </a>
 <span class="compose-box-handle">

--- a/src/routes/_components/profile/AccountProfileDetails.html
+++ b/src/routes/_components/profile/AccountProfileDetails.html
@@ -11,6 +11,7 @@
   <a class="account-profile-details-item"
      href='/accounts/{account.id}/follows'
      aria-label={followingLabel}
+     rel="prefetch"
   >
     <span class="account-profile-details-item-title">
       Follows
@@ -22,6 +23,7 @@
   <a class="account-profile-details-item"
      href='/accounts/{account.id}/followers'
      aria-label={followersLabel}
+     rel="prefetch"
   >
     <span class="account-profile-details-item-title">
       Followers

--- a/src/routes/_components/search/SearchResult.html
+++ b/src/routes/_components/search/SearchResult.html
@@ -1,5 +1,5 @@
 <li class="search-result">
-  <a {href} class="search-result-anchor">
+  <a {href} class="search-result-anchor" rel="prefetch">
     <slot></slot>
   </a>
 </li>

--- a/src/routes/_components/settings/SettingsListButton.html
+++ b/src/routes/_components/settings/SettingsListButton.html
@@ -1,4 +1,4 @@
-<a {href} aria-label={ariaLabel || label} class="settings-list-button {className ? className : ''}">
+<a {href} rel="prefetch" aria-label={ariaLabel || label} class="settings-list-button {className ? className : ''}">
   <span>
     {label}
   </span>

--- a/src/routes/_components/settings/SettingsNavItem.html
+++ b/src/routes/_components/settings/SettingsNavItem.html
@@ -1,5 +1,6 @@
 <a class="settings-nav-item {className}"
    aria-label={ariaLabel}
+   rel="prefetch"
    {href} >
   {label}
 </a>

--- a/src/routes/_components/status/StatusAuthorName.html
+++ b/src/routes/_components/status/StatusAuthorName.html
@@ -1,4 +1,5 @@
 <a class="status-author-name {isStatusInNotification ? 'status-in-notification' : '' } {isStatusInOwnThread ? 'status-in-own-thread' : ''}"
+   rel="prefetch"
    href="/accounts/{originalAccountId}"
    title="{'@' + originalAccount.acct}"
    focus-key={focusKey}

--- a/src/routes/_components/status/StatusDetails.html
+++ b/src/routes/_components/status/StatusDetails.html
@@ -25,6 +25,7 @@
     {/if}
   {/if}
   <a class="status-favs-reblogs status-reblogs"
+     rel="prefetch"
      href="/statuses/{originalStatusId}/reblogs"
      aria-label={reblogsLabel}>
     <svg class="status-favs-reblogs-svg">
@@ -33,6 +34,7 @@
     <span>{numReblogs}</span>
   </a>
   <a class="status-favs-reblogs status-favs"
+     rel="prefetch"
      href="/statuses/{originalStatusId}/favorites"
      aria-label={favoritesLabel}>
     <svg class="status-favs-reblogs-svg">

--- a/src/routes/_components/status/StatusHeader.html
+++ b/src/routes/_components/status/StatusHeader.html
@@ -13,6 +13,7 @@
       </span>
     {:else}
       <a href="/accounts/{accountId}"
+         rel="prefetch"
          class="status-header-author"
          title="{'@' + account.acct}"
          focus-key={focusKey} >

--- a/src/routes/_components/status/StatusMentions.html
+++ b/src/routes/_components/status/StatusMentions.html
@@ -8,6 +8,7 @@
           <!-- empty space -->
         {/if}
         <a href="/accounts/{mention.id}"
+           rel="prefetch"
            title="@{mention.acct}"
            focus-key="status-mention-link-{uuid}-{mention.id}">
           @{mention.username}

--- a/src/routes/_components/status/StatusRelativeDate.html
+++ b/src/routes/_components/status/StatusRelativeDate.html
@@ -1,5 +1,6 @@
 <a class="status-relative-date {isStatusInNotification ? 'status-in-notification' : '' }"
    href="/statuses/{originalStatusId}"
+   rel="prefetch"
    focus-key={focusKey}
 >
   <time datetime={createdAtDate} title={absoluteFormattedDate}

--- a/src/routes/_components/status/StatusSidebar.html
+++ b/src/routes/_components/status/StatusSidebar.html
@@ -1,4 +1,5 @@
 <a class="status-sidebar size-{size}"
+   rel="prefetch"
    href="/accounts/{originalAccountId}"
    focus-key={focusKey}
    aria-hidden="true"

--- a/src/routes/_pages/settings/instances/index.html
+++ b/src/routes/_pages/settings/instances/index.html
@@ -24,10 +24,10 @@
     </SettingsListRow>
     {/each}
   </SettingsList>
-  <p><a href="/settings/instances/add">Add another instance</a></p>
+  <p><a rel="prefetch" href="/settings/instances/add">Add another instance</a></p>
   {:else}
   <p>You're not logged in to any instances.</p>
-  <p><a href="/settings/instances/add">Log in to an instance</a> to start using Pinafore.</p>
+  <p><a rel="prefetch" href="/settings/instances/add">Log in to an instance</a> to start using Pinafore.</p>
   {/if}
 </SettingsLayout>
 <style>


### PR DESCRIPTION
Not sure why I didn't do this before. I guess I assumed that because we were using Service Worker already, there was little point in prefetching internal links. But it seems to make sense anyway, because there's still the fetching from the cache and the compilation and bootstrapping we can do in advance, e.g. when the user hovers over a link.

Probably needs a bit of testing to be sure, but seems like a good perf tweak.