### PR TITLE
fix: remove aria-live region for autosuggest

### DIFF
--- a/src/routes/_components/compose/ComposeAutosuggest.html
+++ b/src/routes/_components/compose/ComposeAutosuggest.html
@@ -8,9 +8,6 @@
     selected={autosuggestSelected}
     {realm}
   />
-  <div class="sr-only" aria-live="assertive">
-    {assertiveAriaText}
-  </div>
 </div>
 <style>
   .compose-autosuggest {
@@ -57,7 +54,6 @@
   import { selectAutosuggestItem } from '../../_actions/autosuggest'
   import { observe } from 'svelte-extras'
   import { once } from '../../_utils/once'
-  import { createAutosuggestAccessibleLabel } from '../../_utils/createAutosuggestAccessibleLabel'
 
   export default {
     oncreate () {
@@ -111,21 +107,7 @@
       /* eslint-enable camelcase */
       shouldBeShown: ({ realm, $autosuggestShown, composeFocused }) => (
         !!($autosuggestShown && composeFocused)
-      ),
-      // text that is read to screen readers. based on https://haltersweb.github.io/Accessibility/autocomplete.html
-      assertiveAriaText: ({
-        shouldBeShown,
-        autosuggestSearchResults,
-        autosuggestSelected,
-        autosuggestType,
-        $omitEmojiInDisplayNames
-      }) => {
-        if (!shouldBeShown || !autosuggestSearchResults || !autosuggestSearchResults.length) {
-          return ''
-        }
-        return createAutosuggestAccessibleLabel(autosuggestType, $omitEmojiInDisplayNames,
-          autosuggestSelected, autosuggestSearchResults)
-      }
+      )
     },
     data: () => ({
       shown: false


### PR DESCRIPTION
After some testing and based on [this suggestion](https://toot.cafe/@marcozehe/102840228729195138) from @MarcoZehe, I think we should just remove the `aria-live` region from the autosuggest. It always felt hacky to me anyway.

I got the original idea from [this implementation](https://haltersweb.github.io/Accessibility/autocomplete.html), but I wonder if it's outdated or wrong. My current implementation seems to cause double utterances in Firefox and some weird garbled text (letter artifacts) as well.

With this new implementation, the results are _perfect_ in Firefox Developer Edition (v70) using NVDA. All other environments I tested have some bugs, but are usable IMO.

- Safari on macOS with VoiceOver: announces that autocomplete results are available, but doesn't announce the first item in the list. Only starts announcing items after you press up and down. Sometimes it gets into a state where it doesn't announce anything, but this only seems to occur when the tab focus and screenreader focus get out of sync, and can be fixed by tabbing out and back in again. I have not found a fix for that.
- Firefox v69 with NVDA: announces that autocomplete results are available, but doesn't announce the first item. Like Safari, you have to press up or down to see the first item
- Chrome with NVDA: only announces the first item. Pressing up or down doesn't announce any new items. But at least it announces the first one.

I tried _not_ swapping out `aria-owns` whenever the owned element becomes `aria-hidden`, but this broke Safari entirely (it stopped speaking any results).

Overall this PR seems to be a slight regression for Chrome+NVDA, no change for Safari+VoiceOver, and a big improvement for Firefox+NVDA. Since I assume NVDA is most commonly used with Firefox, this PR seems like the best implementation I can think of for now.