### PR TITLE
fix: remove safari-specific service worker code

### DIFF
--- a/src/routes/_utils/userAgent/isSafari.js
+++ b/src/routes/_utils/userAgent/isSafari.js
@@ -1,4 +1,0 @@
-import { thunk } from '../thunk'
-
-export const isSafari = thunk(() => process.browser && /Safari/.test(navigator.userAgent) &&
-  !/Chrome/.test(navigator.userAgent))

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,7 +4,6 @@ import {
   routes as __routes__
 } from '../__sapper__/service-worker.js'
 import { get, post } from './routes/_utils/ajax'
-import { isSafari } from './routes/_utils/userAgent/isSafari'
 
 const timestamp = process.env.SAPPER_TIMESTAMP
 const ASSETS = `assets_${timestamp}`
@@ -86,30 +85,6 @@ self.addEventListener('activate', event => {
   })())
 })
 
-async function returnRangeRequest (request) {
-  const response = await fetch(request, { headers: {}, mode: 'cors', credentials: 'omit' })
-  const arrayBuffer = await response.arrayBuffer()
-  const bytes = /^bytes=(\d+)-(\d+)?$/g.exec(request.headers.get('range'))
-  if (bytes) {
-    const start = parseInt(bytes[1], 10)
-    const end = parseInt(bytes[2], 10) || arrayBuffer.byteLength - 1
-
-    return new Response(arrayBuffer.slice(start, end + 1), {
-      status: 206,
-      statusText: 'Partial Content',
-      headers: [
-        ['Content-Range', `bytes ${start}-${end}/${arrayBuffer.byteLength}`]
-      ]
-    })
-  } else {
-    return new Response(null, {
-      status: 416,
-      statusText: 'Range Not Satisfiable',
-      headers: [['Content-Range', `*/${arrayBuffer.byteLength}`]]
-    })
-  }
-}
-
 self.addEventListener('fetch', event => {
   const req = event.request
   const url = new URL(req.url)
@@ -154,14 +129,6 @@ self.addEventListener('fetch', event => {
     }
 
     // for everything else, go network-only
-
-    // range request need to be be patched with a 206 response to satisfy
-    // Safari (https://stackoverflow.com/questions/52087208)
-    // Once this bug is fixed in WebKit we can remove this https://bugs.webkit.org/show_bug.cgi?id=186050
-    if (isSafari() && event.request.headers.get('range')) {
-      return returnRangeRequest(req)
-    }
-
     return fetch(req)
   })())
 })


### PR DESCRIPTION
fixes #1595

The WebKit bug is marked fixed, and based on my testing it appears to be fixed in iOS 13.3 at least. According to caniuse data, the majority of iOS users are already on 13.3.

I could put in UA-sniffing code in here, but that feels brittle and hard to maintain, so I'd prefer to just remove the workaround entirely.

FYI @sgenoud 