### PR TITLE
fix: add placeholder icon for opengraph cards without images

### DIFF
--- a/bin/svgs.js
+++ b/bin/svgs.js
@@ -46,5 +46,6 @@ module.exports = [
   { id: 'fa-search-plus', src: 'src/thirdparty/font-awesome-svg-png/white/svg/search-plus.svg' },
   { id: 'fa-share-square-o', src: 'src/thirdparty/font-awesome-svg-png/white/svg/share-square-o.svg' },
   { id: 'fa-flag', src: 'src/thirdparty/font-awesome-svg-png/white/svg/flag.svg' },
-  { id: 'fa-suitcase', src: 'src/thirdparty/font-awesome-svg-png/white/svg/suitcase.svg' }
+  { id: 'fa-suitcase', src: 'src/thirdparty/font-awesome-svg-png/white/svg/suitcase.svg' },
+  { id: 'fa-file-text', src: 'src/thirdparty/font-awesome-svg-png/white/svg/file-text.svg' }
 ]

--- a/src/routes/_components/status/StatusCard.html
+++ b/src/routes/_components/status/StatusCard.html
@@ -2,10 +2,13 @@
     <strong class="card-title">
      {title}
     </strong>
-  {#if hasBody}
+  {#if description}
     <div class="card-content">
   {#if imageUrl}
     <LazyImage forceSize={true} height="50" width="50" src={imageUrl} ariaHidden={true} />
+  {:else}
+    <SvgIcon style="width: 30px; height: 30px; padding: 10px; fill: var(--action-button-deemphasized-fill-color);"
+             href="#fa-file-text" />
   {/if}
   {#if description}
     <span class="card-description">
@@ -73,10 +76,12 @@
 
 </style>
 <script>
-  import LazyImage from '../LazyImage'
+  import LazyImage from '../LazyImage.html'
+  import SvgIcon from '../SvgIcon.html'
 
   export default {
     components: {
+      SvgIcon,
       LazyImage
     },
     computed: {
@@ -84,8 +89,7 @@
       title: ({ card }) => card.title,
       url: ({ card }) => card.url,
       description: ({ card }) => card.description || card.provider_name,
-      imageUrl: ({ card }) => card.image,
-      hasBody: ({ description, imageUrl }) => description && imageUrl
+      imageUrl: ({ card }) => card.image
     }
   }
 </script>


### PR DESCRIPTION
I don't like that opengraph cards without images don't show any description. So this adds a little placeholder icon like what Mastodon uses.