### PR TITLE
fix: move worker-loader to webpack config

### DIFF
--- a/src/routes/_utils/blurhash.js
+++ b/src/routes/_utils/blurhash.js
@@ -1,4 +1,4 @@
-import BlurhashWorker from 'worker-loader!../_workers/blurhash' // eslint-disable-line
+import BlurhashWorker from '../_workers/blurhash'
 import PromiseWorker from 'promise-worker'
 import { BLURHASH_RESOLUTION as RESOLUTION } from '../_static/blurhash'
 import QuickLRU from 'quick-lru'

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -36,6 +36,12 @@ module.exports = {
         }
       },
       {
+        test: /\/_workers\/blurhash\.js$/,
+        use: {
+          loader: 'worker-loader'
+        }
+      },
+      {
         test: /\.m?js$/,
         include: /node_modules\/emoji-mart/,
         use: {

--- a/webpack/server.config.js
+++ b/webpack/server.config.js
@@ -5,6 +5,7 @@ const { mode, dev, resolve, inlineSvgs } = require('./shared.config')
 
 const serverResolve = JSON.parse(JSON.stringify(resolve))
 serverResolve.alias['page-lifecycle/dist/lifecycle.mjs'] = 'lodash-es/noop' // page lifecycle fails in Node
+serverResolve.alias['../_workers/blurhash'] = 'lodash-es/noop' // not used on the server side
 
 module.exports = {
   entry: config.server.entry(),


### PR DESCRIPTION
This avoids ESLint complaining about the `worker-loader!` declaration