### PR TITLE
fix: fix display of <br>s for Pixelfed

### DIFF
--- a/src/routes/_components/status/StatusContent.html
+++ b/src/routes/_components/status/StatusContent.html
@@ -81,6 +81,14 @@
     text-decoration: underline;
   }
 
+  /* Pixelfed seems to inject many <br>s instead of using <p> tags properly.
+   * This causes a ton of extra vertical whitespace, and the easiest fix is to just disallow <br> tags
+   * entirely, which looks much better.
+   */
+  :global(.status-content br) {
+    display: none;
+  }
+
   @media (max-width: 240px) {
     :global(
       .status-content p:last-child,


### PR DESCRIPTION
Turns out Pixelfed likes to inject tons of `<br>`s, but we can just hide them.