### PR TITLE
fix: remove __fakeFileInput, clean up on destroy

### DIFF
--- a/src/routes/_components/compose/ComposeToolbar.html
+++ b/src/routes/_components/compose/ComposeToolbar.html
@@ -54,14 +54,10 @@
 
   export default {
     oncreate () {
-      // for testing
-      window.__fakeFileInput = (file) => {
-        this.onFileChange({
-          target: {
-            files: [file]
-          }
-        })
-      }
+      window.__composeToolbar = this // for testing
+    },
+    ondestroy () {
+      window.__composeToolbar = null
     },
     components: {
       IconButton,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -131,7 +131,9 @@ export const uploadKittenImage = i => (exec(() => {
   let image = images[`kitten${i}`]
   let blob = blobUtils.base64StringToBlob(image.data, 'image/png')
   blob.name = image.name
-  window.__fakeFileInput(blob)
+  window.__composeToolbar.onFileChange({
+    target: { files: [blob] }
+  })
 }, {
   dependencies: {
     images,


### PR DESCRIPTION
It still makes me nervous to have this in production, but at least this way the component cleans up memory when it's destroyed.