### PR TITLE
perf: reduce install size using yarn --production

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to Pinafore
 
+## Installing
+
+To install with dev dependencies, run:
+
+    yarn
+
 ## Dev server
 
 To run a dev server with hot reloading:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update --no-cache --virtual build-dependencies git python build-ba
 # Install yarn
  && npm i yarn -g \
 # Install Pinafore
- && yarn --pure-lockfile \
+ && yarn --production --pure-lockfile \
  && yarn build \
  && rm -rf ./src \
 # Cleanup

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Pinafore requires [Node.js](https://nodejs.org/en/) v8+ and [Yarn](https://yarnp
 
 To build Pinafore for production, first install dependencies:
 
-    yarn --pure-lockfile
+    yarn --production --pure-lockfile
 
 Then build:
 


### PR DESCRIPTION
node_modules size when not running `--production`: 296M
node_modules size with `--production`: 111M

Related: #1064 