### PR TITLE
fix: remove focus-after class on nav items

### DIFF
--- a/src/routes/_components/NavItem.html
+++ b/src/routes/_components/NavItem.html
@@ -1,4 +1,4 @@
-<a class='main-nav-link focus-after {selected ? "selected" : ""}'
+<a class='main-nav-link {selected ? "selected" : ""}'
    aria-label={ariaLabel}
    aria-current={selected}
    on:click="onClick(event)"


### PR DESCRIPTION
this broke the navigation animation, so let's remove it for now