### PR TITLE
fix: only do range request override in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
       "NotificationEvent",
       "OffscreenCanvas",
       "PointerEvent",
+      "Response",
       "URL",
       "WebSocket",
       "__assets__",


### PR DESCRIPTION
should fix #1590

#1555 was a targeted fix for Safari, so we should disable it in non-Safari browsers, since it seems to be causing problems.

/cc @sgenoud