### PR TITLE
fix: fix search width on narrow sizes

### DIFF
--- a/src/routes/_components/search/Search.html
+++ b/src/routes/_components/search/Search.html
@@ -37,6 +37,7 @@
     border-radius: 10px;
     flex: 1;
     width: 0;
+    min-width: 0;
   }
   :global(.search-button-svg) {
     fill: var(--button-primary-text);


### PR DESCRIPTION
Should fix a reported issue about the search bar not showing up right in the Mastodon-as-a-sidebar Firefox extension.