### PR TITLE
chore: avoid yarn --pure-lockfile in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s
   - export PATH="$HOME/.yarn/bin:$PATH"
   - ./bin/setup-mastodon-in-travis.sh
+install: yarn # don't allow yarn --pure-lockfile because Greenkeeper needs to update
 before_script:
   - yarn run lint
   - greenkeeper-lockfile-update


### PR DESCRIPTION
Travis recently made `--frozen-lockfile` (or `--pure-lockfile` or whatever) the default, which breaks Greenkeeper. This unbreaks it.