### PR TITLE
fix: don't set aria-activedescendant immediately on autocomplete textarea

### DIFF
--- a/src/routes/_components/compose/ComposeInput.html
+++ b/src/routes/_components/compose/ComposeInput.html
@@ -3,10 +3,10 @@
   class="compose-box-input compose-box-input-realm-{realm}"
   placeholder="What's on your mind?"
   aria-describedby="compose-box-input-description-{realm}"
-  aria-owns="compose-autosuggest-list-{realm}"
+  aria-owns="{autosuggestShownForThisInput ? `compose-autosuggest-list-${realm}` : undefined}"
   aria-expanded={autosuggestShownForThisInput}
   aria-autocomplete="both"
-  aria-activedescendant="{autosuggestShownForThisInput ? `compose-autosuggest-active-item-${realm}` : ''}"
+  aria-activedescendant="{autosuggestShownForThisInput ? `compose-autosuggest-active-item-${realm}` : undefined}"
   ref:textarea
   bind:value=rawText
   on:blur="onBlur()"


### PR DESCRIPTION
After some testing on NVDA on Windows on Chrome/Firefox/FirefoxDeveloperEdition and on VoiceOver on Safari macOS, I believe this is the best implementation.

This changes the code so that we don't set `aria-activedescendant` or `aria-owns` until autocomplete results are available. We remove and add the `aria-activedescendant` and `aria-owns` attributes as the autocomplete results appear and disappear. This should make is so that the `aria-hidden` element which is referenced by `aria-activedescendant`/`aria-owns` is not referenced until it's no longer `aria-hidden`.

@marcozehe I don't think I could reproduce the exact issue you describe in NVDA on Firefox Developer Edition, but I believe this fix is an improvement in VoiceOver on Safari at least. The best screenreader seems to be NVDA on Chrome, because the others have odd bugs:

1. In VoiceOver on Safari, the first autocomplete result is not spoken. Autocomplete results aren't spoken until you actually press the down or up arrows to move through the list. (Without this PR, autocomplete results aren't spoken at all.)
2. In Firefox and Firefox Developer Edition using NVDA, there is an odd issue where it tries to speak the text that I've typed in, but it comes out garbled. For instances, sometimes it speaks the numbers "1" or "2" or "3" several times. I see this both in the current implementation on `dev.pinafore.social` and in this PR.

I couldn't figure out how to solve either of these issues.