### PR TITLE
perf: use emoji-mart fork for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cross-env": "^6.0.3",
     "css-dedoupe": "^0.1.1",
     "css-loader": "^3.3.2",
-    "emoji-mart": "^2.11.2",
+    "emoji-mart": "nolanlawson/emoji-mart#8bb6fb6",
     "emoji-regex": "^8.0.0",
     "encoding": "^0.1.12",
     "escape-html": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,10 +3429,9 @@ emittery@^0.4.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.4.1.tgz#abe9d3297389ba424ac87e53d1c701962ce7433d"
   integrity sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==
 
-emoji-mart@^2.11.2:
+emoji-mart@nolanlawson/emoji-mart#8bb6fb6:
   version "2.11.2"
-  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-2.11.2.tgz#ed331867f7f55bb33c8421c9a493090fa4a378c7"
-  integrity sha512-IdHZR5hc3mipTY/r0ergtqBgQ96XxmRdQDSg7fsL+GiJQQ4akMws6+cjLSyIhGQxtvNuPVNaEQiAlU00NsyZUg==
+  resolved "https://codeload.github.com/nolanlawson/emoji-mart/tar.gz/8bb6fb6622355ca33b570041005e0297f95e8a30"
   dependencies:
     prop-types "^15.6.0"
 


### PR DESCRIPTION
Because I want to remove the implicit core-js dependency and not wait for an emoji-mart update.