### PR TITLE
fix: move blurhash worker operations to before status rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "performance-now": "^2.1.0",
     "pinch-zoom-element": "^1.1.1",
     "preact": "^10.0.0-beta.1",
+    "promise-worker": "^2.0.1",
     "prop-types": "^15.7.2",
     "quick-lru": "^4.0.1",
     "remount": "^0.11.0",

--- a/src/routes/_components/status/Media.html
+++ b/src/routes/_components/status/Media.html
@@ -110,16 +110,11 @@
   import LazyImage from '../LazyImage.html'
   import AutoplayVideo from '../AutoplayVideo.html'
   import { registerClickDelegate } from '../../_utils/delegate'
-  import { decode } from '../../_utils/blurhash'
 
 export default {
     async oncreate () {
-      const { elementId, media } = this.get()
+      const { elementId } = this.get()
       registerClickDelegate(this, elementId, () => this.onClick())
-
-      if (media.blurhash) {
-        this.set({ decodedBlurhash: await decode(media.blurhash) })
-      }
     },
     computed: {
       focus: ({ meta }) => meta && meta.focus,
@@ -150,6 +145,7 @@ export default {
       elementId: ({ media, uuid }) => `media-${uuid}-${media.id}`,
       description: ({ media }) => media.description || '',
       previewUrl: ({ media }) => media.preview_url,
+      decodedBlurhash: ({ media }) => media.decodedBlurhash || ONE_TRANSPARENT_PIXEL,
       blurhash: ({ showBlurhash, decodedBlurhash }) => showBlurhash && decodedBlurhash,
       url: ({ media }) => media.url,
       type: ({ media }) => media.type
@@ -166,7 +162,6 @@ export default {
     },
     data: () => ({
       oneTransparentPixel: ONE_TRANSPARENT_PIXEL,
-      decodedBlurhash: ONE_TRANSPARENT_PIXEL,
       mouseover: void 0
     }),
     store: () => store,

--- a/src/routes/_static/blurhash.js
+++ b/src/routes/_static/blurhash.js
@@ -1,0 +1,1 @@
+export const BLURHASH_RESOLUTION = 32

--- a/src/routes/_utils/blurhash.js
+++ b/src/routes/_utils/blurhash.js
@@ -30,10 +30,7 @@ async function decodeUsingCanvas (imageData) {
 export async function decode (blurhash) {
   init()
   // TODO: should maintain a cache outside of worker to avoid round-trip for cached data
-  const { encoded, decoded, imageData } = await worker.postMessage(blurhash)
-  if (encoded !== blurhash) { // TODO: why do we check this? Shouldn't it always be the same?
-    return
-  }
+  const { decoded, imageData } = await worker.postMessage(blurhash)
   if (decoded) {
     return decoded
   }

--- a/src/routes/_utils/blurhash.js
+++ b/src/routes/_utils/blurhash.js
@@ -1,6 +1,6 @@
 import BlurhashWorker from 'worker-loader!../_workers/blurhash' // eslint-disable-line
 import PromiseWorker from 'promise-worker'
-import { BLURHASH_RESOLUTION } from '../_static/blurhash'
+import { BLURHASH_RESOLUTION as RESOLUTION } from '../_static/blurhash'
 
 let worker
 let canvas
@@ -13,8 +13,8 @@ export function init () {
 function initCanvas () {
   if (!canvas) {
     canvas = document.createElement('canvas')
-    canvas.height = BLURHASH_RESOLUTION
-    canvas.width = BLURHASH_RESOLUTION
+    canvas.height = RESOLUTION
+    canvas.width = RESOLUTION
     canvasContext2D = canvas.getContext('2d')
   }
 }

--- a/src/routes/_workers/blurhash.js
+++ b/src/routes/_workers/blurhash.js
@@ -1,5 +1,4 @@
 import { decode as decodeBlurHash } from 'blurhash'
-import QuickLRU from 'quick-lru'
 import registerPromiseWorker from 'promise-worker/register'
 import { BLURHASH_RESOLUTION as RESOLUTION } from '../_static/blurhash'
 
@@ -7,9 +6,8 @@ const OFFSCREEN_CANVAS = typeof OffscreenCanvas === 'function'
   ? new OffscreenCanvas(RESOLUTION, RESOLUTION) : null
 const OFFSCREEN_CANVAS_CONTEXT_2D = OFFSCREEN_CANVAS
   ? OFFSCREEN_CANVAS.getContext('2d') : null
-const CACHE = new QuickLRU({ maxSize: 100 })
 
-async function decodeWithoutCache (encoded) {
+registerPromiseWorker(async (encoded) => {
   const pixels = decodeBlurHash(encoded, RESOLUTION, RESOLUTION)
 
   if (!pixels) {
@@ -25,13 +23,4 @@ async function decodeWithoutCache (encoded) {
   } else {
     return { imageData, decoded: null }
   }
-}
-
-registerPromiseWorker(async (encoded) => {
-  let result = CACHE.get(encoded)
-  if (!result) {
-    result = await decodeWithoutCache(encoded)
-    CACHE.set(encoded, result)
-  }
-  return result
 })

--- a/src/routes/_workers/blurhash.js
+++ b/src/routes/_workers/blurhash.js
@@ -28,11 +28,10 @@ async function decodeWithoutCache (encoded) {
 }
 
 registerPromiseWorker(async (encoded) => {
-  if (CACHE.has(encoded)) {
-    const { decoded, imageData } = CACHE.get(encoded)
-    return { encoded, decoded, imageData }
+  let result = CACHE.get(encoded)
+  if (!result) {
+    result = await decodeWithoutCache(encoded)
+    CACHE.set(encoded, result)
   }
-  const { decoded, imageData } = await decodeWithoutCache(encoded)
-  CACHE.set(encoded, { decoded, imageData })
-  return { encoded, decoded, imageData }
+  return result
 })

--- a/src/routes/_workers/blurhash.js
+++ b/src/routes/_workers/blurhash.js
@@ -1,21 +1,21 @@
 import { decode as decodeBlurHash } from 'blurhash'
 import QuickLRU from 'quick-lru'
 import registerPromiseWorker from 'promise-worker/register'
-import { BLURHASH_RESOLUTION } from '../_static/blurhash'
+import { BLURHASH_RESOLUTION as RESOLUTION } from '../_static/blurhash'
 
 const OFFSCREEN_CANVAS = typeof OffscreenCanvas === 'function'
-  ? new OffscreenCanvas(BLURHASH_RESOLUTION, BLURHASH_RESOLUTION) : null
+  ? new OffscreenCanvas(RESOLUTION, RESOLUTION) : null
 const OFFSCREEN_CANVAS_CONTEXT_2D = OFFSCREEN_CANVAS
   ? OFFSCREEN_CANVAS.getContext('2d') : null
 const CACHE = new QuickLRU({ maxSize: 100 })
 
 async function decodeWithoutCache (encoded) {
-  const pixels = decodeBlurHash(encoded, BLURHASH_RESOLUTION, BLURHASH_RESOLUTION)
+  const pixels = decodeBlurHash(encoded, RESOLUTION, RESOLUTION)
 
   if (!pixels) {
     throw new Error('decode did not return any pixels')
   }
-  const imageData = new ImageData(pixels, BLURHASH_RESOLUTION, BLURHASH_RESOLUTION)
+  const imageData = new ImageData(pixels, RESOLUTION, RESOLUTION)
 
   if (OFFSCREEN_CANVAS) {
     OFFSCREEN_CANVAS_CONTEXT_2D.putImageData(imageData, 0, 0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,6 +5991,11 @@ promise-polyfill@^6.0.1:
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
   integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
 
+promise-worker@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-worker/-/promise-worker-2.0.1.tgz#63bb532624ecd40cdb335b51bb7830c3c892aa6c"
+  integrity sha512-jR7vHqMEwWJ15i9vA3qyCKwRHihyLJp1sAa3RyY5F35m3u5s2lQUfq0nzVjbA8Xc7+3mL3Y9+9MHBO9UFRpFxA==
+
 promisify-event@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/promisify-event/-/promisify-event-1.0.0.tgz#bd7523ea06b70162f370979016b53a686c60e90f"


### PR DESCRIPTION
As described in https://github.com/nolanlawson/pinafore/pull/1381#issuecomment-522258204 I would like to avoid the "pop" where the blurhash suddenly shows after the worker is done decoding it. This moves blurhash decoding into the same point in time when we asynchronously fetch status data from IndexedDB or the cache, so it happens before status rendering.

Other changes:

- Use promise-worker because I wrote it and I like it :)
- Add some perf marks/measures so I can get a better idea of the timeline
- Move `init()` of worker a bit earlier

I'm still dissatisfied with the worker round-trip time (on my local Chrome desktop it seems to take like a few hundred milliseconds... is that normal? is it just a dev tools artifact?). Also I'd like to move the cache away from the worker if we can't fix that round-trip time.