### PR TITLE
fix: fix mobile size of picker when searching

### DIFF
--- a/src/routes/_components/dialog/components/EmojiDialog.html
+++ b/src/routes/_components/dialog/components/EmojiDialog.html
@@ -41,10 +41,7 @@
 
   @media (max-height: 450px) {
     :global(emoji-picker) {
-      height: 100%;
-    }
-    .emoji-container {
-      height: 100%;
+      height: calc(100vh - 75px); /* leave room for the dialog bar */
     }
   }
 </style>


### PR DESCRIPTION
When searching, the emoji picker changes height on mobile, which we don't want