### PR TITLE
fix: unescape html in card titles/descriptions

### DIFF
--- a/src/routes/_components/status/StatusCard.html
+++ b/src/routes/_components/status/StatusCard.html
@@ -1,6 +1,6 @@
 <a ref:cardlink href={url} class="status-card" target="_blank" rel="noopener noreferrer">
     <strong class="card-title">
-     {title}
+     {unescapedTitle}
     </strong>
   {#if description}
     <div class="card-content">
@@ -10,7 +10,7 @@
     </div>
   {/if}
     <span class="card-description">
-      {description}
+      {unescapedDescription}
     </span>
   </div>
   {/if}
@@ -87,6 +87,7 @@
 <script>
   import LazyImage from '../LazyImage.html'
   import Shortcut from '../shortcut/Shortcut.html'
+  import { unescape } from '../../_thirdparty/unescape/unescape'
 
   export default {
     components: {
@@ -96,9 +97,11 @@
     computed: {
       card: ({ originalStatus }) => originalStatus.card,
       title: ({ card }) => card.title,
+      unescapedTitle: ({ title }) => title && unescape(title),
       url: ({ card }) => card.url,
       hostname: ({ url }) => window.URL ? new window.URL(url).hostname : '',
       description: ({ card, hostname }) => card.description || card.provider_name || hostname,
+      unescapedDescription: ({ description }) => description && unescape(description),
       imageUrl: ({ card }) => card.image
     },
     methods: {

--- a/src/routes/_thirdparty/unescape/LICENSE
+++ b/src/routes/_thirdparty/unescape/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014, 2016-2017, Jon Schlinkert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/routes/_thirdparty/unescape/unescape.js
+++ b/src/routes/_thirdparty/unescape/unescape.js
@@ -1,0 +1,63 @@
+// via https://github.com/jonschlinkert/unescape/blob/98d1e52/index.js
+
+const chars = {
+  '&quot;': '"',
+  '&#34;': '"',
+
+  '&apos;': '\'',
+  '&#39;': '\'',
+
+  '&amp;': '&',
+  '&#38;': '&',
+
+  '&gt;': '>',
+  '&#62;': '>',
+
+  '&lt;': '<',
+  '&#60;': '<',
+
+  '&cent;': '¢',
+  '&#162;': '¢',
+
+  '&copy;': '©',
+  '&#169;': '©',
+
+  '&euro;': '€',
+  '&#8364;': '€',
+
+  '&pound;': '£',
+  '&#163;': '£',
+
+  '&reg;': '®',
+  '&#174;': '®',
+
+  '&yen;': '¥',
+  '&#165;': '¥',
+
+  '&nbsp;': ' '
+}
+
+let regex
+
+/**
+ * Convert HTML entities to HTML characters.
+ *
+ * @param  {String} `str` String with HTML entities to un-escape.
+ * @return {String}
+ */
+
+function unescape (str) {
+  regex = regex || toRegex(chars)
+  return str.replace(regex, m => chars[m])
+}
+
+function toRegex (chars) {
+  var keys = Object.keys(chars).join('|')
+  return new RegExp('(' + keys + ')', 'g')
+}
+
+/**
+ * Expose `unescape`
+ */
+
+export { unescape }


### PR DESCRIPTION
It seems a lot of servers like WordPress and GitHub encode the OpenGraph titles/descriptions as HTML. Things like `&nbsp;` and `&#39;` look really ugly. This fixes that.