### PR TITLE
fix: focal point should be only visible for images

### DIFF
--- a/src/routes/_components/compose/ComposeMediaItem.html
+++ b/src/routes/_components/compose/ComposeMediaItem.html
@@ -7,8 +7,8 @@
     aria-hidden="true"
   />
   <div class="compose-media-buttons">
-    <button class="compose-media-button compose-media-focal-button {type === 'audio' ? 'compose-media-hidden' : ''}"
-            aria-hidden={type === 'audio'}
+    <button class="compose-media-button compose-media-focal-button {focalHidden ? 'compose-media-hidden' : ''}"
+            aria-hidden={focalHidden}
             aria-label="Change preview"
             title="Change preview"
             on:click="onSetFocalPoint()" >
@@ -163,7 +163,8 @@
           return 'center center'
         }
         return `${coordsToPercent(focusX)}% ${100 - coordsToPercent(focusY)}%`
-      }
+      },
+      focalHidden: ({ type }) => type !== 'image'
     },
     store: () => store,
     methods: {


### PR DESCRIPTION
Focal points are not supposed to be shown for videos, gifs, and audio apparently.