### PR TITLE
fix: length indicator aria-label should not be negative

### DIFF
--- a/src/routes/_components/LengthIndicator.html
+++ b/src/routes/_components/LengthIndicator.html
@@ -43,7 +43,7 @@
       lengthToDisplay: ({ length, max }) => max - length,
       lengthLabel: ({ overLimit, lengthToDisplayDeferred }) => {
         if (overLimit) {
-          return `${lengthToDisplayDeferred} characters over limit`
+          return `${-lengthToDisplayDeferred} characters over limit`
         } else {
           return `${lengthToDisplayDeferred} characters remaining`
         }


### PR DESCRIPTION
It should say "5 characters over limit", not "-5 characters over limit"