### PR TITLE
fix: fix search on Mastodon v3

### DIFF
--- a/src/routes/_api/search.js
+++ b/src/routes/_api/search.js
@@ -1,8 +1,8 @@
 import { get, paramsString, DEFAULT_TIMEOUT } from '../_utils/ajax'
 import { auth, basename } from './utils'
 
-export function search (instanceName, accessToken, query, resolve = true, limit = 5, signal = null) {
-  const url = `${basename(instanceName)}/api/v1/search?` + paramsString({
+function doSearch (version, instanceName, accessToken, query, resolve, limit, signal) {
+  const url = `${basename(instanceName)}/api/${version}/search?` + paramsString({
     q: query,
     resolve,
     limit
@@ -11,4 +11,30 @@ export function search (instanceName, accessToken, query, resolve = true, limit 
     timeout: DEFAULT_TIMEOUT,
     signal
   })
+}
+
+async function doSearchV1 (instanceName, accessToken, query, resolve, limit, signal) {
+  const resp = await doSearch('v1', instanceName, accessToken, query, resolve, limit, signal)
+  resp.hashtags = resp.hashtags && resp.hashtags.map(tag => ({
+    name: tag,
+    url: `${basename(instanceName)}/tags/${tag.toLowerCase()}`,
+    history: []
+  }))
+  return resp
+}
+
+async function doSearchV2 (instanceName, accessToken, query, resolve, limit, signal) {
+  return doSearch('v2', instanceName, accessToken, query, resolve, limit, signal)
+}
+
+export async function search (instanceName, accessToken, query, resolve = true, limit = 5, signal = null) {
+  try {
+    return (await doSearchV2(instanceName, accessToken, query, resolve, limit, signal))
+  } catch (err) {
+    if (err && err.status === 404) { // fall back to old search API
+      return doSearchV1(instanceName, accessToken, query, resolve, limit, signal)
+    } else {
+      throw err
+    }
+  }
 }

--- a/src/routes/_components/search/HashtagSearchResult.html
+++ b/src/routes/_components/search/HashtagSearchResult.html
@@ -1,5 +1,5 @@
-<SearchResult href="/tags/{hashtag}">
-  {'#' + hashtag}
+<SearchResult href="/tags/{hashtag.name.toLowerCase()}">
+  {'#' + hashtag.name}
 </SearchResult>
 <style>
 </style>

--- a/src/routes/_utils/ajax.js
+++ b/src/routes/_utils/ajax.js
@@ -23,6 +23,11 @@ function makeFetchOptions (method, headers, options) {
 }
 
 async function throwErrorIfInvalidResponse (response) {
+  if (response.status >= 300) {
+    const err = new Error('Request failed: ' + response.status)
+    err.status = response.status
+    throw err
+  }
   const json = await response.json()
   if (response.status >= 200 && response.status < 300) {
     return json


### PR DESCRIPTION
fixes #1539

As far as I can tell, this is the only deprecated API we are using. We can try to hit the v2 version and then fall back to the v1 if there's a 404.