### PR TITLE
chore: use a script to generate the now.json

### DIFF
--- a/bin/build-now-json.js
+++ b/bin/build-now-json.js
@@ -1,0 +1,111 @@
+// create the now.json file
+// Unfortunately this has to be re-run periodically, as AFAICT there is no way to
+// give Zeit a script and tell them to run that, instead of using a static now.json file.
+
+import path from 'path'
+import fs from 'fs'
+import { promisify } from 'util'
+import { routes } from '../__sapper__/service-worker'
+import cloneDeep from 'lodash-es/cloneDeep'
+import inlineScriptChecksum from '../src/inline-script/checksum'
+import { sapperInlineScriptChecksums } from '../src/server/sapperInlineScriptChecksums'
+
+const writeFile = promisify(fs.writeFile)
+
+const JSON_TEMPLATE = {
+  'version': 2,
+  'env': {
+    'NODE_ENV': 'production'
+  },
+  'builds': [
+    {
+      'src': 'package.json',
+      'use': '@now/static-build',
+      'config': {
+        'distDir': '__sapper__/export'
+      }
+    }
+  ],
+  'routes': [
+    {
+      'src': '^/service-worker\\.js$',
+      'headers': {
+        'cache-control': 'public,max-age=0'
+      }
+    },
+    {
+      'src': '^/(report\\.html|stats\\.json)$',
+      'headers': {
+        'cache-control': 'public,max-age=3600'
+      },
+      'dest': 'client/$1'
+    },
+    {
+      'src': '^/client/.*\\.(js|css|map)$',
+      'headers': {
+        'cache-control': 'public,max-age=31536000,immutable'
+      }
+    },
+    {
+      'src': '^/.*\\.(png|css|json|svg|jpe?g|map|txt)$',
+      'headers': {
+        'cache-control': 'public,max-age=3600'
+      }
+    }
+  ]
+}
+
+const HTML_HEADERS = {
+  'cache-control': 'public,max-age=3600',
+  'content-security-policy': `script-src 'self' ` +
+    `${[inlineScriptChecksum].concat(sapperInlineScriptChecksums).map(_ => `'sha256-${_}'`).join(' ')}; ` +
+    `worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'`,
+  'referrer-policy': 'no-referrer',
+  'strict-transport-security': 'max-age=15552000; includeSubDomains',
+  'x-content-type-options': 'nosniff',
+  'x-download-options': 'noopen',
+  'x-frame-options': 'SAMEORIGIN',
+  'x-xss-protection': '1; mode=block'
+}
+
+async function main () {
+  let json = cloneDeep(JSON_TEMPLATE)
+
+  let exportDir = path.resolve(__dirname, '../__sapper__/export')
+
+  for (let { pattern } of routes) {
+    let route = {
+      src: pattern.source,
+      headers: cloneDeep(HTML_HEADERS)
+    }
+
+    // remove all the regexy stuff in the regex
+    let filename = pattern.source.replace(/^\^\\\//, '').replace(/(\\\/)?\?\$$/, '').replace(/\\\//g, '/')
+
+    // try two different possible paths
+    let filePath = [
+      `${filename}.html`,
+      path.join(filename, 'index.html')
+    ].map(_ => path.resolve(exportDir, _)).find(_ => fs.existsSync(_))
+
+    if (!filePath) { // dynamic route, e.g. /accounts/<accountId/
+      // serve calls to dynamic routes via the generic "service worker" index.html,
+      // since we can't generate the dynamic content using Zeit's static server
+      route.dest = 'service-worker-index.html'
+    }
+    json.routes.push(route)
+  }
+
+  // push a generic route to handle everything else
+  json.routes.push({
+    src: '^/(.*)',
+    headers: cloneDeep(HTML_HEADERS)
+  })
+
+  await writeFile(path.resolve(__dirname, '../now.json'), JSON.stringify(json, null, '  '), 'utf8')
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/now.json
+++ b/now.json
@@ -39,7 +39,367 @@
       }
     },
     {
-      "src": "^/(accounts/[^/]+(/(follows|followers))?|statuses/[^/]+(/(reblogs|favorites))?|(lists|tags)/[^/]+|settings/instances/[^/.]+\\.[^/]+)$",
+      "src": "^\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/notifications\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/community\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/favorites\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/federated\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/accounts\\/([^\\/]+?)\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/accounts\\/([^\\/]+?)\\/followers\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/accounts\\/([^\\/]+?)\\/follows\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/requests\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/settings\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/settings\\/quick-login\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/settings\\/instances\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/settings\\/instances\\/add\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/settings\\/instances\\/([^\\/]+?)\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/settings\\/general\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/settings\\/hotkeys\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/settings\\/about\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/statuses\\/([^\\/]+?)\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/statuses\\/([^\\/]+?)\\/favorites\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/statuses\\/([^\\/]+?)\\/reblogs\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/blocked\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/pinned\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/search\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/lists\\/([^\\/]+?)\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      },
+      "dest": "service-worker-index.html"
+    },
+    {
+      "src": "^\\/local\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/muted\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/share\\/?$",
+      "headers": {
+        "cache-control": "public,max-age=3600",
+        "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",
+        "referrer-policy": "no-referrer",
+        "strict-transport-security": "max-age=15552000; includeSubDomains",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block"
+      }
+    },
+    {
+      "src": "^\\/tags\\/([^\\/]+?)\\/?$",
       "headers": {
         "cache-control": "public,max-age=3600",
         "content-security-policy": "script-src 'self' 'sha256-EkTiuvkFbkHUWPvTnH6v0H2/i/09DGGwDOyFPJKCYnw=' 'sha256-Rv0XCoOhq4H0QyKE7rEhr+e9GI5gsmGcC04fY0HPORc=' 'sha256-28NJWgGMi7z1BsySG4SYZCjth/ys7dkElS3oIl5ZEqM=' 'sha256-nUHIts9QUqQq4nfffteH1WG3ZeWESwmxZn6bWMNWsiM=' 'sha256-MGLg9fH15qQqEcT+iTfwx/cfVp2MgjSrVt08u3NVKa8=' 'sha256-OQjxgqHHnjfZwkCEsAo2MRjd3GuPmg+RvmjrZd35TN4=' 'sha256-sS3nggZVNGyoYqI7U/PSwnwI4CymIdHNgJwW49qztWo=' 'sha256-aASq1hOJ8PP2cfK9QGXaCLdqgtkDXDb5VFXlSyrpX/M=' 'sha256-1ujkGrbsh0Yx/bquh2I9gkG1ZaZetCkjre6vciK2u7U='; worker-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'none'; object-src 'none'; manifest-src 'self'",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "print-export-info": "node ./bin/print-export-info.js",
     "export-steps": "run-s before-build sapper-export print-export-info",
     "export": "cross-env NODE_ENV=production run-s export-steps",
-    "now-build": "run-s export"
+    "now-build": "run-s export",
+    "build-now-json": "node -r esm ./bin/build-now-json.js"
   },
   "dependencies": {
     "@gamestdio/websocket": "^0.3.1",


### PR DESCRIPTION
This makes the `now.json` slightly less hacky by generating it rather than writing a bespoke regex to try to catch everything.

This also opens up the possibility of maybe injecting link rel=prefetch headers and CSP checksums into the individual headers for individual HTML files, but I can't get it working right now, because what I build locally ends up with a different Webpack checksums in the filepaths than what Zeit generates on their server.