### PR TITLE
fix: fix useless nav-indicator-key attribute

### DIFF
--- a/src/routes/_components/NavItem.html
+++ b/src/routes/_components/NavItem.html
@@ -12,10 +12,7 @@
     />
     <span class="nav-link-label">{label}</span>
   </div>
-  <div class="nav-indicator"
-       nav-indicator-key={name}
-       ref:indicator
-  ></div>
+  <div class="nav-indicator" ref:indicator></div>
 </a>
 <style>
   .main-nav-link {


### PR DESCRIPTION
As far as I can tell, this attribute is not used anywhere.