### PR TITLE
perf: lazy-load computations (experimental)

### DIFF
--- a/src/routes/_components/NavItem.html
+++ b/src/routes/_components/NavItem.html
@@ -144,7 +144,7 @@
         (name === 'notifications' && $hasNotifications) || (name === 'community' && $hasFollowRequests)
       ),
       badgeNumber: ({ name, $numberOfNotifications, $numberOfFollowRequests }) => (
-        (name === 'notifications' && $numberOfNotifications) || (name === 'community' && $numberOfFollowRequests)
+        (name === 'notifications' && $numberOfNotifications) || (name === 'community' && $numberOfFollowRequests) || 0
       )
     },
     methods: {

--- a/src/routes/_components/compose/LazyComposeBox.html
+++ b/src/routes/_components/compose/LazyComposeBox.html
@@ -6,7 +6,7 @@
 
   export default {
     async oncreate () {
-      const [ composeBox ] = await Promise.all([
+      const [composeBox] = await Promise.all([
         importComposeBox(),
         importLoggedInObserversAndComputations()
       ])

--- a/src/routes/_components/compose/LazyComposeBox.html
+++ b/src/routes/_components/compose/LazyComposeBox.html
@@ -2,13 +2,13 @@
   <svelte:component this={composeBox} {realm} {hidden} />
 {/if}
 <script>
-  import { importComposeBox, importLoggedInObserversAndComputations } from '../../_utils/asyncModules'
+  import { importComposeBox, importLoggedInStoreExtensions } from '../../_utils/asyncModules'
 
   export default {
     async oncreate () {
       const [composeBox] = await Promise.all([
         importComposeBox(),
-        importLoggedInObserversAndComputations()
+        importLoggedInStoreExtensions()
       ])
       this.set({ composeBox })
     },

--- a/src/routes/_components/compose/LazyComposeBox.html
+++ b/src/routes/_components/compose/LazyComposeBox.html
@@ -2,11 +2,14 @@
   <svelte:component this={composeBox} {realm} {hidden} />
 {/if}
 <script>
-  import { importComposeBox } from '../../_utils/asyncModules'
+  import { importComposeBox, importLoggedInObserversAndComputations } from '../../_utils/asyncModules'
 
   export default {
     async oncreate () {
-      const composeBox = await importComposeBox()
+      const [ composeBox ] = await Promise.all([
+        importComposeBox(),
+        importLoggedInObserversAndComputations()
+      ])
       this.set({ composeBox })
     },
     data: () => ({

--- a/src/routes/_components/timeline/LazyTimeline.html
+++ b/src/routes/_components/timeline/LazyTimeline.html
@@ -20,7 +20,7 @@
       this.store.set({ currentTimeline: timeline })
       this.store.setForTimeline(currentInstance, timeline, { runningUpdate: false })
       console.log('importing timeline')
-      const [ timelineComponent ] = await Promise.all([
+      const [timelineComponent] = await Promise.all([
         importTimeline(),
         importLoggedInObserversAndComputations()
       ])

--- a/src/routes/_components/timeline/LazyTimeline.html
+++ b/src/routes/_components/timeline/LazyTimeline.html
@@ -10,7 +10,7 @@
 </style>
 <script>
   import { store } from '../../_store/store'
-  import { importTimeline } from '../../_utils/asyncModules'
+  import { importLoggedInObserversAndComputations, importTimeline } from '../../_utils/asyncModules'
 
   export default {
     async oncreate () {
@@ -20,7 +20,10 @@
       this.store.set({ currentTimeline: timeline })
       this.store.setForTimeline(currentInstance, timeline, { runningUpdate: false })
       console.log('importing timeline')
-      const timelineComponent = await importTimeline()
+      const [ timelineComponent ] = await Promise.all([
+        importTimeline(),
+        importLoggedInObserversAndComputations()
+      ])
       console.log('imported timeline')
       this.set({ timelineComponent })
     },

--- a/src/routes/_components/timeline/LazyTimeline.html
+++ b/src/routes/_components/timeline/LazyTimeline.html
@@ -10,21 +10,19 @@
 </style>
 <script>
   import { store } from '../../_store/store'
-  import { importLoggedInObserversAndComputations, importTimeline } from '../../_utils/asyncModules'
+  import { importLoggedInStoreExtensions, importTimeline } from '../../_utils/asyncModules'
 
   export default {
     async oncreate () {
       console.log('LazyTimeline oncreate')
       const { currentInstance } = this.store.get()
       const { timeline } = this.get()
-      this.store.set({ currentTimeline: timeline })
-      this.store.setForTimeline(currentInstance, timeline, { runningUpdate: false })
-      console.log('importing timeline')
       const [timelineComponent] = await Promise.all([
         importTimeline(),
-        importLoggedInObserversAndComputations()
+        importLoggedInStoreExtensions()
       ])
-      console.log('imported timeline')
+      this.store.set({ currentTimeline: timeline })
+      this.store.setForTimeline(currentInstance, timeline, { runningUpdate: false })
       this.set({ timelineComponent })
     },
     store: () => store,

--- a/src/routes/_store/computations/autosuggestComputations.js
+++ b/src/routes/_store/computations/autosuggestComputations.js
@@ -1,4 +1,5 @@
 import { get } from '../../_utils/lodash-lite'
+import { mark, stop } from '../../_utils/marks'
 
 const MIN_PREFIX_LENGTH = 2
 // Technically mastodon accounts allow dots, but it would be weird to do an autosuggest search if it ends with a dot.
@@ -17,6 +18,7 @@ function computeForAutosuggest (store, key, defaultValue) {
 }
 
 export function autosuggestComputations (store) {
+  mark('autosuggestComputations')
   computeForAutosuggest(store, 'composeFocused', false)
   computeForAutosuggest(store, 'composeSelectionStart', 0)
   computeForAutosuggest(store, 'autosuggestSelected', 0)
@@ -59,4 +61,5 @@ export function autosuggestComputations (store) {
       !!(composeFocused && autosuggestSearchText && autosuggestNumSearchResults)
     )
   )
+  stop('autosuggestComputations')
 }

--- a/src/routes/_store/computations/computations.js
+++ b/src/routes/_store/computations/computations.js
@@ -1,11 +1,7 @@
 import { instanceComputations } from './instanceComputations'
-import { timelineComputations } from './timelineComputations'
 import { navComputations } from './navComputations'
-import { autosuggestComputations } from './autosuggestComputations'
 
 export function computations (store) {
   instanceComputations(store)
-  timelineComputations(store)
   navComputations(store)
-  autosuggestComputations(store)
 }

--- a/src/routes/_store/computations/instanceComputations.js
+++ b/src/routes/_store/computations/instanceComputations.js
@@ -1,4 +1,5 @@
 import { DEFAULT_THEME } from '../../_utils/themeEngine'
+import { mark, stop } from '../../_utils/marks'
 
 function computeForInstance (store, computedKey, key, defaultValue) {
   store.compute(computedKey,
@@ -7,6 +8,7 @@ function computeForInstance (store, computedKey, key, defaultValue) {
 }
 
 export function instanceComputations (store) {
+  mark('instanceComputations')
   computeForInstance(store, 'currentTheme', 'instanceThemes', DEFAULT_THEME)
   computeForInstance(store, 'currentVerifyCredentials', 'verifyCredentials', null)
   computeForInstance(store, 'currentInstanceInfo', 'instanceInfos', null)
@@ -59,4 +61,6 @@ export function instanceComputations (store) {
       (currentInstanceInfo && currentInstanceInfo.max_toot_chars) || 500
     )
   )
+
+  stop('instanceComputations')
 }

--- a/src/routes/_store/computations/loggedInComputations.js
+++ b/src/routes/_store/computations/loggedInComputations.js
@@ -1,0 +1,10 @@
+// like loggedInObservers.js, these can be lazy-loaded once the user is actually logged in
+import { timelineComputations } from './timelineComputations'
+import { autosuggestComputations } from './autosuggestComputations'
+
+import { store } from '../store'
+
+export function loggedInComputations () {
+  timelineComputations(store)
+  autosuggestComputations(store)
+}

--- a/src/routes/_store/computations/navComputations.js
+++ b/src/routes/_store/computations/navComputations.js
@@ -1,4 +1,8 @@
+import { mark, stop } from '../../_utils/marks'
+
 export function navComputations (store) {
+  mark('navComputations')
+
   store.compute(
     'pinnedListTitle',
     ['lists', 'pinnedPage'],
@@ -89,4 +93,6 @@ export function navComputations (store) {
       ]
     }
   )
+
+  stop('navComputations')
 }

--- a/src/routes/_store/computations/timelineComputations.js
+++ b/src/routes/_store/computations/timelineComputations.js
@@ -9,6 +9,7 @@ import {
   NOTIFICATION_POLLS,
   NOTIFICATION_MENTIONS
 } from '../../_static/instanceSettings'
+import { mark, stop } from '../../_utils/marks'
 
 function computeForTimeline (store, key, defaultValue) {
   store.compute(key,
@@ -45,6 +46,7 @@ function computeNotificationFilter (store, computationName, key) {
 }
 
 export function timelineComputations (store) {
+  mark('timelineComputations')
   computeForTimeline(store, 'timelineItemSummaries', null)
   computeForTimeline(store, 'timelineItemSummariesToAdd', null)
   computeForTimeline(store, 'runningUpdate', false)
@@ -191,4 +193,5 @@ export function timelineComputations (store) {
     ['numberOfFollowRequests'],
     (numberOfFollowRequests) => !!numberOfFollowRequests
   )
+  stop('timelineComputations')
 }

--- a/src/routes/_store/loggedInObserversAndComputations.js
+++ b/src/routes/_store/loggedInObserversAndComputations.js
@@ -1,0 +1,6 @@
+import { loggedInComputations } from './computations/loggedInComputations'
+import { loggedInObservers } from './observers/loggedInObservers'
+
+console.log('imported logged in observers and computations')
+loggedInComputations()
+loggedInObservers()

--- a/src/routes/_store/loggedInStoreExtensions.js
+++ b/src/routes/_store/loggedInStoreExtensions.js
@@ -1,6 +1,8 @@
 import { loggedInComputations } from './computations/loggedInComputations'
 import { loggedInObservers } from './observers/loggedInObservers'
+import { loggedInMixins } from './mixins/loggedInMixins'
 
 console.log('imported logged in observers and computations')
+loggedInMixins()
 loggedInComputations()
 loggedInObservers()

--- a/src/routes/_store/mixins/composeMixins.js
+++ b/src/routes/_store/mixins/composeMixins.js
@@ -1,0 +1,27 @@
+import { get } from '../../_utils/lodash-lite'
+
+export function composeMixins (Store) {
+  Store.prototype.setComposeData = function (realm, obj) {
+    const { composeData, currentInstance } = this.get()
+    const instanceNameData = composeData[currentInstance] = composeData[currentInstance] || {}
+    instanceNameData[realm] = Object.assign(
+      instanceNameData[realm] || {},
+      { ts: Date.now() },
+      obj
+    )
+    this.set({ composeData })
+  }
+
+  Store.prototype.getComposeData = function (realm, key) {
+    const { composeData, currentInstance } = this.get()
+    return get(composeData, [currentInstance, realm, key])
+  }
+
+  Store.prototype.clearComposeData = function (realm) {
+    const { composeData, currentInstance } = this.get()
+    if (composeData && composeData[currentInstance]) {
+      delete composeData[currentInstance][realm]
+    }
+    this.set({ composeData })
+  }
+}

--- a/src/routes/_store/mixins/instanceMixins.js
+++ b/src/routes/_store/mixins/instanceMixins.js
@@ -1,32 +1,6 @@
 import { get } from '../../_utils/lodash-lite'
 
 export function instanceMixins (Store) {
-  Store.prototype.setComposeData = function (realm, obj) {
-    const { composeData, currentInstance } = this.get()
-    const instanceNameData = composeData[currentInstance] = composeData[currentInstance] || {}
-    instanceNameData[realm] = Object.assign(
-      instanceNameData[realm] || {},
-      { ts: Date.now() },
-      obj
-    )
-    this.set({ composeData })
-  }
-
-  Store.prototype.getComposeData = function (realm, key) {
-    const { composeData, currentInstance } = this.get()
-    return composeData[currentInstance] &&
-      composeData[currentInstance][realm] &&
-      composeData[currentInstance][realm][key]
-  }
-
-  Store.prototype.clearComposeData = function (realm) {
-    const { composeData, currentInstance } = this.get()
-    if (composeData && composeData[currentInstance]) {
-      delete composeData[currentInstance][realm]
-    }
-    this.set({ composeData })
-  }
-
   Store.prototype.getInstanceSetting = function (instanceName, settingName, defaultValue) {
     const { instanceSettings } = this.get()
     return get(instanceSettings, [instanceName, settingName], defaultValue)

--- a/src/routes/_store/mixins/loggedInMixins.js
+++ b/src/routes/_store/mixins/loggedInMixins.js
@@ -1,0 +1,12 @@
+import { timelineMixins } from './timelineMixins'
+import { statusMixins } from './statusMixins'
+import { autosuggestMixins } from './autosuggestMixins'
+import { composeMixins } from './composeMixins'
+import { PinaforeStore as Store } from '../store'
+
+export function loggedInMixins () {
+  composeMixins(Store)
+  timelineMixins(Store)
+  statusMixins(Store)
+  autosuggestMixins(Store)
+}

--- a/src/routes/_store/mixins/mixins.js
+++ b/src/routes/_store/mixins/mixins.js
@@ -1,11 +1,5 @@
-import { timelineMixins } from './timelineMixins'
 import { instanceMixins } from './instanceMixins'
-import { statusMixins } from './statusMixins'
-import { autosuggestMixins } from './autosuggestMixins'
 
 export function mixins (Store) {
   instanceMixins(Store)
-  timelineMixins(Store)
-  statusMixins(Store)
-  autosuggestMixins(Store)
 }

--- a/src/routes/_store/observers/loggedInObservers.js
+++ b/src/routes/_store/observers/loggedInObservers.js
@@ -8,7 +8,7 @@ import { cleanup } from './cleanup'
 
 // These observers can be lazy-loaded when the user is actually logged in.
 // Prevents circular dependencies and reduces the size of main.js
-export default function loggedInObservers () {
+export function loggedInObservers () {
   instanceObservers()
   timelineObservers()
   notificationObservers()

--- a/src/routes/_store/observers/setupLoggedInObservers.js
+++ b/src/routes/_store/observers/setupLoggedInObservers.js
@@ -1,4 +1,4 @@
-import { importLoggedInObserversAndComputations } from '../../_utils/asyncModules'
+import { importLoggedInStoreExtensions } from '../../_utils/asyncModules'
 
 // An observer that calls an observer... this is a bit weird, but it eliminates
 // circular dependencies and also allows us to lazy load observers/computations
@@ -6,7 +6,7 @@ import { importLoggedInObserversAndComputations } from '../../_utils/asyncModule
 export function setupLoggedInObservers (store) {
   store.observe('isUserLoggedIn', isUserLoggedIn => {
     if (isUserLoggedIn) {
-      importLoggedInObserversAndComputations()
+      importLoggedInStoreExtensions()
     }
   })
 }

--- a/src/routes/_store/observers/setupLoggedInObservers.js
+++ b/src/routes/_store/observers/setupLoggedInObservers.js
@@ -1,15 +1,12 @@
-import { importLoggedInObservers } from '../../_utils/asyncModules'
-
-let observedOnce = false
+import { importLoggedInObserversAndComputations } from '../../_utils/asyncModules'
 
 // An observer that calls an observer... this is a bit weird, but it eliminates
-// circular dependencies and also allows us to lazy load observers that are
-// only needed when you're logged in.
+// circular dependencies and also allows us to lazy load observers/computations
+// that are only needed when you're logged in.
 export function setupLoggedInObservers (store) {
   store.observe('isUserLoggedIn', isUserLoggedIn => {
-    if (isUserLoggedIn && !observedOnce) {
-      importLoggedInObservers().then(loggedInObservers => loggedInObservers())
-      observedOnce = true
+    if (isUserLoggedIn) {
+      importLoggedInObserversAndComputations()
     }
   })
 }

--- a/src/routes/_store/store.js
+++ b/src/routes/_store/store.js
@@ -67,7 +67,7 @@ const nonPersistedState = {
 const state = Object.assign({}, persistedState, nonPersistedState)
 const keysToStoreInLocalStorage = new Set(Object.keys(persistedState))
 
-class PinaforeStore extends LocalStorageStore {
+export class PinaforeStore extends LocalStorageStore {
   constructor (state) {
     super(state, keysToStoreInLocalStorage)
   }

--- a/src/routes/_utils/asyncModules.js
+++ b/src/routes/_utils/asyncModules.js
@@ -26,7 +26,7 @@ export const importDatabase = () => import(
 
 export const importLoggedInObserversAndComputations = () => import(
   /* webpackChunkName: 'loggedInObserversAndComputations.js' */ '../_store/loggedInObserversAndComputations.js'
-).then(getDefault)
+)
 
 export const importNavShortcuts = () => import(
   /* webpackChunkName: 'NavShortcuts' */ '../_components/NavShortcuts.html'

--- a/src/routes/_utils/asyncModules.js
+++ b/src/routes/_utils/asyncModules.js
@@ -24,8 +24,8 @@ export const importDatabase = () => import(
   /* webpackChunkName: 'database.js' */ '../_database/databaseApis.js'
 )
 
-export const importLoggedInObservers = () => import(
-  /* webpackChunkName: 'loggedInObservers.js' */ '../_store/observers/loggedInObservers.js'
+export const importLoggedInObserversAndComputations = () => import(
+  /* webpackChunkName: 'loggedInObserversAndComputations.js' */ '../_store/loggedInObserversAndComputations.js'
 ).then(getDefault)
 
 export const importNavShortcuts = () => import(

--- a/src/routes/_utils/asyncModules.js
+++ b/src/routes/_utils/asyncModules.js
@@ -24,8 +24,8 @@ export const importDatabase = () => import(
   /* webpackChunkName: 'database.js' */ '../_database/databaseApis.js'
 )
 
-export const importLoggedInObserversAndComputations = () => import(
-  /* webpackChunkName: 'loggedInObserversAndComputations.js' */ '../_store/loggedInObserversAndComputations.js'
+export const importLoggedInStoreExtensions = () => import(
+  /* webpackChunkName: 'loggedInStoreExtensions.js' */ '../_store/loggedInStoreExtensions.js'
 )
 
 export const importNavShortcuts = () => import(

--- a/src/routes/share.html
+++ b/src/routes/share.html
@@ -3,12 +3,13 @@
   import { store } from './_store/store'
   import { goto } from '../../__sapper__/client'
   import { decodeURIComponentWithPluses } from './_utils/decodeURIComponentWithPluses'
+  import { importLoggedInStoreExtensions } from './_utils/asyncModules'
 
   const SHARE_KEYS = ['title', 'text', 'url']
 
   export default {
     store: () => store,
-    oncreate () {
+    async oncreate () {
       const params = new URLSearchParams(location.search)
 
       const text = SHARE_KEYS
@@ -16,6 +17,7 @@
         .filter(Boolean)
         .join(' ')
 
+      await importLoggedInStoreExtensions()
       this.store.set({ openShareDialog: true })
       this.store.clearComposeData('dialog')
       this.store.setComposeData('dialog', { text })


### PR DESCRIPTION
I thought it might be neat to try to lazy-load store computations we don't need until you're logged in. It turns out that it only saves ~2KB of JS gzipped (~4KB non-gzipped), and on 6x slowdown maybe reduces one of the tasks from ~40ms to ~15ms. Really seems not worth it, but I'm curious if it even passes the tests.