### PR TITLE
fix: attempt to fix Safari login bug

### DIFF
--- a/src/routes/_actions/addInstance.js
+++ b/src/routes/_actions/addInstance.js
@@ -40,7 +40,10 @@ async function redirectToOauth () {
     instanceData.client_id,
     REDIRECT_URI
   )
-  document.location.href = oauthUrl
+  // setTimeout to allow the browser to *actually* save the localStorage data (fixes Safari bug apparently)
+  setTimeout(() => {
+    document.location.href = oauthUrl
+  }, 200)
 }
 
 export async function logInToInstance () {


### PR DESCRIPTION
Based on my testing, adding a delay here *may* fix the Safari issue. It seems to be some sort of timing problem, where the localStorage ends up being empty after we navigate back from the target Mastodon instance. I'm hoping that adding a 200ms delay will fix it.