### PR TITLE
perf: remove stats.json from webpack

### DIFF
--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -94,15 +94,10 @@ module.exports = {
     })
   ] : [
 
-    new BundleAnalyzerPlugin({ // generates report.html and stats.json
+    new BundleAnalyzerPlugin({ // generates report.html
       analyzerMode: 'static',
-      generateStatsFile: true,
-      statsOptions: {
-        // allows usage with http://chrisbateman.github.io/webpack-visualizer/
-        chunkModules: true
-      },
       openAnalyzer: false,
-      logLevel: 'silent' // do not bother Webpacker, who runs with --json and parses stdout
+      logLevel: 'silent'
     })
   ]),
   devtool: dev ? 'inline-source-map' : 'source-map',


### PR DESCRIPTION
I was not ever really looking at this, and it seems to add compilation time