### PR TITLE
fix: fix nav links in Voice Control on iOS

### DIFF
--- a/src/routes/_components/NavItem.html
+++ b/src/routes/_components/NavItem.html
@@ -92,7 +92,18 @@
 
   @media (max-width: 991px) {
     .main-nav-link .nav-link-label {
-      display: none;
+      /* Copied from the sr-only styles in global.scss
+       * the reason we explicitly leave this <span> in is because Voice Control on iOS does not
+       * understand aria-labels very well, but it understands hidden text just fine
+       */
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0;
     }
   }
 </style>


### PR DESCRIPTION
fixes #1735

After playing around with Voice Control on iOS 13, it seems that Voice Control really doesn't understand aria-label at all, but it understands text inside of the link just fine. So we can exploit that to just move the text off-screen instead of using `display: none`.

Incidentally, Voice Control also doesn't seem to like small tap targets very much, so it still won't necessarily show the names or numbers when you say "show names" or "show numbers" for all links. But I also tested on a very small phone (iPhone SE first gen), so presumably on a larger phone this would work better. And in any case, this PR at least makes some of the links work correctly, even on a small screen.

Long-term, I assume this is just a bug that Apple will fix. aria-label should be exactly the same as hidden text.