### PR TITLE
fix: fix null exception on community page

### DIFF
--- a/src/routes/_actions/followRequests.js
+++ b/src/routes/_actions/followRequests.js
@@ -2,11 +2,12 @@ import { store } from '../_store/store'
 import { cacheFirstUpdateAfter } from '../_utils/sync'
 import { database } from '../_database/database'
 import { getFollowRequests } from '../_api/followRequests'
+import { get } from '../_utils/lodash-lite'
 
 export async function updateFollowRequestCountIfLockedAccount (instanceName) {
   const { verifyCredentials, loggedInInstances } = store.get()
 
-  if (!verifyCredentials[instanceName].locked) {
+  if (!get(verifyCredentials, [instanceName, 'locked'])) {
     return
   }
 


### PR DESCRIPTION
if you refresh the community page, the verifyCredentials may be null