### PR TITLE
feat: press "7" to open compose modal

### DIFF
--- a/src/routes/_components/NavShortcuts.html
+++ b/src/routes/_components/NavShortcuts.html
@@ -7,7 +7,7 @@
 <Shortcut key="g d" on:pressed="goto('/direct')"/>
 <Shortcut key="s" on:pressed="goto('/search')"/>
 <Shortcut key="h|?" on:pressed="showShortcutHelpDialog()"/>
-<Shortcut key="c" on:pressed="showComposeDialog()"/>
+<Shortcut key="c|7" on:pressed="showComposeDialog()"/>
 {#each $navPages as navPage, i}
   <Shortcut key={(i + 1).toString()} on:pressed="goto(navPage.href)" />
 {/each}

--- a/src/routes/_components/ShortcutHelpInfo.html
+++ b/src/routes/_components/ShortcutHelpInfo.html
@@ -5,9 +5,9 @@
   <h2>Global</h2>
   <div class="hotkey-group">
     <ul>
-      <li><kbd>c</kbd> to compose a new toot</li>
-      <li><kbd>s</kbd> to search</li>
       <li><kbd>1</kbd> - <kbd>6</kbd> to switch columns</li>
+      <li><kbd>7</kbd> or <kbd>c</kbd> to compose a new toot</li>
+      <li><kbd>s</kbd> to search</li>
       <li><kbd>g</kbd> + <kbd>h</kbd> to go home</li>
       <li><kbd>g</kbd> + <kbd>n</kbd> to go to notifications</li>
       <li><kbd>g</kbd> + <kbd>l</kbd> to go to the local timeline</li>


### PR DESCRIPTION
Visually the sticky-positioned "toot" button looks like it might be the 7th nav button, so it makes sense to add a keyboard shortcut for "7". In addition, this improves access to the modal on KaiOS which cannot easily input a "c" character.