### PR TITLE
chore: don't let now ignore robots.txt

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -5,7 +5,6 @@
 /mastodon.log
 /src/template.html
 /static/*.css
-/static/robots.txt
 /static/inline-script.js.map
 /static/emoji-mart-all.json
 /src/inline-script/checksum.js


### PR DESCRIPTION
I want dev.pinafore.social to be ignored by search engines