### PR TITLE
fix: fix delete-and-redraft in Firefox Android

### DIFF
--- a/src/routes/_components/compose/ComposeStickyButton.html
+++ b/src/routes/_components/compose/ComposeStickyButton.html
@@ -71,6 +71,10 @@
         (await importShowComposeDialog())()
       },
       setupIntersectionObservers () {
+        const { showSticky } = this.get()
+        if (!showSticky) {
+          return // no need to set up observers if this button can never be sticky (e.g. dialogs)
+        }
         const sentinel = this.refs.sentinel
 
         this.__stickyObserver = new IntersectionObserver(entries => this.onObserve(entries))


### PR DESCRIPTION
fixes #1681

There's apparently an intersection observer bug in Firefox 68 on Android that causes the Toot button to appear as "sticky" even though it's inside the dialog and therefore can never go into the "sticky" state.

The simplest approach is to just never create the intersection observers in the first place if the button can never become sticky. Not sure why I never did this in the first place; there are plenty of never-gonna-be-sticky buttons and there's no point in running the sticky logic for them.