### PR TITLE
fix: fix bugs in streaming gap

### DIFF
--- a/src/routes/_actions/stream/streaming.js
+++ b/src/routes/_actions/stream/streaming.js
@@ -39,7 +39,7 @@ export function createStream (api, instanceName, accessToken, timelineName, firs
     fillGap(timelineName, newFirstStatusId)
     if (timelineName === 'home') {
       // special case - home timeline stream also handles notifications
-      let newFirstNotificationId = store.getFirstTimelineItemId(instanceName, timelineName)
+      let newFirstNotificationId = store.getFirstTimelineItemId(instanceName, 'notifications')
       fillGap('notifications', newFirstNotificationId)
     }
   }

--- a/src/routes/_api/timelines.js
+++ b/src/routes/_api/timelines.js
@@ -39,7 +39,7 @@ export async function getTimeline (instanceName, accessToken, timeline, maxId, s
 
   let params = {}
   if (since) {
-    params.since = since
+    params.since_id = since
   }
 
   if (maxId) {


### PR DESCRIPTION
Not sure how these bugs managed to slip in (one has been there for awhile), but these are clearly errors.

If we had better tests for the streaming gap (e.g. to check that >40 statuses are filled into the gap), then we probably could have caught these.