### PR TITLE
Clean yarn cache during docker image build phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --update --no-cache --virtual build-dependencies git python build-ba
 # Install Pinafore
  && yarn --production --pure-lockfile \
  && yarn build \
+ && yarn cache clean \
  && rm -rf ./src \
 # Cleanup
  && apk del build-dependencies


### PR DESCRIPTION
Cleaning cache allows reduce image size from 388M to 189M