### PR TITLE
fix: remove avatars from tab order / screenreaders

### DIFF
--- a/src/routes/_components/compose/ComposeAuthor.html
+++ b/src/routes/_components/compose/ComposeAuthor.html
@@ -1,14 +1,17 @@
 <a {href}
    rel="prefetch"
    class="compose-box-avatar {loaded ? 'loaded' : 'not-loaded'}"
-   aria-hidden={true}
+   aria-hidden="true"
+   tabindex="-1"
    on:click="onClick(event)"
 >
+  <!-- the avatar is duplicated information, so hide from tab order and screenreaders -->
   <Avatar account={verifyCredentials} size="small"/>
 </a>
 <a class="compose-box-display-name {loaded ? 'loaded' : 'not-loaded'}"
    {href}
-   aria-hidden={!loaded}
+   aria-busy={!loaded}
+   aria-live="polite"
    rel="prefetch"
    on:click="onClick(event)"
 >
@@ -16,7 +19,9 @@
 </a>
 
 <span class="compose-box-handle {loaded ? 'loaded' : 'not-loaded'}"
-      aria-hidden={!loaded} >
+      aria-busy={!loaded}
+      aria-live="polite"
+>
   {'@' + verifyCredentials.acct}
 </span>
 <style>

--- a/src/routes/_components/compose/ComposeAuthor.html
+++ b/src/routes/_components/compose/ComposeAuthor.html
@@ -11,7 +11,7 @@
 <a class="compose-box-display-name {loaded ? 'loaded' : 'not-loaded'}"
    {href}
    aria-busy={!loaded}
-   aria-live="polite"
+   aria-live="off"
    rel="prefetch"
    on:click="onClick(event)"
 >
@@ -20,7 +20,7 @@
 
 <span class="compose-box-handle {loaded ? 'loaded' : 'not-loaded'}"
       aria-busy={!loaded}
-      aria-live="polite"
+      aria-live="off"
 >
   {'@' + verifyCredentials.acct}
 </span>

--- a/src/routes/_components/status/StatusSidebar.html
+++ b/src/routes/_components/status/StatusSidebar.html
@@ -3,7 +3,9 @@
    rel="prefetch"
    href="/accounts/{originalAccountId}"
    aria-hidden="true"
+   tabindex="-1"
 >
+  <!-- the avatar is duplicated information, so hide from tab order and screenreaders -->
   <Avatar account={originalAccount}
           isLink="true"
           {size} />


### PR DESCRIPTION
These elements are duplicated information (the link and name are right next to them), so they should be hidden from screenreaders and tab order.

I also went ahead and fixed a place where I think I should be using aria-busy instead of aria-hidden, because it's content that's asynchronously loading.