### PR TITLE
fix: ignore hidden files in scss/themes

### DIFF
--- a/bin/build-sass.js
+++ b/bin/build-sass.js
@@ -28,7 +28,7 @@ async function compileGlobalSass () {
 }
 
 async function compileThemesSass () {
-  const files = (await readdir(themesScssDir)).filter(file => !path.basename(file).startsWith('_'))
+  const files = (await readdir(themesScssDir)).filter(file => !path.basename(file).startsWith('_') && !path.basename(file).startsWith('.'))
   await Promise.all(files.map(async file => {
     let css = await renderCss(path.join(themesScssDir, file))
     css = cssDedoupe(new TextDecoder('utf-8').decode(css)) // remove duplicate custom properties


### PR DESCRIPTION
(Cherry-picked PR from https://github.com/nolanlawson/pinafore/pull/1694 as it's fairly non-controversial)

> When editing a theme file in vim, a .file.swp file is created and would
> crash the sass compiler. This ignores any hidden files in the directory,
> since they are probably not theme files.