### PR TITLE
Fix author mention in posts that aren't replies

### DIFF
--- a/src/routes/_actions/compose.js
+++ b/src/routes/_actions/compose.js
@@ -11,7 +11,7 @@ export async function insertHandleForReply (statusId) {
   let status = await database.getStatus(currentInstance, statusId)
   let { currentVerifyCredentials } = store.get()
   let originalStatus = status.reblog || status
-  let accounts = [originalStatus.account].concat(originalStatus.mentions || [])
+  let accounts = [originalStatus.account].concat(originalStatus.mentions.filter((mention) => mention.id !== originalStatus.account.id) || [])
     .filter(account => account.id !== currentVerifyCredentials.id)
   if (!store.getComposeData(statusId, 'text') && accounts.length) {
     store.setComposeData(statusId, {

--- a/src/routes/_components/status/StatusMentions.html
+++ b/src/routes/_components/status/StatusMentions.html
@@ -38,7 +38,7 @@
 <script>
   export default {
     computed: {
-      mentions: ({ originalStatus }) => originalStatus.mentions || []
+      mentions: ({ originalStatus }) => originalStatus.mentions.filter((mention) => mention.id === originalStatus.in_reply_to_account_id || mention.id !== originalStatus.account.id) || []
     }
   }
 </script>


### PR DESCRIPTION
It appears that, at least Pleroma, always includes the author of a post in the list of mentions. This appears to cause two, related issues:

1. In a post with a CW that is not a reply, the author will be shown in StatusMentions even though the post is not a reply and even if the status content does not contain an explicit self-mention.
2. When clicking reply, the compose dialog auto-populates two mentions of the author of the in-reply-to post. It makes sense to ensure that the author goes into the mentioned accounts, so it makes sense to filter out the author if they are also listed in the mentions array.
