### PR TITLE
update sapper to fix SNYK-JS-SAPPER-561051

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "rollup": "^2.0.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-terser": "^5.2.0",
-    "sapper": "nolanlawson/sapper#for-pinafore-14",
+    "sapper": "nolanlawson/sapper#for-pinafore-20",
     "stringz": "^2.1.0",
     "svelte": "^2.16.1",
     "svelte-extras": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7594,9 +7594,9 @@ sanitize-filename@^1.6.0:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-sapper@nolanlawson/sapper#for-pinafore-14:
+sapper@nolanlawson/sapper#for-pinafore-20:
   version "0.25.0"
-  resolved "https://codeload.github.com/nolanlawson/sapper/tar.gz/8bf2d62a9911b58d3004a716b2e30d431f6f4b2a"
+  resolved "https://codeload.github.com/nolanlawson/sapper/tar.gz/fb89e84a3b7b46e98c2043b5bfd7605dc3e59cde"
   dependencies:
     html-minifier "^3.5.20"
     http-link-header "^1.0.2"


### PR DESCRIPTION
This vuln doesn't really affect us sync we use `sapper export` to build static files (rather than actually running Sapper on the server side), but we may as well fix it.

Sadly had to fix via cherry-pick because latest Sapper is incompatible with Svelte v2. https://github.com/nolanlawson/sapper/commit/99798006c3a00b9f95ede212f844c75ee7cf1bb0