### PR TITLE
refactor: move all UA-sniffing to its own file

### DIFF
--- a/bin/build-inline-script.js
+++ b/bin/build-inline-script.js
@@ -24,7 +24,11 @@ export async function buildInlineScript () {
       }),
       terser({
         mangle: true,
-        compress: true
+        compress: {
+          // terser does not detect RegExp.prototype.test as a pure func
+          // https://github.com/terser-js/terser/issues/405
+          pure_funcs: ['testUA']
+        }
       })
     ]
   })

--- a/src/inline-script/inline-script.js
+++ b/src/inline-script/inline-script.js
@@ -7,6 +7,7 @@ import { INLINE_THEME, DEFAULT_THEME, switchToTheme } from '../routes/_utils/the
 import { basename } from '../routes/_api/utils'
 import { onUserIsLoggedOut } from '../routes/_actions/onUserIsLoggedOut'
 import { storeLite } from '../routes/_store/storeLite'
+import { IS_IOS_PRE_12_2 } from '../routes/_utils/userAgent'
 
 window.__themeColors = process.env.THEME_COLORS
 
@@ -62,9 +63,7 @@ if (/mac/i.test(navigator.platform)) {
 // for cross-origin authentication: https://github.com/nolanlawson/pinafore/issues/45
 // Here we sniff for iOS <12.2 by checking for the existence of a native IntersectionObserver
 // function, which was added in 12.2.
-if (/iP(?:hone|ad|od)/.test(navigator.userAgent) &&
-  !(typeof IntersectionObserver === 'function' &&
-    IntersectionObserver.toString().includes('[native code]'))) {
+if (IS_IOS_PRE_12_2) {
   document.head.removeChild(document.getElementById('theManifest'))
 }
 

--- a/src/routes/_components/dialog/components/MediaDialog.html
+++ b/src/routes/_components/dialog/components/MediaDialog.html
@@ -214,6 +214,7 @@
   import { store } from '../../../_store/store'
   import { intrinsicScale } from '../../../_thirdparty/intrinsic-scale/intrinsicScale'
   import { get } from '../../../_utils/lodash-lite'
+  import { IS_EDGEHTML } from '../../../_utils/userAgent'
 
   // padding for .media-scroll-item-image-area
   const IMAGE_AREA_PADDING = {
@@ -319,7 +320,7 @@
         let { scrollWidth } = scroller
         let scrollLeft = Math.floor(scrollWidth * (scrolledItem / length))
         if (smooth) {
-          if (!hasNativeSmoothScroll && 'StyleMedia' in window) {
+          if (!hasNativeSmoothScroll && IS_EDGEHTML) {
             // Edge has a weird bug where it changes the height if we try to
             // smooth scroll, so disable smooth scrolling
             scroller.scrollLeft = scrollLeft

--- a/src/routes/_store/store.js
+++ b/src/routes/_store/store.js
@@ -3,6 +3,7 @@ import { computations } from './computations/computations'
 import { mixins } from './mixins/mixins'
 import { LocalStorageStore } from './LocalStorageStore'
 import { observe } from 'svelte-extras'
+import { IS_IOS } from '../_utils/userAgent'
 
 const persistedState = {
   autoplayGifs: false,
@@ -11,7 +12,7 @@ const persistedState = {
   currentRegisteredInstanceName: undefined,
   currentRegisteredInstance: undefined,
   // we disable scrollbars by default on iOS
-  disableCustomScrollbars: process.browser && /iP(?:hone|ad|od)/.test(navigator.userAgent),
+  disableCustomScrollbars: IS_IOS,
   disableFavCounts: false,
   disableFollowerCounts: false,
   disableHotkeys: false,

--- a/src/routes/_utils/decodeImage.js
+++ b/src/routes/_utils/decodeImage.js
@@ -1,4 +1,4 @@
-const IS_FIREFOX = process.browser && /Firefox/.test(navigator.userAgent)
+import { IS_FIREFOX } from './userAgent'
 
 export function decodeImage (img) {
   // Remove this UA sniff when the Firefox bug is fixed

--- a/src/routes/_utils/runMediumPriorityTask.js
+++ b/src/routes/_utils/runMediumPriorityTask.js
@@ -1,9 +1,6 @@
 import { scheduleIdleTask } from './scheduleIdleTask'
 import { store } from '../_store/store'
-
-// Rough guess at whether this is a "mobile" device or not, for the purposes
-// of "device class" estimations
-const IS_MOBILE = process.browser && navigator.userAgent.match(/(?:iPhone|iPod|iPad|Android)/)
+import { IS_MOBILE } from './userAgent'
 
 // Run a task that doesn't need to be processed immediately, but should
 // probably be delayed if we're on a mobile device. Also run it sooner

--- a/src/routes/_utils/userAgent.js
+++ b/src/routes/_utils/userAgent.js
@@ -1,0 +1,19 @@
+// This file contains assorted user agent sniffing, which hopefully
+// we can remove at some point.
+
+function testUA (regex) {
+  return process.browser && regex.test(navigator.userAgent)
+}
+
+// Rough guess at whether this is a "mobile" device or not, for the purposes
+// of "device class" estimations
+export const IS_MOBILE = testUA(/(?:iPhone|iPod|iPad|Android)/)
+
+export const IS_FIREFOX = testUA(/Firefox/)
+
+export const IS_IOS = testUA(/iP(?:hone|ad|od)/)
+
+export const IS_IOS_PRE_12_2 = IS_IOS &&
+  !(typeof IntersectionObserver === 'function' && IntersectionObserver.toString().includes('[native code]'))
+
+export const IS_EDGEHTML = process.browser && 'StyleMedia' in window


### PR DESCRIPTION
I like having this all in one place so we can maybe remove it one day