### PR TITLE
fix: delete-and-redraft preserves polls

### DIFF
--- a/src/routes/_actions/deleteAndRedraft.js
+++ b/src/routes/_actions/deleteAndRedraft.js
@@ -17,7 +17,12 @@ export async function deleteAndRedraft (status) {
       description: _.description || '',
       data: _
     })),
-    inReplyToId: status.in_reply_to_id
+    inReplyToId: status.in_reply_to_id,
+    // note that for polls there is no real way to preserve the original expiry
+    poll: status.poll && {
+      multiple: !!status.poll.multiple,
+      options: (status.poll.options || []).map(option => option.title)
+    }
   })
   let showComposeDialog = await dialogPromise
   showComposeDialog()

--- a/tests/spec/127-compose-polls.js
+++ b/tests/spec/127-compose-polls.js
@@ -7,13 +7,7 @@ import {
   getComposePollNthInput,
   composePoll,
   composePollMultipleChoice,
-  composePollExpiry,
-  composePollAddButton,
-  getComposePollRemoveNthButton,
-  postStatusButton,
-  composeInput,
-  sleep,
-  dialogOptionsOption
+  composePollExpiry, composePollAddButton, getComposePollRemoveNthButton, postStatusButton, composeInput, sleep
 } from '../utils'
 import { loginAsFoobar } from '../roles'
 import { POLL_EXPIRY_DEFAULT } from '../../src/routes/_static/polls'
@@ -78,5 +72,4 @@ test('Can add and remove poll options', async t => {
     .expect(getNthStatusPollResult(1, 3).innerText).eql('0% fourth')
     .expect(getNthStatusPollResult(1, 4).exists).notOk()
     .expect(getNthStatusPollVoteCount(1).innerText).eql('0 votes')
-    .click(dialogOptionsOption.withText('Delete and redraft'))
 })

--- a/tests/spec/127-compose-polls.js
+++ b/tests/spec/127-compose-polls.js
@@ -7,7 +7,13 @@ import {
   getComposePollNthInput,
   composePoll,
   composePollMultipleChoice,
-  composePollExpiry, composePollAddButton, getComposePollRemoveNthButton, postStatusButton, composeInput, sleep
+  composePollExpiry,
+  composePollAddButton,
+  getComposePollRemoveNthButton,
+  postStatusButton,
+  composeInput,
+  sleep,
+  dialogOptionsOption
 } from '../utils'
 import { loginAsFoobar } from '../roles'
 import { POLL_EXPIRY_DEFAULT } from '../../src/routes/_static/polls'
@@ -72,4 +78,5 @@ test('Can add and remove poll options', async t => {
     .expect(getNthStatusPollResult(1, 3).innerText).eql('0% fourth')
     .expect(getNthStatusPollResult(1, 4).exists).notOk()
     .expect(getNthStatusPollVoteCount(1).innerText).eql('0 votes')
+    .click(dialogOptionsOption.withText('Delete and redraft'))
 })

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -65,7 +65,10 @@ export const composeModalPostPrivacyButton = $('.modal-dialog .compose-box-toolb
 
 export const composePoll = $('.compose-poll')
 export const composePollMultipleChoice = $('.compose-poll input[type="checkbox"]')
+export const composePollMultipleChoiceInDialog = $('.modal-dialog .compose-poll input[type="checkbox"]')
 export const composePollExpiry = $('.compose-poll select')
+export const composePollExpiryOption = $('.compose-poll select option')
+export const composePollExpiryInDialog = $('.modal-dialog .compose-poll select')
 export const composePollAddButton = $('.compose-poll button:last-of-type')
 
 export const postPrivacyDialogButtonUnlisted = $('[aria-label="Post privacy dialog"] li:nth-child(2) button')
@@ -263,6 +266,10 @@ export function getNthStatusPollVoteCount (n) {
 
 export function getComposePollNthInput (n) {
   return $(`.compose-poll input[type="text"]:nth-of-type(${n})`)
+}
+
+export function getComposePollNthInputInDialog (n) {
+  return $(`.modal-dialog .compose-poll input[type="text"]:nth-of-type(${n})`)
 }
 
 export function getComposePollRemoveNthButton (n) {


### PR DESCRIPTION
fixes #1342

Unfortunately we can't preserve the poll expiry time, but we can preserve everything else.