### PR TITLE
fix: remove type="*" from videos

### DIFF
--- a/src/routes/_components/AutoplayVideo.html
+++ b/src/routes/_components/AutoplayVideo.html
@@ -14,7 +14,6 @@
     loop
     webkit-playsinline
     playsinline
-    type="*"
     />
 </div>
 <style>

--- a/src/routes/_components/dialog/components/MediaInDialog.html
+++ b/src/routes/_components/dialog/components/MediaInDialog.html
@@ -1,11 +1,8 @@
-<!-- iOS safari requires type="*" on video to play properly, don't ask me why
-     https://stackoverflow.com/a/28361053 -->
 {#if type === 'video'}
   <video
     class="media-fit"
     aria-label={description}
     src={url}
-    type="*"
     {poster}
     controls
     {intrinsicsize}
@@ -17,7 +14,6 @@
       class="audio-player"
       aria-label={description}
       src={url}
-      type="*"
       controls
       ref:player
     />
@@ -27,7 +23,6 @@
     class="media-fit"
     aria-label={description}
     src={url}
-    type="*"
     {poster}
     autoplay
     muted


### PR DESCRIPTION
I never had any evidence that this actually fixed the iOS video issue (I think #1555 actually fixed it), and I suspect that this may be causing #1590.