### PR TITLE
fix: improve a11y of autosuggest labels

### DIFF
--- a/src/routes/_utils/createAutosuggestAccessibleLabel.js
+++ b/src/routes/_utils/createAutosuggestAccessibleLabel.js
@@ -6,7 +6,7 @@ export function createAutosuggestAccessibleLabel (
   const selected = searchResults[selectedIndex]
   let label
   if (autosuggestType === 'emoji') {
-    label = `${selected.unicode || selected.name}`
+    label = selected.name || [selected.unicode].concat(selected.shortcodes).join(', ')
   } else if (autosuggestType === 'hashtag') {
     label = `#${selected.name}`
   } else { // account


### PR DESCRIPTION
Put the native emoji shortcodes into the accessible label