### PR TITLE
fix: when building, use a port unlikely to be in use

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "deploy-dev": "DEPLOY_TYPE=dev ./bin/deploy.sh",
     "deploy-all-travis": "./bin/deploy-all-travis.sh",
     "backup-mastodon-data": "./bin/backup-mastodon-data.sh",
-    "sapper-export": "cross-env PORT=4002 sapper export",
+    "sapper-export": "cross-env PORT=22939 sapper export",
     "print-export-info": "node ./bin/print-export-info.js",
     "export-steps": "run-s before-build sapper-export print-export-info",
     "export": "cross-env NODE_ENV=production run-s export-steps",


### PR DESCRIPTION
Right now if you run `yarn build` while port 4002 is in use, it will
fail. Let's just pick a random port that's unlikely to be used by any
self-hosters. I chose a random 5-digit number.