### PR TITLE
fix: add warnings when click delegates return non-booleans

### DIFF
--- a/src/routes/_utils/delegate.js
+++ b/src/routes/_utils/delegate.js
@@ -28,7 +28,11 @@ function onEvent (e) {
         return // ignore if the user is selecting text inside the clickable area
       }
     }
-    if (callbacks[key](e)) { // callback returns true to indicate it has handled the action
+    let res = callbacks[key](e) // callback returns true to indicate it has handled the action
+    if (process.env.NODE_ENV !== 'production' && typeof res !== 'boolean') {
+      console.warn(`Callback returned a non-boolean response: "${key}". This should never happen.`)
+    }
+    if (res) {
       e.preventDefault()
       e.stopPropagation()
     }


### PR DESCRIPTION
I want to avoid making this mistake in the future