### PR TITLE
Refresh the main streams when on page focus

### DIFF
--- a/src/routes/_store/observers/instanceObservers.js
+++ b/src/routes/_store/observers/instanceObservers.js
@@ -114,4 +114,23 @@ export function instanceObservers () {
 
     scheduleIdleTask(() => refreshInstanceDataAndStream(store, currentInstance))
   })
+
+  store.observe('pageVisibilityHidden', async (isHidden) => {
+    if (!process.browser || isHidden) {
+      return
+    }
+    if (currentInstanceStream) {
+      currentInstanceStream.close()
+      currentInstanceStream = null
+      if (process.env.NODE_ENV !== 'production') {
+        window.currentInstanceStream = null
+      }
+    }
+    const currentInstance = store.get().currentInstance
+    if (!currentInstance) {
+      return
+    }
+
+    scheduleIdleTask(() => refreshInstanceDataAndStream(store, store.get().currentInstance))
+  })
 }


### PR DESCRIPTION
It would be better to use the [resume page lifecycle event](https://developers.google.com/web/updates/2018/07/page-lifecycle-api), but Safari does not support it yet.

This is yet another attempts at my quest to make sure the main stream are listened to on iOS PWA. This is far from being perfect, as the stream will be refreshed more than necessary in standard browsers (every time the pinafore tab gains the focus). 
On the other hand, we will not be more certain that the main stream is actually working now.