### PR TITLE
perf: render virtual list items lazily

### DIFF
--- a/src/routes/_components/virtualList/VirtualListLazyItem.html
+++ b/src/routes/_components/virtualList/VirtualListLazyItem.html
@@ -9,15 +9,20 @@
 <script>
   import VirtualListItem from './VirtualListItem'
   import { mark, stop } from '../../_utils/marks'
+  import { scheduleIdlePriorityTask } from '../../_utils/scheduleIdlePriorityTask'
 
   export default {
     async oncreate () {
-      let { makeProps, key } = this.get()
+      let { makeProps, key, index } = this.get()
       if (makeProps) {
         let props = await makeProps(key)
-        mark('VirtualListLazyItem set props')
-        this.set({ props: props })
-        stop('VirtualListLazyItem set props')
+        // render virtual list items lazily, by index, so that
+        // the earlier ones are rendered first
+        scheduleIdlePriorityTask(index, () => {
+          mark('VirtualListLazyItem set props')
+          this.set({ props: props })
+          stop('VirtualListLazyItem set props')
+        })
       }
     },
     data: () => ({

--- a/src/routes/_utils/scheduleIdlePriorityTask.js
+++ b/src/routes/_utils/scheduleIdlePriorityTask.js
@@ -1,0 +1,36 @@
+import { scheduleIdleTask } from './scheduleIdleTask'
+
+const tasks = []
+
+function binarySearchByPriority (arr, item) {
+  let low = 0
+  let high = arr.length
+  let mid
+  while (low < high) {
+    mid = (low + high) >>> 1
+    if (arr[mid].priority < item.priority) {
+      low = mid + 1
+    } else {
+      high = mid
+    }
+  }
+  return low
+}
+
+// schedule an idle task, but give it a priority so that it executes in a particular order.
+// lower integer == higher priority
+export function scheduleIdlePriorityTask (priority, func) {
+  let task = { priority, func }
+  let idx = binarySearchByPriority(tasks, task)
+  tasks.splice(idx, 0, task)
+  let runNextTask = () => {
+    let task = tasks.shift()
+    if (task) {
+      task.func()
+      if (tasks.length) {
+        scheduleIdleTask(runNextTask)
+      }
+    }
+  }
+  scheduleIdleTask(runNextTask)
+}


### PR DESCRIPTION
Based on my testing on Chrome on Android, this is a modest performance improvement. Rather than greedily render all virtual list items, we render them one-at-a-time inside of requestIdleCallback, being careful to render them in the right order so that it doesn't look weird.

This speeds up initial rendering of the timeline, because you don't have to wait for 20 items to render; you only have to wait for the top 1-3 or so.