### PR TITLE
Enable PWA support for iOS devices

### DIFF
--- a/src/inline-script/inline-script.js
+++ b/src/inline-script/inline-script.js
@@ -50,3 +50,13 @@ if (hasLocalStorage && localStorage.store_disableCustomScrollbars === 'true') {
 if (/mac/i.test(navigator.platform)) {
   document.documentElement.style.setProperty('--scrollbar-border-radius', '50px')
 }
+
+// Versions of iOS Safari before iOS 12.2 do not work properly as a PWA
+// for cross-origin authentication: https://github.com/nolanlawson/pinafore/issues/45
+// Here we sniff for iOS <12.2 by checking for the existence of a native IntersectionObserver
+// function, which was added in 12.2.
+if (/iP(?:hone|ad|od)/.test(navigator.userAgent) &&
+  !(typeof IntersectionObserver === 'function' &&
+    IntersectionObserver.toString().includes('[native code]'))) {
+  document.head.removeChild(document.getElementById('theManifest'))
+}

--- a/src/inline-script/inline-script.js
+++ b/src/inline-script/inline-script.js
@@ -50,9 +50,3 @@ if (hasLocalStorage && localStorage.store_disableCustomScrollbars === 'true') {
 if (/mac/i.test(navigator.platform)) {
   document.documentElement.style.setProperty('--scrollbar-border-radius', '50px')
 }
-
-// TODO: remove this hack when Safari works with cross-origin window.open()
-// in a PWA: https://github.com/nolanlawson/pinafore/issues/45
-if (/iP(?:hone|ad|od)/.test(navigator.userAgent)) {
-  document.head.removeChild(document.getElementById('theManifest'))
-}


### PR DESCRIPTION
With the release of iOS 12.2, the OAuth PWA workflow can work. I tested it on my iPhone and iPad.

Closes #1058