### PR TITLE
Add "unfavorite" label.

### DIFF
--- a/src/routes/_components/status/StatusToolbar.html
+++ b/src/routes/_components/status/StatusToolbar.html
@@ -19,7 +19,7 @@
     ref:reblogIcon
   />
   <IconButton
-    label="Favorite"
+    label="{favoriteLabel}"
     pressable="true"
     pressed={favorited}
     href="#fa-star"
@@ -193,6 +193,10 @@
         }
         return originalStatus.reblogged
       },
+      favoriteLabel: ({ visibility } => {
+        const { favorited } = this.get()
+        return favorited ? 'Unfavorite' : 'Favorite'
+      }),
       favorited: ({ originalStatusId, $currentStatusModifications, originalStatus }) => {
         if ($currentStatusModifications && originalStatusId in $currentStatusModifications.favorites) {
           return $currentStatusModifications.favorites[originalStatusId]

--- a/src/routes/_components/status/StatusToolbar.html
+++ b/src/routes/_components/status/StatusToolbar.html
@@ -19,7 +19,7 @@
     ref:reblogIcon
   />
   <IconButton
-    label="{favoriteLabel}"
+    label={favoriteLabel}
     pressable="true"
     pressed={favorited}
     href="#fa-star"
@@ -164,14 +164,14 @@
         replyShown ? 'Close reply' : inReplyToId ? 'Reply to thread' : 'Reply'
       ),
       replyIcon: ({ inReplyToId }) => inReplyToId ? '#fa-reply-all' : '#fa-reply',
-      reblogLabel: ({ visibility }) => {
+      reblogLabel: ({ visibility, reblogged }) => {
         switch (visibility) {
           case 'private':
             return 'Cannot be boosted because this is followers-only'
           case 'direct':
             return 'Cannot be boosted because this is a direct message'
           default:
-            return 'Boost'
+            return reblogged ? 'Unboost' : 'Boost'
         }
       },
       reblogIcon: ({ visibility }) => {
@@ -193,10 +193,9 @@
         }
         return originalStatus.reblogged
       },
-      favoriteLabel: ({ visibility } => {
-        const { favorited } = this.get()
-        return favorited ? 'Unfavorite' : 'Favorite'
-      }),
+      favoriteLabel: ({ favorited }) => (
+        favorited ? 'Unfavorite' : 'Favorite'
+      ),
       favorited: ({ originalStatusId, $currentStatusModifications, originalStatus }) => {
         if ($currentStatusModifications && originalStatusId in $currentStatusModifications.favorites) {
           return $currentStatusModifications.favorites[originalStatusId]

--- a/tests/spec/011-reblog-favorites-count.js
+++ b/tests/spec/011-reblog-favorites-count.js
@@ -15,7 +15,7 @@ test('shows favorites', async t => {
     .expect(getUrl()).contains('/statuses/')
     .expect(getFavoritesCount()).eql(2)
     .expect(favoritesCountElement.getAttribute('aria-label')).eql('Favorited 2 times')
-    .expect($('.icon-button[aria-label="Favorite"]').getAttribute('aria-pressed')).eql('true')
+    .expect($('.icon-button[aria-label="Unfavorite"]').getAttribute('aria-pressed')).eql('true')
     .click(favoritesCountElement)
     .expect(getUrl()).match(/\/statuses\/[^/]+\/favorites/)
     .expect($('.search-result-account-name').nth(0).innerText).eql('foobar')


### PR DESCRIPTION
Just wanted to float this idea past you maintainers.

I saw a filled-in star on a toot, but I couldn't figure out whether I had already favorited it or not. I hovered over it and saw it said "Favorite", so I thought if I click it then it will favorite the toot. It actually unfavorited it.

So let me know what you think!

I didn't test this yet, btw.