### PR TITLE
fix: use fork of sapper for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rollup": "^1.1.2",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.4",
-    "sapper": "^0.25.0",
+    "sapper": "nolanlawson/sapper#for-pinafore-10",
     "serve-static": "^1.13.2",
     "stringz": "^1.0.0",
     "svelte": "^2.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,6 +3758,11 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-link-header@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/http-link-header/-/http-link-header-1.0.2.tgz#bea50f02e1c7996021f1013b428c63f77e0f4e11"
+  integrity sha512-z6YOZ8ZEnejkcCWlGZzYXNa6i+ZaTfiTg3WhlV/YvnNya3W/RbX1bMVUMTuCrg/DrtTCQxaFCkXCz4FtLpcebg==
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -6457,12 +6462,12 @@ sanitize-filename@^1.6.0:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-sapper@^0.25.0:
+sapper@nolanlawson/sapper#for-pinafore-10:
   version "0.25.0"
-  resolved "https://registry.yarnpkg.com/sapper/-/sapper-0.25.0.tgz#cdda18588d063e10ef464aa77d19669eb01481d4"
-  integrity sha512-qnGPJVYxnGbYnjA4Wu5dHmrr/lsfl/4GfnPTns5O3yOEOcfCPnuTgNtE1juzPzQqG5GUZCyTQ/k5YrpoS1M9fw==
+  resolved "https://codeload.github.com/nolanlawson/sapper/tar.gz/22160f7a7b8fbd39ed037150338236074d69fc2d"
   dependencies:
     html-minifier "^3.5.20"
+    http-link-header "^1.0.2"
     shimport "0.0.11"
     source-map-support "^0.5.9"
     sourcemap-codec "^1.4.3"


### PR DESCRIPTION
Going to temporarily go back to using a fork of Sapper because I would like to get these PRs in (especially the link rel=preload one):

- https://github.com/sveltejs/sapper/pull/566
- https://github.com/sveltejs/sapper/pull/568