### PR TITLE
fix: fix compose toolbar on iphone 4 again

### DIFF
--- a/src/routes/_components/compose/ComposeToolbar.html
+++ b/src/routes/_components/compose/ComposeToolbar.html
@@ -55,8 +55,8 @@
 
   @media (max-width: 320px) {
     :global(button.icon-button.compose-toolbar-button) {
-      padding-left: 8px;
-      padding-right: 8px;
+      padding-left: 5px;
+      padding-right: 5px;
     }
   }
 </style>


### PR DESCRIPTION
These icons need to be closer together still