### PR TITLE
chore: delete posix-spawn-benchmark in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_script:
   - greenkeeper-lockfile-update
 after_script:
   - greenkeeper-lockfile-upload
+  - rm -f /home/travis/.rvm/gems/ruby-*/bin/posix-spawn-benchmark # file seems generated every time, breaks travis cache
 script: travis_retry yarn run $COMMAND
 env:
   global:


### PR DESCRIPTION
This thing also seems to break the cache every time. Not sure what it does, but let's just delete it after the script has run.