### PR TITLE
fix: remove firefox UA sniff for img.decode

### DIFF
--- a/src/routes/_utils/decodeImage.js
+++ b/src/routes/_utils/decodeImage.js
@@ -1,10 +1,5 @@
-const IS_FIREFOX = process.browser && /Firefox/.test(navigator.userAgent)
-
 export function decodeImage (img) {
-  // Remove this UA sniff when the Firefox bug is fixed
-  // https://github.com/nolanlawson/pinafore/issues/1344#issuecomment-514312672
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1565542
-  if (!IS_FIREFOX && typeof img.decode === 'function' && !img.src.startsWith('data:image/png;base64,')) {
+  if (typeof img.decode === 'function' && !img.src.startsWith('data:image/png;base64,')) {
     return img.decode()
   }
 


### PR DESCRIPTION
fixes #1388