### PR TITLE
fix: fix missing export pages in node v8

### DIFF
--- a/src/routes/_pages/community/index.html
+++ b/src/routes/_pages/community/index.html
@@ -76,6 +76,14 @@
   </FreeTextLayout>
 </HiddenFromSSR>
 {/if}
+<div style="display: none">
+  <!-- TODO: this is just a hack so that `sapper export` knows to crawl these files -->
+  <a href="/muted">Muted</a>
+  <a href="/blocked">Blocked</a>
+  <a href="/pinned">Pinned</a>
+  <a href="/requests">Requests</a>
+  <a href="/share">Share</a>
+</div>
 <style>
   .community-page {
     margin: 20px;

--- a/src/routes/_pages/settings/about.html
+++ b/src/routes/_pages/settings/about.html
@@ -13,14 +13,6 @@
 
   <p>Logo thanks to "sailboat" by Gregor Cresnar from <ExternalLink href="https://thenounproject.com/">the Noun Project</ExternalLink>.</p>
 
-  <div style="display: none">
-    <!-- TODO: this is just a hack so that `sapper export` knows to crawl these files -->
-    <a href="/muted">Muted</a>
-    <a href="/blocked">Blocked</a>
-    <a href="/pinned">Pinned</a>
-    <a href="/requests">Requests</a>
-    <a href="/share">Share</a>
-  </div>
 </SettingsLayout>
 <script>
   import SettingsLayout from '../../_components/settings/SettingsLayout.html'


### PR DESCRIPTION
For reasons that are mysterious to me, #1000 works in Node v10 but not v8. And Zeit runs v8. Moving the hidden links to a different page fixes it. ¯\\\_(ツ)_/¯