### PR TITLE
fix: set max-age to 3600 for html

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,8 @@ import { sapperInlineScriptChecksums } from './server/sapperInlineScriptChecksum
 const { PORT = 4002 } = process.env
 const app = express()
 
+const MAX_AGE = 3600
+
 // this allows us to do e.g. `fetch('/_api/blog')` on the server
 global.fetch = (url, opts) => {
   if (url[0] === '/') {
@@ -50,14 +52,26 @@ app.use(coreHtmlFilesOnly(helmet({
 
 app.use(serveStatic('static', {
   setHeaders: (res) => {
-    res.setHeader('Cache-Control', 'public,max-age=3600')
+    res.setHeader('Cache-Control', `public,max-age=${MAX_AGE}`)
   }
 }))
 
 app.use(express.static('__sapper__/build/client/report.html'))
 app.use(express.static('__sapper__/build/client/stats.json'))
 
-app.use(sapper.middleware())
+// TODO: hack to override Sapper's default max-age of 600 for HTML files
+function overrideSetHeader (req, res, next) {
+  const origSetHeader = res.setHeader
+  res.setHeader = function (key, value) {
+    if (key === 'Cache-Control' && value === 'max-age=600') {
+      return origSetHeader.apply(this, ['Cache-Control', `max-age=${MAX_AGE}`])
+    }
+    return origSetHeader.apply(this, arguments)
+  }
+  return next()
+}
+
+app.use(overrideSetHeader, sapper.middleware())
 
 app.listen(PORT, () => {
   console.log(`listening on port ${PORT}`)


### PR DESCRIPTION
another attempt to address #985

This is a bit hacky, but we can override Sapper's default max-age of 600.