### PR TITLE
feat: use :focus-visible, add setting to enable/disable it

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "file-api": "^0.10.4",
     "file-drop-element": "0.2.0",
     "file-loader": "^6.0.0",
+    "focus-visible": "^5.1.0",
     "form-data": "^3.0.0",
     "glob": "^7.1.6",
     "indexeddb-getall-shim": "^1.3.6",

--- a/src/build/template.html
+++ b/src/build/template.html
@@ -28,6 +28,25 @@
     }
   </style>
 
+  <style id="theFocusVisibleStyle" media="all">
+    /*  :focus-visible styles */
+    /* polyfill */
+    .js-focus-visible :focus:not(.focus-visible) {
+      outline: none !important;
+    }
+    .js-focus-visible :focus:not(.focus-visible).focus-after::after {
+      display: none !important;
+    }
+
+    /* standard version */
+    :focus:not(:focus-visible) {
+      outline: none !important;
+    }
+    :focus:not(:focus-visible).focus-after::after {
+      display: none !important;
+    }
+  </style>
+
   <noscript>
     <style>
       .hidden-from-ssr {

--- a/src/build/template.html
+++ b/src/build/template.html
@@ -32,18 +32,18 @@
     /*  :focus-visible styles */
     /* polyfill */
     .js-focus-visible :focus:not(.focus-visible) {
-      outline: none !important;
+      outline: none !important; /* important to win the specificity war */
     }
     .js-focus-visible :focus:not(.focus-visible).focus-after::after {
-      display: none !important;
+      display: none;
     }
 
     /* standard version */
     :focus:not(:focus-visible) {
-      outline: none !important;
+      outline: none !important; /* important to win the specificity war */
     }
     :focus:not(:focus-visible).focus-after::after {
-      display: none !important;
+      display: none;
     }
   </style>
 

--- a/src/routes/_pages/settings/general.html
+++ b/src/routes/_pages/settings/general.html
@@ -4,12 +4,12 @@
   <h2>Media</h2>
   <form class="ui-settings">
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-never-mark-media-sensitive"
              bind:checked="$neverMarkMediaAsSensitive" on:change="onChange(event)">
       Show sensitive media by default
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-use-blurhash"
               bind:checked="$ignoreBlurhash" on:change="onChange(event)">
       Show a plain gray color for sensitive media
     </label>
@@ -19,12 +19,12 @@
       Treat all media as sensitive
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-large-inline-media"
              bind:checked="$largeInlineMedia" on:change="onChange(event)">
       Show large inline images and videos
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-autoplay-gif"
              bind:checked="$autoplayGifs" on:change="onChange(event)">
       Autoplay GIFs
     </label>
@@ -33,12 +33,12 @@
   <h2>UI</h2>
   <form class="ui-settings">
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-disable-custom-scrollbars"
              bind:checked="$disableCustomScrollbars" on:change="onChange(event)">
       Disable custom scrollbars
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-disable-infinite-scroll"
              bind:checked="$disableInfiniteScroll" on:change="onChange(event)">
       Disable
         <Tooltip
@@ -50,12 +50,12 @@
         />
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-hide-cards"
              bind:checked="$hideCards" on:change="onChange(event)">
       Hide link preview cards
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-underline-links"
              bind:checked="$underlineLinks" on:change="onChange(event)">
       Underline links in toots and profiles
     </label>
@@ -64,12 +64,12 @@
   <h2>Accessibility</h2>
   <form class="ui-settings">
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-reduce-motion"
              bind:checked="$reduceMotion" on:change="onChange(event)">
       Reduce motion in UI animations
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-always-show-focus-ring"
              bind:checked="$alwaysShowFocusRing" on:change="onChange(event)">
       Always show
       <Tooltip
@@ -81,17 +81,17 @@
       />
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-disable-tap-on-status"
              bind:checked="$disableTapOnStatus" on:change="onChange(event)">
       Disable tappable area on entire toot
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-omit-emoji-in-display-names"
              bind:checked="$omitEmojiInDisplayNames" on:change="onChange(event)">
       Remove emoji from user display names
     </label>
     <label class="setting-group">
-      <input type="checkbox"
+      <input type="checkbox" id="choice-disable-long-aria-labels"
              bind:checked="$disableLongAriaLabels" on:change="onChange(event)">
       Use short article ARIA labels
     </label>

--- a/src/routes/_pages/settings/general.html
+++ b/src/routes/_pages/settings/general.html
@@ -4,12 +4,12 @@
   <h2>Media</h2>
   <form class="ui-settings">
     <label class="setting-group">
-      <input type="checkbox" id="choice-never-mark-media-sensitive"
+      <input type="checkbox"
              bind:checked="$neverMarkMediaAsSensitive" on:change="onChange(event)">
       Show sensitive media by default
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-use-blurhash"
+      <input type="checkbox"
               bind:checked="$ignoreBlurhash" on:change="onChange(event)">
       Show a plain gray color for sensitive media
     </label>
@@ -19,12 +19,12 @@
       Treat all media as sensitive
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-large-inline-media"
+      <input type="checkbox"
              bind:checked="$largeInlineMedia" on:change="onChange(event)">
       Show large inline images and videos
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-autoplay-gif"
+      <input type="checkbox"
              bind:checked="$autoplayGifs" on:change="onChange(event)">
       Autoplay GIFs
     </label>
@@ -33,12 +33,12 @@
   <h2>UI</h2>
   <form class="ui-settings">
     <label class="setting-group">
-      <input type="checkbox" id="choice-disable-custom-scrollbars"
+      <input type="checkbox"
              bind:checked="$disableCustomScrollbars" on:change="onChange(event)">
       Disable custom scrollbars
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-disable-infinite-scroll"
+      <input type="checkbox"
              bind:checked="$disableInfiniteScroll" on:change="onChange(event)">
       Disable
         <Tooltip
@@ -50,12 +50,12 @@
         />
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-hide-cards"
+      <input type="checkbox"
              bind:checked="$hideCards" on:change="onChange(event)">
       Hide link preview cards
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-underline-links"
+      <input type="checkbox"
              bind:checked="$underlineLinks" on:change="onChange(event)">
       Underline links in toots and profiles
     </label>
@@ -64,22 +64,34 @@
   <h2>Accessibility</h2>
   <form class="ui-settings">
     <label class="setting-group">
-      <input type="checkbox" id="choice-reduce-motion"
+      <input type="checkbox"
              bind:checked="$reduceMotion" on:change="onChange(event)">
       Reduce motion in UI animations
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-disable-tap-on-status"
+      <input type="checkbox"
+             bind:checked="$alwaysShowFocusRing" on:change="onChange(event)">
+      Always show
+      <Tooltip
+        text="focus ring"
+        tooltipText={
+          "The focus ring is the outline showing the currently focused element. By default, it's only " +
+          "shown when using the keyboard (not mouse or touch), but you may choose to always show it."
+        }
+      />
+    </label>
+    <label class="setting-group">
+      <input type="checkbox"
              bind:checked="$disableTapOnStatus" on:change="onChange(event)">
       Disable tappable area on entire toot
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-omit-emoji-in-display-names"
+      <input type="checkbox"
              bind:checked="$omitEmojiInDisplayNames" on:change="onChange(event)">
       Remove emoji from user display names
     </label>
     <label class="setting-group">
-      <input type="checkbox" id="choice-disable-long-aria-labels"
+      <input type="checkbox"
              bind:checked="$disableLongAriaLabels" on:change="onChange(event)">
       Use short article ARIA labels
     </label>

--- a/src/routes/_store/observers/focusRingObservers.js
+++ b/src/routes/_store/observers/focusRingObservers.js
@@ -1,0 +1,11 @@
+const style = process.browser && document.getElementById('theFocusVisibleStyle')
+
+export function focusRingObservers (store) {
+  if (!process.browser) {
+    return
+  }
+
+  store.observe('alwaysShowFocusRing', alwaysShowFocusRing => {
+    style.setAttribute('media', alwaysShowFocusRing ? 'only x' : 'all') // disable or enable the style
+  })
+}

--- a/src/routes/_store/observers/observers.js
+++ b/src/routes/_store/observers/observers.js
@@ -7,6 +7,7 @@ import { setupLoggedInObservers } from './setupLoggedInObservers'
 import { logOutObservers } from './logOutObservers'
 import { touchObservers } from './touchObservers'
 import { grayscaleObservers } from './grayscaleObservers'
+import { focusRingObservers } from './focusRingObservers'
 import { leftRightFocusObservers } from './leftRightFocusObservers'
 
 export function observers (store) {
@@ -17,6 +18,7 @@ export function observers (store) {
   resizeObservers(store)
   touchObservers(store)
   logOutObservers(store)
+  focusRingObservers(store)
   grayscaleObservers(store)
   leftRightFocusObservers(store)
   setupLoggedInObservers(store)

--- a/src/routes/_store/store.js
+++ b/src/routes/_store/store.js
@@ -6,6 +6,7 @@ import { observe } from 'svelte-extras'
 import { isKaiOS } from '../_utils/userAgent/isKaiOS'
 
 const persistedState = {
+  alwaysShowFocusRing: false,
   autoplayGifs: false,
   composeData: {},
   currentInstance: null,

--- a/src/routes/_utils/asyncPolyfills.js
+++ b/src/routes/_utils/asyncPolyfills.js
@@ -17,3 +17,7 @@ export const importCustomElementsPolyfill = () => import(
 export const importIntl = () => import(
   /* webpackChunkName: '$polyfill$-intl' */ 'intl'
 )
+
+export const importFocusVisible = () => import(
+  /* webpackChunkName: '$polyfill$-focus-visible' */ 'focus-visible'
+)

--- a/src/routes/_utils/loadPolyfills.js
+++ b/src/routes/_utils/loadPolyfills.js
@@ -1,10 +1,12 @@
 import {
   importCustomElementsPolyfill,
+  importFocusVisible,
   importIndexedDBGetAllShim,
   importIntersectionObserver,
   importIntl,
   importRequestIdleCallback
 } from './asyncPolyfills'
+import { supportsSelector } from './supportsSelector'
 
 export function loadPolyfills () {
   return Promise.all([
@@ -12,6 +14,7 @@ export function loadPolyfills () {
     typeof requestIdleCallback === 'undefined' && importRequestIdleCallback(),
     !IDBObjectStore.prototype.getAll && importIndexedDBGetAllShim(),
     typeof customElements === 'undefined' && importCustomElementsPolyfill(),
-    process.env.LEGACY && typeof Intl === 'undefined' && importIntl()
+    process.env.LEGACY && typeof Intl === 'undefined' && importIntl(),
+    !supportsSelector(':focus-visible') && importFocusVisible()
   ])
 }

--- a/src/routes/_utils/supportsSelector.js
+++ b/src/routes/_utils/supportsSelector.js
@@ -1,0 +1,13 @@
+// See https://stackoverflow.com/a/8533927
+export function supportsSelector (selector) {
+  const style = document.createElement('style')
+  document.head.appendChild(style)
+  try {
+    style.sheet.insertRule(selector + '{}', 0)
+  } catch (e) {
+    return false
+  } finally {
+    document.head.removeChild(style)
+  }
+  return true
+}

--- a/src/scss/focus.scss
+++ b/src/scss/focus.scss
@@ -1,6 +1,4 @@
-
-
-*:focus {
+:focus {
   outline: var(--focus-width) solid var(--focus-outline);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4254,6 +4254,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-visible@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.1.0.tgz#4b9d40143b865f53eafbd93ca66672b3bf9e7b6a"
+  integrity sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
Uses the [`:focus-visible` polyfill](https://github.com/WICG/focus-visible) to disable the focus ring when using mouse/touch interaction as opposed to keyboard interaction. This follows a pretty common pattern across webapps, where the focus ring is only shown when the user is detected to be a keyboard user.

The standard is currently not implemented in any browser, except Chrome with "experimental web platform features" enabled. But if it's never implemented, we can just keep using the polyfill.

I also added a setting to always show the focus ring, disabled by default. I disabled it by default because my hunch is that 1) the average mouse user does not know what a focus ring is and can't be bothered to go into their settings to change things, whereas 2) keyboard users are more likely to be a bit savvier (either because they are power users or because they have learned about how to toggle accessibility settings on sites to behave the way they like).

Similar to reduced motion, I think it's okay to have it disabled by default. Unlike reduced motion, though, I really wish there was some kind of CSS media query to detect this, ala the settings on macOS where you can tell it whether you want to always show the focus ring for all elements (not just inputs).

The situation with focus rings on the web is far from ideal, but I think this PR is a good compromise. As a mouse user, I am just really annoyed by having to always click away to remove the focus ring, and I prefer the more "app-like" experience. But I don't want hotkeys or pressing Esc on modals to behave poorly. This PR gives us the best of both worlds.