### PR TITLE
fix: fix timeline jumping on focus

### DIFF
--- a/src/routes/_components/compose/ComposeInput.html
+++ b/src/routes/_components/compose/ComposeInput.html
@@ -88,7 +88,7 @@
             firstTime = false
             let { autoFocus } = this.get()
             if (autoFocus) {
-              requestAnimationFrame(() => textarea.focus())
+              requestAnimationFrame(() => textarea.focus({ preventScroll: true }))
             }
           }
         })

--- a/src/routes/_components/status/StatusToolbar.html
+++ b/src/routes/_components/status/StatusToolbar.html
@@ -144,7 +144,7 @@
         }
         try {
           // return status to the reply button after posting a reply
-          this.refs.node.querySelector('.status-toolbar-reply-button').focus()
+          this.refs.node.querySelector('.status-toolbar-reply-button').focus({ preventScroll: true })
         } catch (e) { /* ignore */ }
       }
     },

--- a/src/routes/_components/timeline/Timeline.html
+++ b/src/routes/_components/timeline/Timeline.html
@@ -283,7 +283,7 @@
           requestAnimationFrame(() => {
             let element = document.querySelector(lastFocusedElementSelector)
             if (element) {
-              element.focus()
+              element.focus({ preventScroll: true })
             }
           })
         })


### PR DESCRIPTION
This should fix #840. I can't see any reason why we would want it to scroll when we're focusing these things.