### PR TITLE
refactor(store/observers/instance): Don't fetch lists eagerly

### DIFF
--- a/src/routes/_store/observers/instanceObservers.js
+++ b/src/routes/_store/observers/instanceObservers.js
@@ -1,5 +1,4 @@
 import { updateInstanceInfo, updateVerifyCredentialsForInstance } from '../../_actions/instances'
-import { updateListsForInstance } from '../../_actions/lists'
 import { createStream } from '../../_actions/stream/streaming'
 import { updatePushSubscriptionForInstance } from '../../_actions/pushSubscription'
 import { updateCustomEmojiForInstance } from '../../_actions/emoji'
@@ -42,7 +41,6 @@ async function doRefreshInstanceDataAndStream (store, instanceName) {
 async function refreshInstanceData (instanceName) {
   // these are all low-priority
   scheduleIdleTask(() => updateCustomEmojiForInstance(instanceName))
-  scheduleIdleTask(() => updateListsForInstance(instanceName))
   scheduleIdleTask(() => updatePushSubscriptionForInstance(instanceName))
 
   // these are the only critical ones


### PR DESCRIPTION
They are already fetched on-demand when the community column is loaded.

Part of https://github.com/nolanlawson/pinafore/issues/812.