### PR TITLE
fix: remove no longer needed `initial-scale=1`

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8' >
-  <meta name="viewport" content="width=device-width, initial-scale=1" >
+  <meta name="viewport" content="width=device-width" >
   <meta id='theThemeColor' name='theme-color' content='#4169e1' >
   <meta name="description" content="An alternative web client for Mastodon, focused on speed and simplicity." >
 


### PR DESCRIPTION
`initial-scale=1` was a workaround for a orientation change bug, that was only needed for the no longer relevant Safari for iOS < 9.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref:

  * https://www.quirksmode.org/blog/archives/2013/10/more_about_scal.html
  * https://twitter.com/ppk/status/829329567219343360