### PR TITLE
fix: beef up CSP headers

### DIFF
--- a/bin/build-now-json.js
+++ b/bin/build-now-json.js
@@ -69,7 +69,7 @@ const HTML_HEADERS = {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' * data: blob:",
     "media-src 'self' *",
-    "connect-src 'self' *",
+    "connect-src 'self' * data:",
     "frame-src 'none'",
     "frame-ancestors 'none'",
     "object-src 'none'",

--- a/bin/build-now-json.js
+++ b/bin/build-now-json.js
@@ -74,7 +74,8 @@ const HTML_HEADERS = {
     "frame-ancestors 'none'",
     "object-src 'none'",
     "manifest-src 'self'",
-    "form-action 'none'"
+    "form-action 'none'",
+    "base-uri 'self'"
   ].join(';'),
   'referrer-policy': 'no-referrer',
   'strict-transport-security': 'max-age=15552000; includeSubDomains',

--- a/bin/build-now-json.js
+++ b/bin/build-now-json.js
@@ -63,13 +63,13 @@ const SCRIPT_CHECKSUMS = [inlineScriptChecksum]
 const HTML_HEADERS = {
   'cache-control': 'public,max-age=3600',
   'content-security-policy': [
-    "default-src 'none'",
+    "default-src 'self'",
     `script-src 'self' ${SCRIPT_CHECKSUMS}`,
     "worker-src 'self'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' * data: blob:",
     "media-src 'self' *",
-    "connect-src 'self' * data:",
+    "connect-src 'self' * data: blob:",
     "frame-src 'none'",
     "frame-ancestors 'none'",
     "object-src 'none'",

--- a/bin/build-now-json.js
+++ b/bin/build-now-json.js
@@ -55,16 +55,32 @@ const JSON_TEMPLATE = {
   ]
 }
 
+const SCRIPT_CHECKSUMS = [inlineScriptChecksum]
+  .concat(sapperInlineScriptChecksums)
+  .map(_ => `'sha256-${_}'`)
+  .join(' ')
+
 const HTML_HEADERS = {
   'cache-control': 'public,max-age=3600',
-  'content-security-policy': 'script-src \'self\' ' +
-    `${[inlineScriptChecksum].concat(sapperInlineScriptChecksums).map(_ => `'sha256-${_}'`).join(' ')}; ` +
-    'worker-src \'self\'; style-src \'self\' \'unsafe-inline\'; frame-src \'none\'; object-src \'none\'; manifest-src \'self\'',
+  'content-security-policy': [
+    "default-src 'none'",
+    `script-src 'self' ${SCRIPT_CHECKSUMS}`,
+    "worker-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' * data: blob:",
+    "media-src 'self' *",
+    "connect-src 'self' *",
+    "frame-src 'none'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "manifest-src 'self'",
+    "form-action 'none'"
+  ].join(';'),
   'referrer-policy': 'no-referrer',
   'strict-transport-security': 'max-age=15552000; includeSubDomains',
   'x-content-type-options': 'nosniff',
   'x-download-options': 'noopen',
-  'x-frame-options': 'SAMEORIGIN',
+  'x-frame-options': 'DENY',
   'x-xss-protection': '1; mode=block'
 }
 


### PR DESCRIPTION
Improves the CSP a bit, following advice from Mozilla Observatory.

- `default-src` is `'none'`
- restrict `form-action` and `frame-ancestors`
- restrict `img-src` and `media-src` to just what we need

Pinafore doesn't need to run in an iframe, and it does need to send XHRs and img/audio/video requests to arbitrary origins, but most stuff we can just block