### PR TITLE
chore: make greenkeeper ignore svelte for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
   },
   "greenkeeper": {
     "ignore": [
-      "sapper"
+      "sapper",
+      "svelte"
     ]
   },
   "repository": {


### PR DESCRIPTION
It is unlikely that we will update to Svelte v3 anytime soon, if ever. Our versions of Svelte/Sapper are probably frozen in time.