### PR TITLE
fix(service-worker): Open notifications if no status

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -130,7 +130,7 @@ async function showSimpleNotification (data) {
     icon: data.icon,
     body: data.body,
     data: {
-      url: `${origin}/notifications`
+      url: `${self.origin}/notifications`
     }
   })
 }

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -128,7 +128,10 @@ self.addEventListener('push', event => {
 async function showSimpleNotification (data) {
   await self.registration.showNotification(data.title, {
     icon: data.icon,
-    body: data.body
+    body: data.body,
+    data: {
+      url: `${origin}/notifications`
+    }
   })
 }
 


### PR DESCRIPTION
If the notification couldn't be fetched fallback to displaying all notifications (aligned with how the Mastodon Web UI [handles it](https://github.com/tootsuite/mastodon/blob/master/app/javascript/mastodon/service_worker/web_push_notifications.js#L118)).

Might fix https://github.com/nolanlawson/pinafore/issues/1365.