### PR TITLE
Add the non-truncated text in the title attribute

### DIFF
--- a/src/routes/_components/status/StatusCard.html
+++ b/src/routes/_components/status/StatusCard.html
@@ -1,5 +1,5 @@
 <a ref:cardlink href={url} class="status-card" target="_blank" rel="noopener noreferrer">
-    <strong class="card-title">
+    <strong class="card-title" title={unescapedTitle}>
      {unescapedTitle}
     </strong>
   {#if description}


### PR DESCRIPTION
The `.card-title` element carries `text-overflow: ellipsis`, (and
`white-space: nowrap`), resulting in the last part of long article
titles not being visible. By adding it to the `title` attribute,
one can see the full title on hovering without having to visit the
article first.

The main concern I had was that the text is now technically
duplicated in the source code, and for short titles, also in the
UI. The primary concern there, however, was screen reader users
getting duplicate announcements. However, I believe the `title`
attribute is not announced by screen readers, which this (old)
article seems to confirm:
https://developer.paciellogroup.com/blog/2010/11/using-the-html-title-attribute/

That leaves the following two disadvantages:
- This doesn't solve anything for mobile users, who will still
  have to follow the link to see the full title.
- Desktop users can however a (non-truncated) title to see the same
  title again.

*Important:* Unfortunately, I was unable to view the result locally, presumably due to this error message:

```
✗ server
ENAMETOOLONG: name too long, open '/home/vincent/Workspace/MRs/pinafore/__sapper__/dev/server/277ba6e924bc83eb2709/showAccountProfileOptionsDialog~showComposeDialog~showCopyDialog~showEmojiDialog~showMediaDialog~sho~0b8a9ef3.showAccountProfileOptionsDialog~showComposeDialog~showCopyDialog~showEmojiDialog~showMediaDialog~sho~0b8a9ef3.js'
```

But the unit tests and linting still succeeds, and the change is so small, that I hope it has the desired effect anyway. I didn't add any tests myself, but if you'd like to add me some, let me know what type of test you'd like.