### PR TITLE
perf: improve input responsiveness in compose input

### DIFF
--- a/src/routes/_components/compose/ComposeBox.html
+++ b/src/routes/_components/compose/ComposeBox.html
@@ -102,6 +102,7 @@
   import { postStatus, insertHandleForReply, setReplySpoiler, setReplyVisibility } from '../../_actions/compose'
   import { classname } from '../../_utils/classname'
   import { POLL_EXPIRY_DEFAULT } from '../../_static/polls'
+  import { scheduleIdleTask } from '../../_utils/scheduleIdleTask'
 
   export default {
     oncreate () {
@@ -179,6 +180,13 @@
     },
     methods: {
       doPostStatus () {
+        // The reason we add a scheduleIdleTask delay here is because we also use scheduleIdleTask
+        // in ComposeInput.html to debounce the input events. If the user is very fast at typing
+        // at their keyboard and quickly presses Ctrl+Enter or the "Toot" button then there could
+        // be a race condition where not all of their status is posted.
+        scheduleIdleTask(() => this.doPostStatusAfterDelay())
+      },
+      doPostStatusAfterDelay () {
         const {
           text,
           media,

--- a/src/routes/_components/compose/ComposeInput.html
+++ b/src/routes/_components/compose/ComposeInput.html
@@ -59,7 +59,6 @@
   import { store } from '../../_store/store'
   import { autosize } from '../../_thirdparty/autosize/autosize'
   import { scheduleIdleTask } from '../../_utils/scheduleIdleTask'
-  import debounce from 'lodash-es/debounce'
   import { mark, stop } from '../../_utils/marks'
   import { selectionChange } from '../../_utils/events'
   import {
@@ -70,6 +69,9 @@
   import { get } from '../../_utils/lodash-lite'
   import { on } from '../../_utils/eventBus'
   import { requestPostAnimationFrame } from '../../_utils/requestPostAnimationFrame'
+  import { throttleTimer } from '../../_utils/throttleTimer'
+
+  const updateComposeTextInStore = throttleTimer(scheduleIdleTask)
 
   export default {
     oncreate () {
@@ -106,14 +108,14 @@
         })
       },
       setupSyncToStore () {
-        const saveStore = debounce(() => scheduleIdleTask(() => this.store.save()), 1000)
-
+        const { realm } = this.get()
         this.observe('rawText', rawText => {
-          mark('observe rawText')
-          const { realm } = this.get()
-          this.store.setComposeData(realm, { text: rawText })
-          saveStore()
-          stop('observe rawText')
+          updateComposeTextInStore(() => {
+            mark('updateComposeTextInStore')
+            this.store.setComposeData(realm, { text: rawText })
+            this.store.save()
+            stop('updateComposeTextInStore')
+          })
         }, { init: false })
       },
       setupAutosize () {

--- a/src/routes/_thirdparty/autosize/autosize.js
+++ b/src/routes/_thirdparty/autosize/autosize.js
@@ -73,17 +73,12 @@ function assign (ta) {
   const destroy = () => {
     window.removeEventListener('resize', pageResize, false)
     ta.removeEventListener('input', deferredUpdate, false)
-    ta.removeEventListener('autosize:destroy', destroy, false)
-    ta.removeEventListener('autosize:update', update, false)
 
     map.delete(ta)
   }
 
-  ta.addEventListener('autosize:destroy', destroy, false)
-
   window.addEventListener('resize', pageResize, false)
   ta.addEventListener('input', deferredUpdate, false)
-  ta.addEventListener('autosize:update', update, false)
 
   map.set(ta, {
     destroy,

--- a/src/routes/_thirdparty/autosize/autosize.js
+++ b/src/routes/_thirdparty/autosize/autosize.js
@@ -5,8 +5,10 @@
 
 import { mark, stop } from '../../_utils/marks'
 import debounce from 'lodash-es/debounce'
-import throttle from 'lodash-es/throttle'
 import { getScrollContainer } from '../../_utils/scrollContainer'
+import { throttleTimer } from '../../_utils/throttleTimer'
+
+const doUpdate = process.browser && throttleTimer(requestAnimationFrame)
 
 const map = new Map()
 const createEvent = (name) => new Event(name, { bubbles: true })
@@ -59,7 +61,7 @@ function assign (ta) {
     return endHeight
   }
 
-  const deferredUpdate = throttle(() => requestAnimationFrame(update), 100)
+  const deferredUpdate = () => doUpdate(update)
 
   function update () {
     mark('autosize:update()')


### PR DESCRIPTION
1. Throttle using the technique described in [my blog post](https://nolanlawson.com/2019/08/11/high-performance-input-handling-on-the-web/))
2. Syncing to the store is debounced via requestIdleCallback
3. textarea auto-resizing happens more instantly now, which looks nicer

Profiling indicates this is about the same as before, but more consistent, probably because I'm aligning with rAF rather than throttling to an arbitrary 100ms.