### PR TITLE
Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ To build a Docker image for production:
 
 Now Pinafore is running at `localhost:4002`.
 
+### docker-compose
+
+Alternatively, use docker-compose to build and serve the image for production:
+
+    docker-compose up --build -d
+
+The image will build and start, then detach from the terminal running at `localhost:4002`.
+
 ### Updating
 
 To keep your version of Pinafore up to date, you can use `git` to check out the latest tag:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: "3"
+services:
+  pinafore:
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: pinafore:latest
+    ports:
+      - 4002:4002


### PR DESCRIPTION
Added a new file `docker-compose.yml` which defines a docker-compose build for the image defined in the `Dockerfile`. This allows production users to use a single command to build and start an image for Pinafore that exposes a defined port, rather than needing to specify an open port in a docker command.

Additionally, added to the `README.md` an instruction on how to build/start the container.