### PR TITLE
fix: use radiogroup for instance switcher

### DIFF
--- a/src/routes/_components/radio/RadioGroup.html
+++ b/src/routes/_components/radio/RadioGroup.html
@@ -35,8 +35,8 @@
       className: ''
     }),
     computed: {
-      ariaOwns: ({ length }) => (
-        times(length, index => `radio-group-button-${index}`).join(' ')
+      ariaOwns: ({ length, id }) => (
+        times(length, index => `radio-group-button-${id}-${index}`).join(' ')
       )
     }
   }

--- a/src/routes/_components/radio/RadioGroup.html
+++ b/src/routes/_components/radio/RadioGroup.html
@@ -1,0 +1,43 @@
+<!-- Modeled after https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20160317/examples/radio/radio.html -->
+<div class="radio-group focus-fix {className}"
+     role="radiogroup"
+     aria-label={label}
+     aria-owns={ariaOwns}
+     on:keydown="onKeyDown(event)"
+     ref:radiogroup
+>
+  <slot></slot>
+</div>
+<script>
+  import { times } from '../../_utils/lodash-lite'
+
+  export default {
+    methods: {
+      onKeyDown(e) {
+        // ArrowUp and ArrowDown should change the focused/checked radio button per
+        // https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20160317/examples/radio/radio.html
+        const { key, target } = e
+        if (!['ArrowUp', 'ArrowDown'].includes(key)) {
+          return
+        }
+        if (!target.classList.contains('radio-group-button')) {
+          return
+        }
+        const buttons = Array.from(this.refs.radiogroup.getElementsByClassName('radio-group-button'))
+        const len = buttons.length
+        const index = Math.max(0, buttons.findIndex(button => button.getAttribute('aria-checked') === 'true'))
+        const newIndex = (len + (index + (key === 'ArrowUp' ? -1 : 1))) % len // increment/decrement and wrap around
+        buttons[newIndex].focus()
+        buttons[newIndex].click()
+      }
+    },
+    data: () => ({
+      className: ''
+    }),
+    computed: {
+      ariaOwns: ({ length }) => (
+        times(length, index => `radio-group-button-${index}`).join(' ')
+      )
+    }
+  }
+</script>

--- a/src/routes/_components/radio/RadioGroup.html
+++ b/src/routes/_components/radio/RadioGroup.html
@@ -13,7 +13,7 @@
 
   export default {
     methods: {
-      onKeyDown(e) {
+      onKeyDown (e) {
         // ArrowUp and ArrowDown should change the focused/checked radio button per
         // https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20160317/examples/radio/radio.html
         const { key, target } = e

--- a/src/routes/_components/radio/RadioGroupButton.html
+++ b/src/routes/_components/radio/RadioGroupButton.html
@@ -1,0 +1,17 @@
+<button id="radio-group-button-{index}"
+        class="radio-group-button {className}"
+        role="radio"
+        aria-label={label}
+        title={label}
+        aria-checked={checked}
+        on:click
+>
+  <slot></slot>
+</button>
+<script>
+  export default {
+    data: () => ({
+      className: ''
+    })
+  }
+</script>

--- a/src/routes/_components/radio/RadioGroupButton.html
+++ b/src/routes/_components/radio/RadioGroupButton.html
@@ -1,4 +1,4 @@
-<button id="radio-group-button-{index}"
+<button id="radio-group-button-{id}-{index}"
         class="radio-group-button {className}"
         role="radio"
         aria-label={label}

--- a/src/routes/_pages/settings/instances/index.html
+++ b/src/routes/_pages/settings/instances/index.html
@@ -3,7 +3,7 @@
 
   {#if $isUserLoggedIn}
   <p>Instances you've logged in to:</p>
-  <RadioGroup label="Switch to instance" length={numInstances}>
+  <RadioGroup id="instance-switch" label="Switch to instance" length={numInstances}>
     <SettingsList label="Instances">
       {#each instanceStates as instance}
       <SettingsListRow>
@@ -13,6 +13,7 @@
                             ariaLabel={instance.label} />
         <div class="instance-switcher-button-wrapper">
           <RadioGroupButton
+                  id="instance-switch"
                   className="instance-switcher-button"
                   label={instance.switchLabel}
                   checked={instance.current}

--- a/src/routes/_pages/settings/instances/index.html
+++ b/src/routes/_pages/settings/instances/index.html
@@ -3,26 +3,29 @@
 
   {#if $isUserLoggedIn}
   <p>Instances you've logged in to:</p>
-  <SettingsList label="Instances">
-    {#each instanceStates as instance}
-    <SettingsListRow>
-      <SettingsListButton className="instance-switcher-instance-name"
-                          href="/settings/instances/{instance.name}"
-                          label={instance.name}
-                          ariaLabel={instance.label} />
-      <div class="instance-switcher-button-wrapper">
-        <button class="instance-switcher-button"
-                aria-label={instance.switchLabel}
-                title={instance.switchLabel}
-                aria-pressed={instance.current}
-                on:click="onSwitchToThisInstance(event, instance.name)">
-          <SvgIcon className="instance-switcher-button-svg"
-                   href={instance.current ? '#fa-star' : '#fa-star-o'} />
-        </button>
-      </div>
-    </SettingsListRow>
-    {/each}
-  </SettingsList>
+  <RadioGroup label="Switch to instance" length={numInstances}>
+    <SettingsList label="Instances">
+      {#each instanceStates as instance}
+      <SettingsListRow>
+        <SettingsListButton className="instance-switcher-instance-name"
+                            href="/settings/instances/{instance.name}"
+                            label={instance.name}
+                            ariaLabel={instance.label} />
+        <div class="instance-switcher-button-wrapper">
+          <RadioGroupButton
+                  className="instance-switcher-button"
+                  label={instance.switchLabel}
+                  checked={instance.current}
+                  index={instance.index}
+                  on:click="onSwitchToThisInstance(event, instance.name)">
+            <SvgIcon className="instance-switcher-button-svg"
+                     href={instance.current ? '#fa-star' : '#fa-star-o'} />
+          </RadioGroupButton>
+        </div>
+      </SettingsListRow>
+      {/each}
+    </SettingsList>
+  </RadioGroup>
   <p><a rel="prefetch" href="/settings/instances/add">Add another instance</a></p>
   {:else}
   <p>You're not logged in to any instances.</p>
@@ -40,7 +43,7 @@
     border: 1px solid var(--settings-list-item-border);
     min-width: 44px;
   }
-  .instance-switcher-button {
+  :global(.instance-switcher-button) {
     display: flex;
     position: absolute;
     top: 0;
@@ -69,6 +72,8 @@
   import SettingsListRow from '../../../_components/settings/SettingsListRow.html'
   import SettingsListButton from '../../../_components/settings/SettingsListButton.html'
   import SvgIcon from '../../../_components/SvgIcon.html'
+  import RadioGroup from '../../../_components/radio/RadioGroup.html'
+  import RadioGroupButton from '../../../_components/radio/RadioGroupButton.html'
 
   export default {
     components: {
@@ -76,7 +81,9 @@
       SettingsList,
       SettingsListRow,
       SettingsListButton,
-      SvgIcon
+      SvgIcon,
+      RadioGroup,
+      RadioGroupButton
     },
     methods: {
       onSwitchToThisInstance (e, instanceName) {
@@ -88,13 +95,15 @@
     store: () => store,
     computed: {
       instanceStates: ({ $loggedInInstancesAsList }) => (
-        $loggedInInstancesAsList.map(({ name, current }) => ({
+        $loggedInInstancesAsList.map(({ name, current }, index) => ({
+          index,
           name,
           current,
           label: `${name} ${current ? '(current instance)' : ''}`,
-          switchLabel: current ? `${name} is the current instance` : `Switch to ${name}`
+          switchLabel: `Switch to ${name}`
         }))
-      )
+      ),
+      numInstances: ({ $loggedInInstancesAsList }) => $loggedInInstancesAsList.length
     }
   }
 </script>

--- a/src/routes/_utils/lodash-lite.js
+++ b/src/routes/_utils/lodash-lite.js
@@ -36,3 +36,11 @@ export function sum (list) {
   }
   return total
 }
+
+export function times (n, func) {
+  const res = []
+  for (let i = 0; i < n; i++) {
+    res.push(func(i))
+  }
+  return res
+}


### PR DESCRIPTION
Progress on #1633

This is just s quick sketch of implementing radio buttons for the instance switcher.

One very tricky thing is that the UI is made up of a list where each item has two interactive elements: a link that goes to the instance page, and a button to switch to that instance. It's only the button that should be a radio button, and it's very weird to have links mixed in there.

My current solution is just to wrap the whole thing in a radio group, and then make it so that if any radio button is focused, then you can press up and down to change the radio checked value, as with a standard radio control. But you cannot focus the radio group itself.

Testing in NVDA and VoiceOver, it seems okay. At least it speaks how many items are in the radio group and which one is checked. But I may need to noodle on this and test it more.