### PR TITLE
fix: use url over id as media upload cache key

### DIFF
--- a/src/routes/_actions/media.js
+++ b/src/routes/_actions/media.js
@@ -13,7 +13,7 @@ export async function doMediaUpload (realm, file) {
     if (composeMedia.length === 4) {
       throw new Error('Only 4 media max are allowed')
     }
-    mediaUploadFileCache.set(response.id, file)
+    mediaUploadFileCache.set(response.url, file)
     composeMedia.push({
       data: response,
       file: { name: file.name },

--- a/src/routes/_components/dialog/components/MediaAltEditor.html
+++ b/src/routes/_components/dialog/components/MediaAltEditor.html
@@ -120,8 +120,7 @@
     computed: {
       length: ({ rawText }) => length(rawText || ''),
       overLimit: ({ mediaAltCharLimit, length }) => length > mediaAltCharLimit,
-      url: ({ media, index }) => get(media, [index, 'data', 'url']),
-      mediaId: ({ media, index }) => get(media, [index, 'data', 'id'])
+      url: ({ media, index }) => get(media, [index, 'data', 'url'])
     },
     methods: {
       observe,
@@ -167,8 +166,8 @@
       async onClick () {
         this.set({ extracting: true })
         try {
-          const { url, mediaId } = this.get()
-          const file = mediaUploadFileCache.get(mediaId)
+          const { url } = this.get()
+          const file = mediaUploadFileCache.get(url)
           let text
           if (file) { // Avoid downloading from the network a file that the user *just* uploaded
             const fileUrl = URL.createObjectURL(file)


### PR DESCRIPTION
The id may be the same across instances but the URL is not. So it's safer to use the URL as the key.