### PR TITLE
feat: add debug build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,12 @@ Pinafore also offers a "legacy" build designed for older browsers. To build this
 
     LEGACY=1 yarn build
 
+## Debug build
+
+To disable minification in a production build (for debugging purposes), you can run:
+
+    DEBUG=1 yarn build
+
 ## Debugging Webpack
 
 The Webpack Bundle Analyzer `report.html` and `stats.json` are available publicly via e.g.:

--- a/bin/build-inline-script.js
+++ b/bin/build-inline-script.js
@@ -21,13 +21,14 @@ export async function buildInlineScript () {
     plugins: [
       replace({
         'process.browser': true,
+        'process.env.LEGACY': JSON.stringify(process.env.LEGACY),
         'process.env.THEME_COLORS': JSON.stringify(themeColors)
       }),
       process.env.LEGACY && babel({
         runtimeHelpers: true,
         presets: ['@babel/preset-env']
       }),
-      terser({
+      !process.env.DEBUG && terser({
         mangle: true,
         compress: true,
         ecma: 8

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -88,7 +88,7 @@ module.exports = {
   optimization: dev ? {} : {
     minimizer: [
       terser()
-    ],
+    ].filter(Boolean),
     splitChunks: {
       chunks: 'async',
       minSize: 5000,
@@ -130,7 +130,7 @@ module.exports = {
   ]),
   devtool: dev ? 'inline-source-map' : 'source-map',
   performance: {
-    hints: dev ? false : 'error',
+    hints: dev ? false : (process.env.DEBUG ? 'warning' : 'error'),
     assetFilter: assetFilename => {
       return !(/\.map$/.test(assetFilename)) && !/tesseract-asset/.test(assetFilename)
     }

--- a/webpack/service-worker.config.js
+++ b/webpack/service-worker.config.js
@@ -23,5 +23,5 @@ module.exports = {
       'process.env.SAPPER_TIMESTAMP': process.env.SAPPER_TIMESTAMP || Date.now()
     }),
     terser()
-  ]
+  ].filter(Boolean)
 }

--- a/webpack/terser.config.js
+++ b/webpack/terser.config.js
@@ -1,6 +1,6 @@
 const TerserWebpackPlugin = require('terser-webpack-plugin')
 
-module.exports = () => new TerserWebpackPlugin({
+module.exports = () => !process.env.DEBUG && new TerserWebpackPlugin({
   exclude: /tesseract-asset/,
   cache: true,
   parallel: true,


### PR DESCRIPTION
Sometimes I find it useful to debug in production mode. This adds

    DEBUG=1 yarn build

which can be used to disable minification during a production build.