### PR TITLE
perf: put apple touch icon in service worker cache

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -16,7 +16,6 @@ const WEBPACK_ASSETS = `webpack_assets_${timestamp}`
 // `static` is an array of everything in the `static` directory
 const assets = __assets__
   .map(file => file.startsWith('/') ? file : `/${file}`)
-  .filter(filename => !filename.startsWith('/apple-icon'))
   .filter(filename => !filename.endsWith('.map'))
   .filter(filename => filename !== '/robots.txt')
 


### PR DESCRIPTION
Apparently Firefox desktop requests this file every time you refresh, so putting it in the SW cache can avoid an unnecessary 304. We already do this for all the Android icons anyway.