### PR TITLE
fix: increase cache, use csp checksums over nonce

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "terser-webpack-plugin": "^1.2.1",
     "text-encoding": "^0.7.0",
     "tiny-queue": "^0.2.1",
-    "uuid": "^3.3.2",
     "web-animations-js": "^2.3.1",
     "webpack": "^4.29.0",
     "webpack-bundle-analyzer": "^3.0.3"

--- a/src/server/sapperInlineScriptChecksums.js
+++ b/src/server/sapperInlineScriptChecksums.js
@@ -1,0 +1,21 @@
+// TODO: this is a hacky solution to generating checksums for Sapper's inline scripts.
+// I determined this by running `sapper export` and then checking all unique inline scripts.
+// Really, this ought to be built into Sapper somehow.
+
+import crypto from 'crypto'
+
+let scripts = [
+  `__SAPPER__={baseUrl:"",preloaded:[{},{}]};`,
+  `__SAPPER__={baseUrl:"",preloaded:[{}]};`,
+  `__SAPPER__={baseUrl:"",preloaded:[{},null,null,{}]};`,
+  `__SAPPER__={baseUrl:"",preloaded:[{},null,{}]};`
+]
+
+if (process.env.NODE_ENV === 'production') {
+  // sapper adds service worker only in production
+  scripts = scripts.map(script => `${script}if('serviceWorker' in navigator)navigator.serviceWorker.register('/service-worker.js');`)
+}
+
+export const sapperInlineScriptChecksums = scripts.map(script => {
+  return crypto.createHash('sha256').update(script).digest('base64')
+})


### PR DESCRIPTION
attempt to address #985

This is a somewhat hacky solution to the problem. I'm trying to avoid nonces in favor of checksums so that (presumably) Zeit's CDN (Cloudflare I think?) can cache the content more reliable.

TODO: core HTML files are still being served with cache-control max-age=600, which I believe is hard-coded in Sapper somewhere