### PR TITLE
fix: do not cache license files in service worker

### DIFF
--- a/bin/build-now-json.js
+++ b/bin/build-now-json.js
@@ -41,7 +41,7 @@ const JSON_TEMPLATE = {
       dest: 'client/$1'
     },
     {
-      src: '^/client/.*\\.(js|css|map)$',
+      src: '^/client/.*\\.(js|css|map|LICENSE)$',
       headers: {
         'cache-control': 'public,max-age=31536000,immutable'
       }

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -26,6 +26,7 @@ const assets = __assets__
 const webpackAssets = __shell__
   .filter(filename => !filename.endsWith('.map')) // don't bother with sourcemaps
   .filter(filename => !filename.includes('tesseract-core.wasm')) // cache on-demand
+  .filter(filename => !filename.endsWith('.LICENSE')) // don't bother with license files
 
 // `routes` is an array of `{ pattern: RegExp }` objects that
 // match the pages in your src


### PR DESCRIPTION
Like sourcemap files, there is no point in proactively caching these