### PR TITLE
fix: fix grayscale wellness setting in dark mode

### DIFF
--- a/src/routes/_utils/themeEngine.js
+++ b/src/routes/_utils/themeEngine.js
@@ -36,7 +36,7 @@ function loadCSS (href) {
 
 export function switchToTheme (themeName = DEFAULT_THEME, enableGrayscale) {
   if (enableGrayscale) {
-    themeName = prefersDarkTheme ? 'grayscale-dark' : 'grayscale'
+    themeName = prefersDarkTheme ? 'dark-grayscale' : 'grayscale'
   }
   let themeColor = window.__themeColors[themeName]
   meta.content = themeColor || window.__themeColors[DEFAULT_THEME]


### PR DESCRIPTION
This was a typo on my part; if the browser is set to prefer dark mode and the user ticks the grayscale box in the settings, then it should choose dark grayscale.