### PR TITLE
fix: remove deferred polyfill caching

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -24,7 +24,6 @@ const assets = __assets__
 // also contains '/index.html' for some reason
 const webpackAssets = __shell__
   .filter(filename => !filename.endsWith('.map')) // don't bother with sourcemaps
-  .filter(filename => !filename.includes('$polyfill$')) // polyfills are cached on-demand
 
 // `routes` is an array of `{ pattern: RegExp }` objects that
 // match the pages in your src
@@ -99,13 +98,6 @@ self.addEventListener('fetch', event => {
         if (response) {
           return response
         }
-      }
-      // for polyfills, cache them on-the-fly
-      if (url.pathname.includes('$polyfill$')) {
-        let response = await fetch(req)
-        // cache asynchronously, don't wait
-        caches.open(WEBPACK_ASSETS).then(cache => cache.put(req, response))
-        return response.clone()
       }
     }
 

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -6,15 +6,17 @@ const terser = require('./terser.config')
 const CircularDependencyPlugin = require('circular-dependency-plugin')
 const { mode, dev, resolve } = require('./shared.config')
 
-const output = config.client.output()
-
-// Zeit does not like filenames with "$" in them, so just keep things simple
-output.filename = '[hash]/[id].js'
-output.chunkFilename = '[hash]/[id].js'
+const output = Object.assign(config.client.output(), {
+  // enables HMR in workers
+  globalObject: 'this',
+  // Zeit does not like filenames with "$" in them, so just keep things simple
+  filename: '[hash]/[id].js',
+  chunkFilename: '[hash]/[id].js'
+})
 
 module.exports = {
   entry: config.client.entry(),
-  output: Object.assign(output, { globalObject: 'this' }), // enables HMR in workers
+  output,
   resolve,
   mode,
   module: {


### PR DESCRIPTION
As of #998 we can no longer rely on JS files containing "$", let alone "$polyfill$". This was a nice idea, but it's just not maintainable anymore nor does it provide a huge benefit.