### PR TITLE
fix: close/open websocket on freeze/resume events

### DIFF
--- a/bin/browser-shim.js
+++ b/bin/browser-shim.js
@@ -1,0 +1,9 @@
+// browser shims that run in node, so that page-lifecycle won't error
+global.self = global
+global.document = {
+  visibilityState: 'visible',
+  hasFocus: () => true,
+  wasDiscarded: false
+}
+global.addEventListener = () => {}
+global.removeEventListener = () => {}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "testcafe": "run-s testcafe-suite0 testcafe-suite1",
     "testcafe-suite0": "cross-env-shell testcafe --hostname localhost --skip-js-errors -c 4 $BROWSER tests/spec/0*",
     "testcafe-suite1": "cross-env-shell testcafe --hostname localhost --skip-js-errors $BROWSER tests/spec/1*",
-    "test-unit": "mocha -r esm tests/unit/",
+    "test-unit": "mocha -r esm -r bin/browser-shim.js tests/unit/",
     "wait-for-mastodon-to-start": "node -r esm bin/wait-for-mastodon-to-start.js",
     "wait-for-mastodon-data": "node -r esm bin/wait-for-mastodon-data.js",
     "deploy-prod": "DEPLOY_TYPE=prod ./bin/deploy.sh",

--- a/src/routes/_store/LocalStorageStore.js
+++ b/src/routes/_store/LocalStorageStore.js
@@ -1,6 +1,6 @@
 import { Store } from 'svelte/store'
 import { safeLocalStorage as LS } from '../_utils/safeLocalStorage'
-import { importPageLifecycle } from '../_utils/asyncModules'
+import lifecycle from 'page-lifecycle/dist/lifecycle.mjs'
 
 function safeParse (str) {
   return !str ? undefined : (str === 'undefined' ? undefined : JSON.parse(str))
@@ -31,13 +31,11 @@ export class LocalStorageStore extends Store {
       })
     })
     if (process.browser) {
-      importPageLifecycle().then(lifecycle => {
-        lifecycle.addEventListener('statechange', e => {
-          if (e.newState === 'passive') {
-            console.log('saving LocalStorageStore...')
-            this.save()
-          }
-        })
+      lifecycle.addEventListener('statechange', e => {
+        if (e.newState === 'passive') {
+          console.log('saving LocalStorageStore...')
+          this.save()
+        }
       })
     }
   }

--- a/src/routes/_utils/asyncModules.js
+++ b/src/routes/_utils/asyncModules.js
@@ -4,14 +4,6 @@ export const importTimeline = () => import(
   /* webpackChunkName: 'Timeline' */ '../_components/timeline/Timeline.html'
   ).then(getDefault)
 
-export const importPageLifecycle = () => import(
-  /* webpackChunkName: 'page-lifecycle' */ 'page-lifecycle/dist/lifecycle.mjs'
-  ).then(getDefault)
-
-export const importWebSocketClient = () => import(
-  /* webpackChunkName: '@gamestdio/websocket' */ '@gamestdio/websocket'
-  ).then(getDefault)
-
 export const importVirtualList = () => import(
   /* webpackChunkName: 'VirtualList.html' */ '../_components/virtualList/VirtualList.html'
   ).then(getDefault)

--- a/webpack/server.config.js
+++ b/webpack/server.config.js
@@ -3,11 +3,14 @@ const config = require('sapper/config/webpack.js')
 const pkg = require('../package.json')
 const { mode, dev, resolve, inlineSvgs } = require('./shared.config')
 
+const serverResolve = JSON.parse(JSON.stringify(resolve))
+serverResolve.alias['page-lifecycle/dist/lifecycle.mjs'] = 'lodash-es/noop' // page lifecycle fails in Node
+
 module.exports = {
   entry: config.server.entry(),
   output: config.server.output(),
   target: 'node',
-  resolve,
+  resolve: serverResolve,
   externals: Object.keys(pkg.dependencies),
   module: {
     rules: [


### PR DESCRIPTION
attempt to address #14

I can't prove for certain that this will fix the issue, but according to Google's [Page Lifecycle docs](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#developer-recommendations-for-each-state) this is the recommended approach.

I also got rid of the dynamic imports because they weren't saving us much.