### PR TITLE
Fix reversed base62 encoding

### DIFF
--- a/src/routes/_utils/statusIdSorting.js
+++ b/src/routes/_utils/statusIdSorting.js
@@ -6,8 +6,7 @@ import { padStart } from './lodash-lite'
 
 // Unfortunately base62 ordering is not the same as JavaScript's default ASCII ordering,
 // used both for JS string comparisons as well as IndexedDB ordering.
-const BASE62_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-const ASCII_ORDERING = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+const BASE62_ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
 const MAX_ID_LENGTH = 30 // assume that Mastodon/Pleroma IDs won't get any bigger than this
 
 const BASE62_LOOKUP = new Map(BASE62_ALPHABET.split('').map((char, i) => ([char, i])))
@@ -17,14 +16,7 @@ export function zeroPad (str, toSize) {
 }
 
 export function toPaddedBigInt (id) {
-  let asciiOrdered = ''
-  for (let i = 0; i < id.length; i++) {
-    let char = id.charAt(i)
-    let idx = BASE62_LOOKUP.get(char)
-    let asciiChar = ASCII_ORDERING[idx]
-    asciiOrdered += asciiChar
-  }
-  return zeroPad(asciiOrdered, MAX_ID_LENGTH)
+  return zeroPad(id, MAX_ID_LENGTH)
 }
 
 export function toReversePaddedBigInt (id) {
@@ -34,7 +26,7 @@ export function toReversePaddedBigInt (id) {
     let char = padded.charAt(i)
     let idx = BASE62_LOOKUP.get(char)
     let reverseIdx = BASE62_ALPHABET.length - 1 - idx
-    reversed += ASCII_ORDERING[reverseIdx]
+    reversed += BASE62_ALPHABET[reverseIdx]
   }
   return reversed
 }

--- a/tests/unit/test-id-sorting.js
+++ b/tests/unit/test-id-sorting.js
@@ -56,10 +56,10 @@ describe('test-id-sorting.js', () => {
 
   it('can sort base62 IDs correctly', () => {
     let id1 = '0'
-    let id2 = 'a'
-    let id3 = 't'
-    let id4 = 'A'
-    let id5 = 'Z'
+    let id2 = 'A'
+    let id3 = 'Z'
+    let id4 = 'a'
+    let id5 = 't'
 
     lt(toPaddedBigInt(id1), toPaddedBigInt(id2))
     lt(toPaddedBigInt(id2), toPaddedBigInt(id3))
@@ -99,17 +99,17 @@ describe('test-id-sorting.js', () => {
     let ids = [
       '9gP7cpqqJWyp93GxRw',
       '9gP7p4Ng7RdTgOSsro',
-      '9gP8eQQFvdZgoQ9tw0',
       '9gP8XTjVDpsT3Iqgb2',
+      '9gP8eQQFvdZgoQ9tw0',
       '9gP99enEY6IAMJnaXA',
       '9gP9WIcp8QCIGbj6ES',
       '9gPA897muEuxo0FxCa',
+      '9gPAG1uvaSBblj05Y0',
       '9gPAaSqTB8Rv4nev0C',
       '9gPAhfTCdeRCG5D9IO',
-      '9gPAG1uvaSBblj05Y0',
-      '9gPBatpwvN76kABf7Y',
       '9gPBA9SYjPFVNUUZTU',
       '9gPBOzteZJZO3wFCQy',
+      '9gPBatpwvN76kABf7Y',
       '9gPC7jAtaS1vEQdcnY',
       '9gPC9Ps4KQMLwRdZWy',
       '9gPCF0G8SvCKFHYg52',


### PR DESCRIPTION
Pleroma uses numbers, upper case, and then lower case for its ordering for base62.