### PR TITLE
fix: statuses in own thread should not have cursor:pointer

### DIFF
--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -305,7 +305,7 @@
         timelineType !== 'search' && 'status-in-timeline',
         isStatusInOwnThread && 'status-in-own-thread',
         $underlineLinks && 'underline-links',
-        !$disableTapOnStatus && 'tap-on-status'
+        !$disableTapOnStatus && !isStatusInOwnThread && 'tap-on-status'
       )),
       content: ({ originalStatus }) => originalStatus.content || '',
       showContent: ({ spoilerText, spoilerShown }) => !spoilerText || spoilerShown,


### PR DESCRIPTION
It's not tappable, so it shouldn't have cursor:pointer.