### PR TITLE
fix: fix html style of glitch-soc markdown content

### DIFF
--- a/src/routes/_utils/massageStatusPlainText.js
+++ b/src/routes/_utils/massageStatusPlainText.js
@@ -1,0 +1,10 @@
+// Glitch Social can have statuses that just contain blockquote/ol/ul, no p
+const STARTING_TAG_REGEX = /^<(?:p|blockquote|ol|ul)>/i
+
+export function massageStatusPlainText (text) {
+  // GNU Social and Pleroma don't add <p> tags, so wrap them
+  if (text && !STARTING_TAG_REGEX.test(text)) {
+    text = `<p>${text}</p>`
+  }
+  return text
+}

--- a/src/routes/_utils/massageUserText.js
+++ b/src/routes/_utils/massageUserText.js
@@ -1,12 +1,9 @@
 import { emojifyText } from './emojifyText'
+import { massageStatusPlainText } from './massageStatusPlainText'
 
 export function massageUserText (text, emojis, $autoplayGifs) {
   text = text || ''
   text = emojifyText(text, emojis, $autoplayGifs)
-
-  // GNU Social and Pleroma don't add <p> tags
-  if (text && !text.startsWith('<p>')) {
-    text = `<p>${text}</p>`
-  }
+  text = massageStatusPlainText(text)
   return text
 }

--- a/src/routes/_utils/statusHtmlToPlainText.js
+++ b/src/routes/_utils/statusHtmlToPlainText.js
@@ -1,4 +1,5 @@
 import { mark, stop } from './marks'
+import { massageStatusPlainText } from './massageStatusPlainText'
 
 let domParser = process.browser && new DOMParser()
 
@@ -37,10 +38,7 @@ export function statusHtmlToPlainText (html, mentions) {
     return ''
   }
   mark('statusHtmlToPlainText')
-  // GNU Social and Pleroma don't add <p> tags
-  if (!html.startsWith('<p>')) {
-    html = `<p>${html}</p>`
-  }
+  html = massageStatusPlainText(html)
   let doc = domParser.parseFromString(html, 'text/html')
   massageMentions(doc, mentions)
   let res = innerTextRetainingNewlines(doc)


### PR DESCRIPTION
Along with #1348, this fixes the style of Markdown content from glitch-soc (while still not breaking Pleroma).

Before (note the extra padding):

![Screenshot from 2019-07-21 14-09-33](https://user-images.githubusercontent.com/283842/61597287-8469a800-abc3-11e9-931e-bd8854210450.png)

After (note no padding):

![Screenshot from 2019-07-21 14-22-53](https://user-images.githubusercontent.com/283842/61597290-8895c580-abc3-11e9-8f74-81ee277b7205.png)
