### PR TITLE
perf: do preconnect instead of prefetch for instance

### DIFF
--- a/src/inline-script/inline-script.js
+++ b/src/inline-script/inline-script.js
@@ -22,13 +22,10 @@ const {
 const theme = (instanceThemes && instanceThemes[currentInstance]) || DEFAULT_THEME
 
 if (currentInstance) {
-  // Do prefetch if we're logged in, so we can connect faster to the other origin.
-  // Note that /api/v1/instance is basically the only URL that doesn't require credentials,
-  // which is why we can do this. Also we do end up calling this on loading the home page,
-  // so it's not a wasted request.
+  // Do preconnect if we're logged in, so we can connect faster to the other origin.
   let link = document.createElement('link')
-  link.setAttribute('rel', 'prefetch')
-  link.setAttribute('href', `${basename(currentInstance)}/api/v1/instance`)
+  link.setAttribute('rel', 'preconnect')
+  link.setAttribute('href', basename(currentInstance))
   link.setAttribute('crossorigin', 'anonymous')
   document.head.appendChild(link)
 }


### PR DESCRIPTION
It occurs to me that prefetch doesn't make much sense here, because the resource may be cached, in which case the browser won't connect. What we really want is to make the timeline request start faster, but that's tricky to do with any of the existing prefetch/preload/preconnect primitives because of the Authorization header. So the best thing to do is probably just a preconnect so the browser knows to start connecting to the instance.