### PR TITLE
perf: call revokeObjectURL() on stale blurhash blob URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "preact": "^10.0.0-beta.1",
     "promise-worker": "^2.0.1",
     "prop-types": "^15.7.2",
-    "quick-lru": "^4.0.1",
     "remount": "^0.11.0",
     "requestidlecallback": "^0.3.0",
     "rollup": "^1.16.2",

--- a/src/routes/_database/cache.js
+++ b/src/routes/_database/cache.js
@@ -1,4 +1,4 @@
-import QuickLRU from 'quick-lru'
+import { QuickLRU } from '../_thirdparty/quick-lru/quick-lru'
 
 export const statusesCache = {
   maxSize: 100,

--- a/src/routes/_thirdparty/quick-lru/license
+++ b/src/routes/_thirdparty/quick-lru/license
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/routes/_thirdparty/quick-lru/quick-lru.js
+++ b/src/routes/_thirdparty/quick-lru/quick-lru.js
@@ -1,0 +1,126 @@
+// Forked from https://github.com/sindresorhus/quick-lru/blob/16d15d470a8eb87c2a7dd5b80892d9b74f1acd3c/index.js
+// Adds the ability to listen for 'evict' events using an EventEmitter, also removes some unused code
+
+import { EventEmitter } from 'events-light'
+
+export class QuickLRU extends EventEmitter {
+  constructor (options = {}) {
+    super()
+    if (!(options.maxSize && options.maxSize > 0)) {
+      throw new TypeError('`maxSize` must be a number greater than 0')
+    }
+
+    this.maxSize = options.maxSize
+    this.cache = new Map()
+    this.oldCache = new Map()
+    this._size = 0
+  }
+
+  _set (key, value) {
+    this.cache.set(key, value)
+    this._size++
+
+    if (this._size >= this.maxSize) {
+      this._size = 0
+      if (this.listenerCount('evict')) {
+        for (const key of this.oldCache.keys()) {
+          if (!this.cache.has(key)) {
+            this.emit('evict', this.oldCache.get(key), key)
+          }
+        }
+      }
+      this.oldCache = this.cache
+      this.cache = new Map()
+    }
+  }
+
+  get (key) {
+    if (this.cache.has(key)) {
+      return this.cache.get(key)
+    }
+
+    if (this.oldCache.has(key)) {
+      const value = this.oldCache.get(key)
+      this.oldCache.delete(key)
+      this._set(key, value)
+      return value
+    }
+  }
+
+  set (key, value) {
+    if (this.cache.has(key)) {
+      this.cache.set(key, value)
+    } else {
+      this._set(key, value)
+    }
+
+    return this
+  }
+
+  has (key) {
+    return this.cache.has(key) || this.oldCache.has(key)
+  }
+
+  // unused
+  // peek (key) {
+  //   if (this.cache.has(key)) {
+  //     return this.cache.get(key)
+  //   }
+  //
+  //   if (this.oldCache.has(key)) {
+  //     return this.oldCache.get(key)
+  //   }
+  // }
+
+  delete (key) {
+    const deleted = this.cache.delete(key)
+    if (deleted) {
+      this._size--
+    }
+
+    return this.oldCache.delete(key) || deleted
+  }
+
+  clear () {
+    this.cache.clear()
+    this.oldCache.clear()
+    this._size = 0
+  }
+
+  // unused
+  // * keys() {
+  //   for (const [key] of this) {
+  //     yield key;
+  //   }
+  // }
+  //
+  // * values() {
+  //   for (const [, value] of this) {
+  //     yield value;
+  //   }
+  // }
+  //
+  // * [Symbol.iterator]() {
+  //   for (const item of this.cache) {
+  //     yield item;
+  //   }
+  //
+  //   for (const item of this.oldCache) {
+  //     const [key] = item;
+  //     if (!this.cache.has(key)) {
+  //       yield item;
+  //     }
+  //   }
+  // }
+  //
+  // get size () {
+  //   let oldCacheSize = 0
+  //   for (const key of this.oldCache.keys()) {
+  //     if (!this.cache.has(key)) {
+  //       oldCacheSize++
+  //     }
+  //   }
+  //
+  //   return this._size + oldCacheSize
+  // }
+}

--- a/src/routes/_utils/RealmStore.js
+++ b/src/routes/_utils/RealmStore.js
@@ -2,7 +2,7 @@
 // Each realm has self-contained data that you can set with setForRealm() and compute
 // with computeForRealm(). The maxSize determines how many realms to keep in the LRU cache.
 import { Store } from 'svelte/store.js'
-import QuickLRU from 'quick-lru'
+import { QuickLRU } from '../_thirdparty/quick-lru/quick-lru'
 import { mark, stop } from './marks'
 import { requestPostAnimationFrame } from './requestPostAnimationFrame'
 

--- a/src/routes/_utils/blurhash.js
+++ b/src/routes/_utils/blurhash.js
@@ -1,13 +1,20 @@
 import BlurhashWorker from 'worker-loader!../_workers/blurhash' // eslint-disable-line
 import PromiseWorker from 'promise-worker'
 import { BLURHASH_RESOLUTION as RESOLUTION } from '../_static/blurhash'
-import QuickLRU from 'quick-lru'
+import { QuickLRU } from '../_thirdparty/quick-lru/quick-lru'
 
-const CACHE = new QuickLRU({ maxSize: 100 })
+// A timeline will typically show 20-30 articles at once in the virtual list. The maximum number
+// of sensitive images per article is 4. 30*4=120, so this is a very conservative number.
+const cache = new QuickLRU({ maxSize: 150 })
 
 let worker
 let canvas
 let canvasContext2D
+
+cache.on('evict', (evictedUrl, blurhash) => {
+  console.log('evicted URL', evictedUrl, 'with blurhash', blurhash)
+  URL.revokeObjectURL(evictedUrl)
+})
 
 export function init () {
   worker = worker || new PromiseWorker(new BlurhashWorker())
@@ -40,10 +47,10 @@ async function decodeWithoutCache (blurhash) {
 }
 
 export async function decode (blurhash) {
-  let result = CACHE.get(blurhash)
+  let result = cache.get(blurhash)
   if (!result) {
     result = await decodeWithoutCache(blurhash)
-    CACHE.set(blurhash, result)
+    cache.set(blurhash, result)
   }
   return result
 }

--- a/src/routes/_utils/blurhash.js
+++ b/src/routes/_utils/blurhash.js
@@ -5,6 +5,7 @@ import { QuickLRU } from '../_thirdparty/quick-lru/quick-lru'
 
 // A timeline will typically show 20-30 articles at once in the virtual list. The maximum number
 // of sensitive images per article is 4. 30*4=120, so this is a very conservative number.
+// Blurhash blobs seem to range from ~1.2-2kB, so this cache could grow to about 2kB*150=300kB max.
 const cache = new QuickLRU({ maxSize: 150 })
 
 let worker
@@ -34,6 +35,7 @@ async function decodeUsingCanvas (imageData) {
   initCanvas()
   canvasContext2D.putImageData(imageData, 0, 0)
   const blob = await new Promise(resolve => canvas.toBlob(resolve))
+  console.log('blob.size', blob.size)
   return URL.createObjectURL(blob)
 }
 

--- a/tests/unit/test-quick-lru.js
+++ b/tests/unit/test-quick-lru.js
@@ -1,0 +1,34 @@
+/* global describe, it */
+
+import { QuickLRU } from '../../src/routes/_thirdparty/quick-lru/quick-lru'
+import assert from 'assert'
+
+describe('test-quick-lru.js', () => {
+  it('fires evict events correctly', () => {
+    return new Promise((resolve) => {
+      const cache = new QuickLRU({ maxSize: 3 })
+      const evictions = []
+      cache.on('evict', (value, key) => {
+        evictions.push({ key, value })
+      })
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3)
+      cache.set('d', 4)
+      cache.set('e', 5)
+      cache.set('f', 6)
+      cache.set('a', 1)
+      cache.set('d', 4)
+      cache.set('g', 7)
+      Promise.resolve().then(() => resolve(evictions))
+    }).then(evictions => {
+      assert.deepStrictEqual(evictions, [
+        { key: 'a', value: 1 },
+        { key: 'b', value: 2 },
+        { key: 'c', value: 3 },
+        { key: 'e', value: 5 },
+        { key: 'f', value: 6 }
+      ])
+    })
+  })
+})

--- a/tests/unit/test-quick-lru.js
+++ b/tests/unit/test-quick-lru.js
@@ -5,30 +5,50 @@ import assert from 'assert'
 
 describe('test-quick-lru.js', () => {
   it('fires evict events correctly', () => {
-    return new Promise((resolve) => {
-      const cache = new QuickLRU({ maxSize: 3 })
-      const evictions = []
-      cache.on('evict', (value, key) => {
-        evictions.push({ key, value })
-      })
-      cache.set('a', 1)
-      cache.set('b', 2)
-      cache.set('c', 3)
-      cache.set('d', 4)
-      cache.set('e', 5)
-      cache.set('f', 6)
-      cache.set('a', 1)
-      cache.set('d', 4)
-      cache.set('g', 7)
-      Promise.resolve().then(() => resolve(evictions))
-    }).then(evictions => {
-      assert.deepStrictEqual(evictions, [
-        { key: 'a', value: 1 },
-        { key: 'b', value: 2 },
-        { key: 'c', value: 3 },
-        { key: 'e', value: 5 },
-        { key: 'f', value: 6 }
-      ])
+    const cache = new QuickLRU({ maxSize: 3 })
+    const evictions = []
+    cache.on('evict', (value, key) => {
+      evictions.push({ key, value })
     })
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('c', 3)
+    cache.set('d', 4)
+    cache.set('e', 5)
+    cache.set('f', 6)
+    cache.set('a', 1)
+    cache.set('d', 4)
+    cache.set('g', 7)
+    assert.deepStrictEqual(evictions, [
+      { key: 'a', value: 1 },
+      { key: 'b', value: 2 },
+      { key: 'c', value: 3 },
+      { key: 'e', value: 5 },
+      { key: 'f', value: 6 }
+    ])
+  })
+
+  it('fires evict events correctly, using get()', () => {
+    const cache = new QuickLRU({ maxSize: 3 })
+    const evictions = []
+    cache.on('evict', (value, key) => {
+      evictions.push({ key, value })
+    })
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('c', 3)
+    cache.set('d', 4)
+    cache.set('e', 5)
+    cache.set('f', 6)
+    cache.set('a', 1)
+    cache.get('e')
+    cache.set('g', 7)
+    assert.deepStrictEqual(evictions, [
+      { key: 'a', value: 1 },
+      { key: 'b', value: 2 },
+      { key: 'c', value: 3 },
+      { key: 'd', value: 4 },
+      { key: 'f', value: 6 }
+    ])
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6117,11 +6117,6 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
fixes #1402

I forked quick-lru to do this. The added benefit is that I could remove a bunch of unused code from that module.