### PR TITLE
fix: add some pages that "sapper export" missed

### DIFF
--- a/src/routes/_pages/blocked.html
+++ b/src/routes/_pages/blocked.html
@@ -1,5 +1,7 @@
 <DynamicPageBanner title="Blocked users" icon="#fa-ban" />
-<AccountsListPage {accountsFetcher} {accountActions} />
+{#if $isUserLoggedIn }
+  <AccountsListPage {accountsFetcher} {accountActions} />
+{/if}
 <script>
   import AccountsListPage from '../_components/AccountsListPage.html'
   import { store } from '../_store/store'

--- a/src/routes/_pages/muted.html
+++ b/src/routes/_pages/muted.html
@@ -1,5 +1,7 @@
 <DynamicPageBanner title="Muted users" icon="#fa-volume-off" />
-<AccountsListPage {accountsFetcher} {accountActions} />
+{#if $isUserLoggedIn }
+  <AccountsListPage {accountsFetcher} {accountActions} />
+{/if}
 <script>
   import AccountsListPage from '../_components/AccountsListPage.html'
   import { store } from '../_store/store'

--- a/src/routes/_pages/pinned.html
+++ b/src/routes/_pages/pinned.html
@@ -1,15 +1,17 @@
 <DynamicPageBanner title="Pinned toots" icon="#fa-thumb-tack" />
-<div class="pinned-toots-page">
-  {#if loading}
-  <LoadingPage />
-  {:elseif statuses && statuses.length}
-  <ul class="pinned-toots-results">
-    {#each statuses as status, index}
-    <StatusSearchResult {status} {index} length={statuses.length} />
-    {/each}
-  </ul>
-  {/if}
-</div>
+{#if $isUserLoggedIn }
+  <div class="pinned-toots-page">
+    {#if loading}
+    <LoadingPage />
+    {:elseif statuses && statuses.length}
+    <ul class="pinned-toots-results">
+      {#each statuses as status, index}
+      <StatusSearchResult {status} {index} length={statuses.length} />
+      {/each}
+    </ul>
+    {/if}
+  </div>
+{/if}
 <style>
   .pinned-toots-page {
     padding: 20px 20px;

--- a/src/routes/_pages/requests.html
+++ b/src/routes/_pages/requests.html
@@ -1,5 +1,7 @@
 <DynamicPageBanner title="Follow requests" icon="#fa-user-plus" />
-<AccountsListPage {accountsFetcher} {accountActions} />
+{#if $isUserLoggedIn }
+  <AccountsListPage {accountsFetcher} {accountActions} />
+{/if}
 <script>
   import AccountsListPage from '../_components/AccountsListPage.html'
   import { store } from '../_store/store'

--- a/src/routes/_pages/settings/about.html
+++ b/src/routes/_pages/settings/about.html
@@ -12,6 +12,15 @@
   <p>Icons provided by <ExternalLink href="http://fontawesome.io/">Font Awesome</ExternalLink>.</p>
 
   <p>Logo thanks to "sailboat" by Gregor Cresnar from <ExternalLink href="https://thenounproject.com/">the Noun Project</ExternalLink>.</p>
+
+  <div style="display: none">
+    <!-- TODO: this is just a hack so that `sapper export` knows to crawl these files -->
+    <a href="/muted">Muted</a>
+    <a href="/blocked">Blocked</a>
+    <a href="/pinned">Pinned</a>
+    <a href="/requests">Requests</a>
+    <a href="/share">Share</a>
+  </div>
 </SettingsLayout>
 <script>
   import SettingsLayout from '../../_components/settings/SettingsLayout.html'


### PR DESCRIPTION
Unfortunately it looks like `sapper export` works by crawling the
non-logged-in site, which means that any pages that are inaccessible
when you're not logged in don't get generated, including "pinned,"
"muted," "blocked," "requests," and "share."

Normally this isn't a problem, but it is in browsers that don't
have Service Worker; you get a 404 when you try to refresh those pages.

My fix is to just add a hidden div that links to these pages. It's not
pretty, but it works.