### PR TITLE
fix: fix autosuggested accounts order

### DIFF
--- a/src/routes/_actions/autosuggestAccountSearch.js
+++ b/src/routes/_actions/autosuggestAccountSearch.js
@@ -2,23 +2,17 @@ import { database } from '../_database/database'
 import { store } from '../_store/store'
 import { search } from '../_api/search'
 import { SEARCH_RESULTS_LIMIT } from '../_static/autosuggest'
-import { USERNAME_LOWERCASE } from '../_database/constants'
 import { concat } from '../_utils/arrays'
 import uniqBy from 'lodash-es/uniqBy'
 import { scheduleIdleTask } from '../_utils/scheduleIdleTask'
 
 const DATABASE_SEARCH_RESULTS_LIMIT = 30
 
-function byAccountRelevance (a, b) {
-  // accounts you're following go first
-  if (a.following !== b.following) {
-    return a.following ? -1 : 1
-  }
-  // after that, just sort by username
-  if (a[USERNAME_LOWERCASE] !== b[USERNAME_LOWERCASE]) {
-    return a[USERNAME_LOWERCASE] < b[USERNAME_LOWERCASE] ? -1 : 1
-  }
-  return 0
+function byUsername (a, b) {
+  let usernameA = a.acct.toLowerCase()
+  let usernameB = b.acct.toLowerCase()
+
+  return usernameA < usernameB ? -1 : usernameA === usernameB ? 0 : 1
 }
 
 function byAccountId (a) {
@@ -41,9 +35,22 @@ export function doAccountSearch (searchText) {
   }
 
   function mergeAndTruncateResults () {
-    return uniqBy(concat(localResults || [], remoteResults || []), byAccountId)
-      .sort(byAccountRelevance)
+    // Always include local results; they are more likely to be relevant
+    // because the user has seen their content before. Otherwise, sort by username.
+    let results = (localResults || [])
+      .slice()
+      .sort(byUsername)
       .slice(0, SEARCH_RESULTS_LIMIT)
+
+    if (results.length < SEARCH_RESULTS_LIMIT) {
+      let topRemoteResults = (remoteResults || [])
+        .sort(byUsername)
+        .slice(0, SEARCH_RESULTS_LIMIT - results.length)
+      results = concat(results, topRemoteResults)
+      results = uniqBy(results, byAccountId)
+    }
+
+    return results
   }
 
   function onNewResults () {


### PR DESCRIPTION
new order is local first, followed by remote, and each sorted alphabetically