### PR TITLE
theme improvements

### DIFF
--- a/bin/build-sass.js
+++ b/bin/build-sass.js
@@ -28,7 +28,7 @@ async function compileGlobalSass () {
 }
 
 async function compileThemesSass () {
-  const files = (await readdir(themesScssDir)).filter(file => !path.basename(file).startsWith('_'))
+  const files = (await readdir(themesScssDir)).filter(file => !path.basename(file).startsWith('_') && !path.basename(file).startsWith('.'))
   await Promise.all(files.map(async file => {
     let css = await renderCss(path.join(themesScssDir, file))
     css = cssDedoupe(new TextDecoder('utf-8').decode(css)) // remove duplicate custom properties

--- a/src/routes/_static/themes.js
+++ b/src/routes/_static/themes.js
@@ -90,6 +90,12 @@ const themes = [
     color: '#282C37'
   },
   {
+    name: 'oceanblue',
+    label: 'Ocean Blue',
+    dark: true,
+    color: '#03131b'
+  },
+  {
     name: 'pitchblack',
     label: 'Pitch Black',
     dark: true,

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -42,7 +42,7 @@
   --nav-svg-fill-hover: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 18%)};
+  --action-button-fill-color: #{#aaa};
   --action-button-fill-color-hover: #{lighten($main-theme-color, 22%)};
   --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
   --action-button-fill-color-pressed: #{darken($main-theme-color, 7%)};

--- a/src/scss/themes/cobalt.scss
+++ b/src/scss/themes/cobalt.scss
@@ -18,7 +18,7 @@ $compose-background: lighten($main-theme-color, 32%);
   --settings-list-item-text: #{$main-text-color};
   --settings-list-item-text-hover: #{$main-text-color};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 30%)};
+  --action-button-fill-color: #{lighten($main-theme-color, 60%)};
   --action-button-fill-color-hover: #{lighten($main-theme-color, 35%)};
   --action-button-fill-color-active: #{lighten($main-theme-color, 40%)};
 

--- a/src/scss/themes/dark-grayscale.scss
+++ b/src/scss/themes/dark-grayscale.scss
@@ -14,3 +14,12 @@ $compose-background: lighten($main-theme-color, 52%);
 @import "_dark.scss";
 @import "_dark_navbar.scss";
 @import "_dark_scrollbars.scss";
+
+:root {
+  --action-button-fill-color: #{lighten($main-theme-color, 5%)};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 12%)};
+  --action-button-fill-color-active: #{darken($main-theme-color, 15%)};
+  --action-button-fill-color-pressed: #{lighten($main-theme-color, 80%)};
+  --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 50%)};
+  --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 80%)};
+}

--- a/src/scss/themes/mastodon.scss
+++ b/src/scss/themes/mastodon.scss
@@ -23,6 +23,7 @@ $compose-background: darken($main-theme-color, 12%);
   --button-primary-bg-hover: #56a7e1;
   --button-primary-border: transparent;
 
+	--action-button-fill-color: #{lighten($main-theme-color, 18%)};
   --action-button-fill-color-pressed: #2b90d9;
   --action-button-fill-color-pressed-hover: #2b90d9;
 }

--- a/src/scss/themes/oceanblue.scss
+++ b/src/scss/themes/oceanblue.scss
@@ -1,0 +1,38 @@
+$main-theme-color: rgb( 16,61,80);
+$body-bg-color: #03131b;
+$main-bg-color: #000;
+$anchor-color: lighten($main-theme-color, 20%);
+$main-text-color: #fafaff;
+$border-color: $body-bg-color;
+$secondary-text-color: #f6f6ff;
+$toast-border: lighten($body-bg-color, 4%);
+$toast-bg: lighten($body-bg-color, 4%);
+$focus-outline: lighten($main-theme-color, 10%);
+$compose-background: darken($main-theme-color, 12%);
+
+@import "_base.scss";
+@import "_dark.scss";
+@import "_dark_scrollbars.scss";
+
+:root {
+  --settings-list-item-text: #{$anchor-color};
+  --settings-list-item-text-hover: #{$anchor-color};
+  --settings-list-item-bg-active: #{darken($body-bg-color, 10%)};
+  --settings-list-item-bg-hover: #{darken($body-bg-color, 2%)};
+
+  --button-bg: #{lighten($body-bg-color, 5%)};
+  --button-border: #{$border-color};
+  --button-bg-hover: #{lighten($body-bg-color, 10%)};
+  --button-bg-active: #{lighten($body-bg-color, 15%)};
+
+  --form-bg: #{$body-bg-color};
+  --form-border: #{darken($border-color, 10%)};
+
+
+  --action-button-fill-color: #{#555};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 12%)};
+  --action-button-fill-color-active: #{darken($main-theme-color, 15%)};
+  --action-button-fill-color-pressed: #{lighten($main-theme-color, 20%)};
+  --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 24%)};
+  --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 7%)};
+}

--- a/src/scss/themes/pitchblack.scss
+++ b/src/scss/themes/pitchblack.scss
@@ -1,13 +1,13 @@
-$main-theme-color: rgb( 16,61,80);
-$body-bg-color: #03131b;
+$main-theme-color: #000;
+$body-bg-color: #000;
 $main-bg-color: #000;
-$anchor-color: lighten($main-theme-color, 20%);
+$anchor-color: lighten($main-theme-color, 90%);
 $main-text-color: #fafaff;
-$border-color: $body-bg-color;
+$border-color: #222;
 $secondary-text-color: #f6f6ff;
 $toast-border: lighten($body-bg-color, 4%);
 $toast-bg: lighten($body-bg-color, 4%);
-$focus-outline: lighten($main-theme-color, 10%);
+$focus-outline: lighten($main-theme-color, 50%);
 $compose-background: darken($main-theme-color, 12%);
 
 @import "_base.scss";
@@ -20,19 +20,24 @@ $compose-background: darken($main-theme-color, 12%);
   --settings-list-item-bg-active: #{darken($body-bg-color, 10%)};
   --settings-list-item-bg-hover: #{darken($body-bg-color, 2%)};
 
-  --button-bg: #{lighten($body-bg-color, 5%)};
+  --button-primary-bg: #{lighten($body-bg-color, 10%)};
+  --button-primary-border: #{$border-color};
+  --button-primary-bg-hover: #{lighten($body-bg-color, 15%)};
+  --button-primary-bg-active: #{lighten($body-bg-color, 15%)};
+
+  --button-bg: #{lighten($body-bg-color, 10%)};
   --button-border: #{$border-color};
-  --button-bg-hover: #{lighten($body-bg-color, 10%)};
+  --button-bg-hover: #{lighten($body-bg-color, 15%)};
   --button-bg-active: #{lighten($body-bg-color, 15%)};
 
   --form-bg: #{$body-bg-color};
   --form-border: #{darken($border-color, 10%)};
 
 
-  --action-button-fill-color: #{#555};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 12%)};
-  --action-button-fill-color-active: #{darken($main-theme-color, 15%)};
-  --action-button-fill-color-pressed: #{lighten($main-theme-color, 20%)};
-  --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 24%)};
-  --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 7%)};
+  --action-button-fill-color: #{lighten($main-theme-color, 20%)};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 30%)};
+  --action-button-fill-color-active: #{darken($main-theme-color, 40%)};
+  --action-button-fill-color-pressed: #{lighten($main-theme-color, 85%)};
+  --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 100%)};
+  --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 80%)};
 }

--- a/src/scss/themes/pitchblack.scss
+++ b/src/scss/themes/pitchblack.scss
@@ -29,7 +29,7 @@ $compose-background: darken($main-theme-color, 12%);
   --form-border: #{darken($border-color, 10%)};
 
 
-  --action-button-fill-color: #{lighten($main-theme-color, 5%)};
+  --action-button-fill-color: #{#555};
   --action-button-fill-color-hover: #{lighten($main-theme-color, 12%)};
   --action-button-fill-color-active: #{darken($main-theme-color, 15%)};
   --action-button-fill-color-pressed: #{lighten($main-theme-color, 20%)};


### PR DESCRIPTION
  **fix: ignore hidden files in scss/themes**
  When editing a theme file in vim, a .file.swp file is created and would
  crash the sass compiler. This ignores any hidden files in the directory,
  since they are probably not theme files.
 
  **feat: improve button colors in various themes**
  It was very difficult to differentiate pressed buttons from unpressed
  buttons with the lightness difference. This changes the unpressed
  buttons to a grey tone, while the pressed buttons use a variation of the
  theme color.
 
  **feat: add real pitch black theme** 
  On AMOLED displays the pitch black theme was unsatisfying, I have
  renamed it to "Ocean Blue" and added a new theme that uses #000 as main
  theme color.