### PR TITLE
Remove placeholder for cards without images

### DIFF
--- a/bin/svgs.js
+++ b/bin/svgs.js
@@ -46,6 +46,5 @@ module.exports = [
   { id: 'fa-search-plus', src: 'src/thirdparty/font-awesome-svg-png/white/svg/search-plus.svg' },
   { id: 'fa-share-square-o', src: 'src/thirdparty/font-awesome-svg-png/white/svg/share-square-o.svg' },
   { id: 'fa-flag', src: 'src/thirdparty/font-awesome-svg-png/white/svg/flag.svg' },
-  { id: 'fa-suitcase', src: 'src/thirdparty/font-awesome-svg-png/white/svg/suitcase.svg' },
-  { id: 'fa-file-text', src: 'src/thirdparty/font-awesome-svg-png/white/svg/file-text.svg' }
+  { id: 'fa-suitcase', src: 'src/thirdparty/font-awesome-svg-png/white/svg/suitcase.svg' }
 ]

--- a/src/routes/_components/status/StatusCard.html
+++ b/src/routes/_components/status/StatusCard.html
@@ -6,15 +6,10 @@
     <div class="card-content">
   {#if imageUrl}
     <LazyImage forceSize={true} height="50" width="50" src={imageUrl} ariaHidden={true} />
-  {:else}
-    <SvgIcon style="width: 30px; height: 30px; padding: 10px; fill: var(--action-button-deemphasized-fill-color);"
-             href="#fa-file-text" />
   {/if}
-  {#if description}
     <span class="card-description">
       {description}
     </span>
-  {/if}
   </div>
   {/if}
 </a>
@@ -41,7 +36,7 @@
     background: transparent;
   }
 
-  .status-card :first-child {
+  .status-card :first-child:not(span) {
     flex-shrink: 0;
   }
 
@@ -77,11 +72,9 @@
 </style>
 <script>
   import LazyImage from '../LazyImage.html'
-  import SvgIcon from '../SvgIcon.html'
 
   export default {
     components: {
-      SvgIcon,
       LazyImage
     },
     computed: {


### PR DESCRIPTION
It feels like a waste of space, especially when shown on mobile devices (as in the picture).

![Capture d'écran 2019-04-02 09 34 11](https://user-images.githubusercontent.com/263325/55402222-361c9480-5553-11e9-92cb-60833dec25b7.png)
![Capture d'écran 2019-04-02 09 34 40](https://user-images.githubusercontent.com/263325/55402223-36b52b00-5553-11e9-96d8-9ded3921bfbb.png)
