### PR TITLE
Revert "fix: no need for double reload of SW in Chrome (#1251)"

### DIFF
--- a/src/routes/_pages/settings/index.html
+++ b/src/routes/_pages/settings/index.html
@@ -36,7 +36,7 @@
     methods: {
       reload (event) {
         event.preventDefault()
-        location.reload()
+        document.location.reload(true)
       }
     }
   }

--- a/src/routes/_utils/serviceWorkerClient.js
+++ b/src/routes/_utils/serviceWorkerClient.js
@@ -1,81 +1,17 @@
 import { snackbar } from '../_components/snackbar/snackbar'
 
-// A lot of this code is borrowed from https://github.com/GoogleChromeLabs/squoosh/blob/53b46f8/src/lib/offliner.ts
-// Service Workers are hard!
+function onUpdateFound (registration) {
+  const newWorker = registration.installing
 
-// Tell the service worker to skip waiting
-async function skipWaiting () {
-  const reg = await navigator.serviceWorker.getRegistration()
-  if (!reg || !reg.waiting) {
-    return
-  }
-  reg.waiting.postMessage('skip-waiting')
-}
-
-// Wait for an installing worker
-async function installingWorker (reg) {
-  if (reg.installing) {
-    return reg.installing
-  }
-  return new Promise((resolve) => {
-    reg.addEventListener(
-      'updatefound',
-      () => resolve(reg.installing),
-      { once: true }
-    )
+  newWorker.addEventListener('statechange', async () => {
+    if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+      snackbar.announce('App update available.', 'Reload', () => document.location.reload(true))
+    }
   })
 }
 
-// Wait a service worker to become waiting
-async function updateReady (reg) {
-  if (reg.waiting) {
-    return
-  }
-  const installing = await installingWorker(reg)
-  return new Promise((resolve) => {
-    const listener = () => {
-      if (installing.state === 'installed') {
-        installing.removeEventListener('statechange', listener)
-        resolve()
-      }
-    }
-    installing.addEventListener('statechange', listener)
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/service-worker.js').then(registration => {
+    registration.addEventListener('updatefound', () => onUpdateFound(registration))
   })
 }
-
-(async () => {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/service-worker.js')
-
-    const hasController = !!navigator.serviceWorker.controller
-
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      if (!hasController) { // first install
-        return
-      }
-
-      location.reload()
-    })
-
-    // If we don't have a controller, we don't need to check for updates – we've just loaded from the
-    // network.
-    if (!hasController) {
-      return
-    }
-
-    const reg = await navigator.serviceWorker.getRegistration()
-    if (!reg) { // SW not registered yet
-      return
-    }
-
-    // Look for updates
-    await updateReady(reg)
-
-    // Ask the user if they want to update.
-    snackbar.announce('App update available.', 'Reload', () => {
-      // Tell the waiting worker to activate, this will change the controller and cause a reload (see
-      // 'controllerchange')
-      /* no await */ skipWaiting()
-    })
-  }
-})()

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -35,6 +35,7 @@ self.addEventListener('install', event => {
       caches.open(WEBPACK_ASSETS).then(cache => cache.addAll(webpackAssets)),
       caches.open(ASSETS).then(cache => cache.addAll(assets))
     ])
+    self.skipWaiting()
   })())
 })
 
@@ -241,12 +242,4 @@ self.addEventListener('notificationclick', event => {
       }
     }
   })())
-})
-
-self.addEventListener('message', (event) => {
-  switch (event.data) {
-    case 'skip-waiting':
-      self.skipWaiting()
-      break
-  }
 })


### PR DESCRIPTION
This reverts commit fa2eb8fe52e985185a7157cca31ba57382609734.

Unfortunately it looks like we're going to have to fix #1251 in stages. The issue is that I need to account for the situation where a _new_ service worker is controlling an _old_ page. The new SW thinks it just needs to wait for a postMessage to call `skipWaiting`, whereas the old page will never do that - it will just try to refresh.

This seems bad enough that an iOS Safari app is just permanently stuck. In other browsers you have to completely close and reopen the browser in order for the page to update. That's just unacceptable.