### PR TITLE
perf: use more efficient CSS selectors for inline media

### DIFF
--- a/src/routes/_components/status/Media.html
+++ b/src/routes/_components/status/Media.html
@@ -1,7 +1,7 @@
 {#if (type === 'video' && !blurhash) || type === 'audio'}
     <button id={elementId}
             type="button"
-            class="play-video-button focus-after {$largeInlineMedia ? '' : 'fixed-size'} {type === 'audio' ? 'play-audio-button' : ''}"
+            class="inline-media play-video-button focus-after {$largeInlineMedia ? '' : 'fixed-size'} {type === 'audio' ? 'play-audio-button' : ''}"
             aria-label="Play video: {description}"
             style="width: {inlineWidth}px; height: {inlineHeight}px;">
       <PlayVideoIcon />
@@ -22,7 +22,7 @@
 {:else}
   <button id={elementId}
           type="button"
-          class="show-image-button focus-after {$largeInlineMedia ? '' : 'fixed-size'}"
+          class="inline-media show-image-button focus-after {$largeInlineMedia ? '' : 'fixed-size'}"
           aria-label="Show image: {description}"
           title={description}
           on:mouseover="set({mouseover: event})"

--- a/src/routes/_components/status/MediaAttachments.html
+++ b/src/routes/_components/status/MediaAttachments.html
@@ -23,16 +23,16 @@
     border-radius: 6px;
   }
 
-  .status-media.grouped-images > :global(*) {
+  .status-media.grouped-images > :global(.inline-media) {
       padding-bottom: 56.25%;
       width: 100%;
   }
 
-  .status-media.grouped-images.two-cols > :global(*) {
+  .status-media.grouped-images.two-cols > :global(.inline-media) {
       padding-bottom: calc(112.5% + 5px);
   }
 
-  .status-media.grouped-images.odd-cols > :global(:first-child) {
+  .status-media.grouped-images.odd-cols > :global(.inline-media:first-child) {
       grid-row-end: span 2;
       padding-bottom: calc(112.5% + 5px);
       background-color: blue;


### PR DESCRIPTION
It makes me nervous to have overly-generic selectors on the right-hand-side of a CSS selector. I know [browsers have optimized this](https://calendar.perfplanet.com/2011/css-selector-performance-has-changed-for-the-better/) but bloom filters can still report false positives, so it's best to err on the side of caution here, especially since it's easy to add a class name to the inline media elements.