### PR TITLE
fix: don't autosuggest when text ends with punctuation

### DIFF
--- a/src/routes/_store/computations/autosuggestComputations.js
+++ b/src/routes/_store/computations/autosuggestComputations.js
@@ -1,8 +1,11 @@
 import { get } from '../../_utils/lodash-lite'
 
 const MIN_PREFIX_LENGTH = 2
-const ACCOUNT_SEARCH_REGEX = new RegExp(`(?:\\s|^)(@\\S{${MIN_PREFIX_LENGTH},})$`)
-const EMOJI_SEARCH_REGEX = new RegExp(`(?:\\s|^)(:[^:]{${MIN_PREFIX_LENGTH},})$`)
+// Technically mastodon accounts allow dots, but it would be weird to do an autosuggest search if it ends with a dot.
+// Also this is rare. https://github.com/tootsuite/mastodon/pull/6844
+const VALID_ACCOUNT_AND_EMOJI_CHAR = '\\w'
+const ACCOUNT_SEARCH_REGEX = new RegExp(`(?:\\s|^)(@${VALID_ACCOUNT_AND_EMOJI_CHAR}{${MIN_PREFIX_LENGTH},})$`)
+const EMOJI_SEARCH_REGEX = new RegExp(`(?:\\s|^)(:${VALID_ACCOUNT_AND_EMOJI_CHAR}{${MIN_PREFIX_LENGTH},})$`)
 
 function computeForAutosuggest (store, key, defaultValue) {
   store.compute(key,


### PR DESCRIPTION
It's annoying when you type something like `@foo.` and it keeps autosuggesting even though you've typed a dot. Mastodon actually allows dots in usernames (https://github.com/tootsuite/mastodon/pull/6844) but I'm going to ignore that for the purposes of autocomplete because it's rare and will cause more problems than it solves to allow it in autosuggest.