### PR TITLE
perf: avoid aria-hidden="false"

### DIFF
--- a/src/routes/_components/IconButton.html
+++ b/src/routes/_components/IconButton.html
@@ -5,7 +5,7 @@
         title={pressable ? (pressed ? pressedLabel : label) : label}
         aria-label={label}
         aria-pressed={pressable ? !!pressed : undefined}
-        aria-hidden={ariaHidden}
+        aria-hidden={ariaHidden ? 'true' : undefined}
         tabindex="{ariaHidden ? '-1' : '0'}"
         class={computedClass}
         {disabled}


### PR DESCRIPTION
Putting `aria-hidden="false"` everywhere is just extra work and unnecessary. If it's undefined, then Svelte just won't add the attribute at all.