### PR TITLE
fix: improve focus styles

### DIFF
--- a/src/routes/_components/NavItem.html
+++ b/src/routes/_components/NavItem.html
@@ -1,4 +1,4 @@
-<a class='main-nav-link {selected ? "selected" : ""}'
+<a class='main-nav-link focus-fix {selected ? "selected" : ""}'
    aria-label={ariaLabel}
    aria-current={selected}
    on:click="onClick(event)"
@@ -22,7 +22,6 @@
     align-items: center;
     flex: 1;
     flex-direction: column;
-    outline-offset: calc(-1 * var(--focus-width)); /* TODO: this is hacky, switch to box-sizing:border-box */
   }
 
   .nav-icon-and-label {

--- a/src/routes/_components/TabSet.html
+++ b/src/routes/_components/TabSet.html
@@ -3,6 +3,7 @@
     {#each tabs as tab (tab.name)}
     <li class="{currentTabName === tab.name ? 'current' : 'not-current'}">
       <a aria-label="{tab.label} { currentTabName === tab.name ? '(Current)' : ''}"
+         class="focus-fix"
          href={tab.href}
          rel="prefetch">
         {tab.label}

--- a/src/routes/_components/dialog/components/GenericDialogList.html
+++ b/src/routes/_components/dialog/components/GenericDialogList.html
@@ -2,7 +2,7 @@
   {#each items as item (item.key)}
   <li class="generic-dialog-list-item">
     <button
-        class="generic-dialog-list-button focus-after"
+        class="generic-dialog-list-button focus-fix"
         on:click="fire('click', item)">
       <!-- Extra wrapper inside button is required for KaiOS. Seems old Firefox does not like flex buttons. -->
       <div class="generic-dialog-list-button-inner">

--- a/src/routes/_components/dialog/components/ModalDialog.html
+++ b/src/routes/_components/dialog/components/ModalDialog.html
@@ -13,7 +13,7 @@
         <h1 class="modal-dialog-title">{title}</h1>
       {/if}
       <div class="close-dialog-button-wrapper">
-        <button class="close-dialog-button focus-after"
+        <button class="close-dialog-button focus-fix"
                 data-a11y-dialog-hide aria-label="Close dialog">
           <SvgIcon className="close-dialog-button-svg" href="#fa-times" />
         </button>

--- a/src/routes/_components/settings/SettingsListButton.html
+++ b/src/routes/_components/settings/SettingsListButton.html
@@ -2,7 +2,7 @@
    on:click="fire('click', event)"
    rel="prefetch"
    aria-label={ariaLabel || label}
-   class="settings-list-button focus-after {className ? className : ''}"
+   class="settings-list-button focus-fix {className ? className : ''}"
 >
   <span>
     {label}

--- a/src/routes/_components/status/Media.html
+++ b/src/routes/_components/status/Media.html
@@ -1,7 +1,7 @@
 {#if !blurhash && (type === 'video' || type === 'audio')}
     <button id={elementId}
             type="button"
-            class="inline-media play-video-button focus-after {$largeInlineMedia ? '' : 'fixed-size'} {type === 'audio' ? 'play-audio-button' : ''}"
+            class="inline-media play-video-button focus-fix {$largeInlineMedia ? '' : 'fixed-size'} {type === 'audio' ? 'play-audio-button' : ''}"
             aria-label="Play video: {description}"
             style={inlineMediaStyle}>
       <PlayVideoIcon />
@@ -22,7 +22,7 @@
 {:else}
   <button id={elementId}
           type="button"
-          class="inline-media show-image-button focus-after {$largeInlineMedia ? '' : 'fixed-size'}"
+          class="inline-media show-image-button focus-fix {$largeInlineMedia ? '' : 'fixed-size'}"
           aria-label="Show image: {description}"
           title={description}
           on:mouseover="set({mouseover: event})"

--- a/src/routes/_components/status/Media.html
+++ b/src/routes/_components/status/Media.html
@@ -1,7 +1,7 @@
 {#if !blurhash && (type === 'video' || type === 'audio')}
     <button id={elementId}
             type="button"
-            class="inline-media play-video-button focus-fix {$largeInlineMedia ? '' : 'fixed-size'} {type === 'audio' ? 'play-audio-button' : ''}"
+            class="inline-media play-video-button focus-after {$largeInlineMedia ? '' : 'fixed-size'} {type === 'audio' ? 'play-audio-button' : ''}"
             aria-label="Play video: {description}"
             style={inlineMediaStyle}>
       <PlayVideoIcon />
@@ -22,7 +22,7 @@
 {:else}
   <button id={elementId}
           type="button"
-          class="inline-media show-image-button focus-fix {$largeInlineMedia ? '' : 'fixed-size'}"
+          class="inline-media show-image-button focus-after {$largeInlineMedia ? '' : 'fixed-size'}"
           aria-label="Show image: {description}"
           title={description}
           on:mouseover="set({mouseover: event})"
@@ -83,6 +83,10 @@
 
   .show-image-button {
     cursor: zoom-in;
+  }
+
+  .inline-media {
+    position: relative;
   }
 
   @media (max-width: 240px) {

--- a/src/routes/_components/status/Notification.html
+++ b/src/routes/_components/status/Notification.html
@@ -70,7 +70,7 @@
       className: ({ $underlineLinks }) => (classname(
         'notification-article',
         'shortcut-list-item',
-        'focus-after',
+        'focus-fix',
         $underlineLinks && 'underline-links'
       ))
     },

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -294,7 +294,7 @@
       className: ({ visibility, timelineType, isStatusInOwnThread, $underlineLinks, $disableTapOnStatus }) => (classname(
         'status-article',
         'shortcut-list-item',
-        'focus-after',
+        'focus-fix',
         timelineType !== 'direct' && visibility === 'direct' && 'status-direct',
         timelineType !== 'search' && 'status-in-timeline',
         isStatusInOwnThread && 'status-in-own-thread',

--- a/src/routes/_components/status/StatusPoll.html
+++ b/src/routes/_components/status/StatusPoll.html
@@ -48,6 +48,7 @@
     </li>
     <li class="poll-stat {notification ? 'is-notification' : ''} {expired ? 'poll-expired' : ''}">
       <button id={refreshElementId}
+              class="focus-fix"
               aria-label="Refresh">
         <SvgIcon className="poll-icon" href="#fa-refresh" />
         <span class="poll-stat-text poll-stat-text-refresh" aria-hidden="true">

--- a/src/scss/focus.scss
+++ b/src/scss/focus.scss
@@ -1,6 +1,6 @@
 
 
-*:focus, .focus {
+*:focus {
   outline: var(--focus-width) solid var(--focus-outline);
 }
 
@@ -15,6 +15,26 @@
 /* TODO: use box-sizing:border-box everywhere so we can get rid of this hack */
 .focus-fix:focus {
   outline-offset: calc(-1 * var(--focus-width)); /* TODO: this is hacky, switch to box-sizing:border-box */
+}
+
+/* Another hack to make some focus styles appear better */
+.focus-after {
+  position: relative;
+}
+
+.focus-after:focus {
+  outline: none;
+}
+
+.focus-after:focus::after {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  content: '';
+  border: var(--focus-width) solid var(--focus-outline);
+  pointer-events: none;
 }
 
 // For KaiOS, do some additional things to improve the focus styles, which don't show up well
@@ -36,7 +56,7 @@
     position: relative;
   }
 
-  // add extremely obvious styles for buttons to increase visibility
+  // add extremely visible styles for buttons, ala .focus-after
   button:focus, .button:focus {
     outline: none;
   }

--- a/src/scss/focus.scss
+++ b/src/scss/focus.scss
@@ -13,46 +13,35 @@
 /* Special class to make focus outlines easier to see in some odd
  * cases where the outline would be clipped. */
 /* TODO: use box-sizing:border-box everywhere so we can get rid of this hack */
-.focus-after {
-  position: relative;
-}
-
-.focus-after:focus {
-  outline: none;
-}
-
-.focus-after:focus::after {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-  content: '';
-  border: var(--focus-width) solid var(--focus-outline);
-  pointer-events: none;
+.focus-fix:focus {
+  outline-offset: calc(-1 * var(--focus-width)); /* TODO: this is hacky, switch to box-sizing:border-box */
 }
 
 // For KaiOS, do some additional things to improve the focus styles, which don't show up well
 // for some reason
 @media (max-width: 240px) {
-  a:focus, span:focus {
+  a:not(.button):focus, span:focus {
     background: var(--focus-bg) !important;
   }
 
-  button:focus {
+  button:focus, .button:focus {
     opacity: 0.7;
   }
 
-  // add extra "focus-after"-like styles for buttons to increase visibility
-  button.icon-button {
+  button.primary:focus, .button.primary:focus {
+    opacity: 0.8;
+  }
+
+  button, .button {
     position: relative;
   }
 
-  button.icon-button:focus {
+  // add extremely obvious styles for buttons to increase visibility
+  button:focus, .button:focus {
     outline: none;
   }
 
-  button.icon-button:focus::after {
+  button:focus::after, .button:focus::after {
     position: absolute;
     left: 0;
     right: 0;


### PR DESCRIPTION
I still feel that our focus styles are hacky (mostly due to lack of `box-sizing:border-box`, but it's slightly better to use `outline` rather than an extra pseudo-element with a `border`, since the latter can cause re-layouts.

On KaiOS I have to go to extreme lengths to make the focus styles more visible, for whatever reason.