### PR TITLE
Add a setting to reload the page

### DIFF
--- a/src/routes/_components/settings/SettingsListButton.html
+++ b/src/routes/_components/settings/SettingsListButton.html
@@ -1,4 +1,4 @@
-<a {href} rel="prefetch" aria-label={ariaLabel || label} class="settings-list-button {className ? className : ''}">
+<a {href} on:click="fire('click', event)" rel="prefetch" aria-label={ariaLabel || label} class="settings-list-button {className ? className : ''}">
   <span>
     {label}
   </span>

--- a/src/routes/_pages/settings/index.html
+++ b/src/routes/_pages/settings/index.html
@@ -12,7 +12,7 @@
       <SettingsListButton href="/settings/hotkeys" label="Hotkeys"/>
     </SettingsListRow>
     <SettingsListRow>
-    <SettingsListButton href="" on:click=reload(event) label="Reload"/>
+    <SettingsListButton href="#" on:click="reload(event)" label="Reload"/>
     </SettingsListRow>
     <SettingsListRow>
       <SettingsListButton href="/settings/about" label="About Pinafore"/>

--- a/src/routes/_pages/settings/index.html
+++ b/src/routes/_pages/settings/index.html
@@ -12,6 +12,9 @@
       <SettingsListButton href="/settings/hotkeys" label="Hotkeys"/>
     </SettingsListRow>
     <SettingsListRow>
+    <SettingsListButton href="" on:click=reload(event) label="Reload"/>
+    </SettingsListRow>
+    <SettingsListRow>
       <SettingsListButton href="/settings/about" label="About Pinafore"/>
     </SettingsListRow>
   </SettingsList>
@@ -29,6 +32,12 @@
       SettingsList,
       SettingsListRow,
       SettingsListButton
+    },
+    methods: {
+      reload (event) {
+        event.preventDefault()
+        document.location.reload(true)
+      }
     }
   }
 </script>


### PR DESCRIPTION
The iOS PWA version does not allow you to reload the page - even with killing the app. 

With this feature the user can reload for new versions of the app. It makes it possible to solve bad transient state issues as well.