### PR TITLE
fix: Avoid autocapitalize keyboard for instance name

### DIFF
--- a/src/routes/_pages/settings/instances/add.html
+++ b/src/routes/_pages/settings/instances/add.html
@@ -25,7 +25,7 @@
       </noscript>
 
       <label for="instanceInput">Instance:</label>
-      <input type="text" inputmode="url" id="instanceInput"
+      <input type="text" inputmode="url" autocapitalize="none" id="instanceInput"
              bind:value='$instanceNameInSearch' placeholder="Enter instance name" required
       >
       <button class="primary" type="submit" id="submitButton"

--- a/src/routes/_pages/settings/instances/add.html
+++ b/src/routes/_pages/settings/instances/add.html
@@ -25,7 +25,7 @@
       </noscript>
 
       <label for="instanceInput">Instance:</label>
-      <input type="text" inputmode="url" autocapitalize="none" id="instanceInput"
+      <input type="text" inputmode="url" autocapitalize="none" spellcheck="false" id="instanceInput"
              bind:value='$instanceNameInSearch' placeholder="Enter instance name" required
       >
       <button class="primary" type="submit" id="submitButton"


### PR DESCRIPTION
On iOS Safari (possibly other browsers as well), auto-capitalization is enabled
even for input fields with inputmode=url.

In my testing, the inputmode attribute itself is supported and working (in so
far that iOS does consider it and provides me a keyboard optimised for URL
inputs, with quick buttons for slash and .com etc).

The autocapitalize is supported on Safari, per:
https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize

Fixes https://github.com/nolanlawson/pinafore/issues/1652.