### PR TITLE
fix: h2 in media edit dialog should be h1

### DIFF
--- a/src/routes/_components/dialog/components/MediaEditDialog.html
+++ b/src/routes/_components/dialog/components/MediaEditDialog.html
@@ -8,7 +8,7 @@
 >
   <div class="media-edit-dialog-container">
     <div class="media-edit-header-and-item media-edit-header-and-item-alt">
-      <h2>Description</h2>
+      <h1>Description</h1>
       <MediaAltEditor
         className="media-edit-item"
         {realm}
@@ -20,7 +20,7 @@
     </div>
     {#if type === 'image'}
       <div class="media-edit-header-and-item media-edit-header-and-item-focal">
-        <h2>Preview (focal point)</h2>
+        <h1>Preview (focal point)</h1>
         <MediaFocalPointEditor
           className="media-edit-item"
           {realm}
@@ -49,8 +49,9 @@
     padding: 10px;
   }
 
-  .media-edit-header-and-item h2 {
+  .media-edit-header-and-item h1 {
     margin-bottom: 10px;
+    font-size: 1.4em;
   }
 
   @media (max-width: 767px) {
@@ -84,7 +85,7 @@
       flex-basis: 60%;
     }
 
-    .media-edit-header-and-item h2 {
+    .media-edit-header-and-item h1 {
       font-size: 1.2em;
       margin-bottom: 5px;
     }


### PR DESCRIPTION
The dialog is in its own document, so the heading level should start
back at h1.