### PR TITLE
perf: use OffscreenCanvas in Chrome 82+

### DIFF
--- a/src/routes/_utils/userAgent/isChromePre82.js
+++ b/src/routes/_utils/userAgent/isChromePre82.js
@@ -1,0 +1,15 @@
+// checking for Chrome 82 because that's when this bug was fixed
+// https://bugs.chromium.org/p/chromium/issues/detail?id=1053477
+
+import { thunk } from '../thunk'
+import { isChrome } from './isChrome'
+
+function getChromeVersion () {
+  try {
+    return parseInt(navigator.userAgent.match(/Chrome\/(\d+)/)[1], 10) || undefined
+  } catch (e) {
+    return undefined
+  }
+}
+
+export const isChromePre82 = thunk(() => process.browser && isChrome() && getChromeVersion() < 82)

--- a/src/routes/_workers/blurhash.js
+++ b/src/routes/_workers/blurhash.js
@@ -2,11 +2,11 @@ import '../_thirdparty/regenerator-runtime/runtime.js'
 import { decode as decodeBlurHash } from 'blurhash'
 import registerPromiseWorker from 'promise-worker/register'
 import { BLURHASH_RESOLUTION as RESOLUTION } from '../_static/blurhash'
-import { isChrome } from '../_utils/userAgent/isChrome'
+import { isChromePre82 } from '../_utils/userAgent/isChromePre82'
 
 // Disabled in Chrome because convertToBlob() is slow
 // https://github.com/nolanlawson/pinafore/issues/1396
-const OFFSCREEN_CANVAS = !isChrome() && typeof OffscreenCanvas === 'function'
+const OFFSCREEN_CANVAS = !isChromePre82() && typeof OffscreenCanvas === 'function'
   ? new OffscreenCanvas(RESOLUTION, RESOLUTION) : null
 const OFFSCREEN_CANVAS_CONTEXT_2D = OFFSCREEN_CANVAS
   ? OFFSCREEN_CANVAS.getContext('2d') : null


### PR DESCRIPTION
Chrome fixed this bug (https://bugs.chromium.org/p/chromium/issues/detail?id=1053477), so we can re-enable it for Chrome 82+