### PR TITLE
test: add basic memory leak test

### DIFF
--- a/src/routes/_utils/delegate.js
+++ b/src/routes/_utils/delegate.js
@@ -2,8 +2,8 @@
 
 const callbacks = {}
 
-if (process.browser && process.env.NODE_ENV !== 'production') {
-  window.delegateCallbacks = callbacks
+if (process.browser) {
+  window.__delegateCallbacks = callbacks
 }
 
 function onEvent (e) {

--- a/src/routes/_utils/eventBus.js
+++ b/src/routes/_utils/eventBus.js
@@ -2,8 +2,8 @@ import EventEmitter from 'events-light'
 
 export const eventBus = new EventEmitter()
 
-if (process.browser && process.env.NODE_ENV !== 'production') {
-  window.eventBus = eventBus
+if (process.browser) {
+  window.__eventBus = eventBus
 }
 
 export function on (eventName, component, method) {

--- a/src/routes/_utils/resize.js
+++ b/src/routes/_utils/resize.js
@@ -4,8 +4,8 @@ const DEBOUNCE_DELAY = 700
 
 const listeners = new Set()
 
-if (process.browser && process.env.NODE_ENV !== 'production') {
-  window.resizeListeners = listeners
+if (process.browser) {
+  window.__resizeListeners = listeners
 }
 
 if (process.browser) {

--- a/tests/spec/038-memory-leaks.js
+++ b/tests/spec/038-memory-leaks.js
@@ -1,0 +1,44 @@
+import {
+  composeInput,
+  getNthAutosuggestionResult,
+  getNumSyntheticListeners,
+  getUrl,
+  homeNavButton,
+  scrollToStatus,
+  scrollToTop,
+  settingsNavButton
+} from '../utils'
+import { loginAsFoobar } from '../roles'
+
+fixture`038-memory-leaks.js`
+  .page`http://localhost:4002`
+
+async function goToStartPoint (t) {
+  await t
+    .click(settingsNavButton)
+    .expect(getUrl()).contains('/settings')
+}
+
+async function interactAndGoToEndPoint (t) {
+  await t
+    .click(homeNavButton)
+    .expect(getUrl()).eql('http://localhost:4002/')
+  await scrollToStatus(t, 15)
+  await scrollToTop()
+  await t
+    .typeText(composeInput, 'hey @qu')
+    .expect(getNthAutosuggestionResult(1).find('.sr-only').innerText).contains('@quux')
+    .click(settingsNavButton)
+    .expect(getUrl()).contains('/settings')
+}
+
+test('Does not leak synthetic listeners', async t => {
+  await loginAsFoobar(t)
+  await goToStartPoint(t)
+  const numSyntheticListeners = await getNumSyntheticListeners()
+  await t
+    .expect(numSyntheticListeners).typeOf('number')
+  await interactAndGoToEndPoint(t)
+  await t
+    .expect(getNumSyntheticListeners()).eql(numSyntheticListeners)
+})

--- a/tests/spec/038-memory-leaks.js
+++ b/tests/spec/038-memory-leaks.js
@@ -6,7 +6,7 @@ import {
   homeNavButton,
   scrollToStatus,
   scrollToTop,
-  settingsNavButton
+  settingsNavButton, sleep
 } from '../utils'
 import { loginAsFoobar } from '../roles'
 
@@ -35,10 +35,12 @@ async function interactAndGoToEndPoint (t) {
 test('Does not leak synthetic listeners', async t => {
   await loginAsFoobar(t)
   await goToStartPoint(t)
+  await sleep(1000)
   const numSyntheticListeners = await getNumSyntheticListeners()
   await t
     .expect(numSyntheticListeners).typeOf('number')
   await interactAndGoToEndPoint(t)
+  await sleep(1000)
   await t
     .expect(getNumSyntheticListeners()).eql(numSyntheticListeners)
 })

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -119,6 +119,13 @@ export const sleep = timeout => new Promise(resolve => setTimeout(resolve, timeo
 
 export const getUrl = exec(() => window.location.href)
 
+export const getNumSyntheticListeners = exec(() => {
+  return Object.keys(window.__eventBus.$e).map(key => window.__eventBus.listenerCount(key))
+    .concat(window.__resizeListeners.size)
+    .concat(Object.keys(window.__delegateCallbacks).length)
+    .reduce((a, b) => a + b, 0)
+})
+
 export const getMediaScrollLeft = exec(() => document.querySelector('.media-scroll').scrollLeft || 0)
 
 export const getActiveElementClassList = exec(() =>


### PR DESCRIPTION
I would love to be able to test DOM listeners too, but it seems too difficult to keep track of these. For now, though, we can at least verify that our synthetic listeners don't leak.