### PR TITLE
fix: limit search results from 40 to 5

### DIFF
--- a/src/routes/_api/search.js
+++ b/src/routes/_api/search.js
@@ -1,7 +1,7 @@
 import { get, paramsString, DEFAULT_TIMEOUT } from '../_utils/ajax'
 import { auth, basename } from './utils'
 
-export function search (instanceName, accessToken, query, resolve = true, limit = 40, signal = null) {
+export function search (instanceName, accessToken, query, resolve = true, limit = 5, signal = null) {
   let url = `${basename(instanceName)}/api/v1/search?` + paramsString({
     q: query,
     resolve,


### PR DESCRIPTION
40 is too much, also this aligns us with the Mastodon frontend UI.