### PR TITLE
autofocus search input field

### DIFF
--- a/src/routes/_components/search/Search.html
+++ b/src/routes/_components/search/Search.html
@@ -5,6 +5,7 @@
            placeholder="Search"
            aria-label="Search input"
            required
+           autofocus
            bind:value="$queryInSearch">
   </div>
   <button type="submit" class="primary search-button" aria-label="Search" disabled={$searchLoading}>


### PR DESCRIPTION
it is annoying to have to use `Tab` to focus the search input field on
the search page ( in keyboard mode ).

this changeset adds the `autofocus` tag on the input field so that it is
focused when the search page is brought to view.

I am aware that it is not recommended to use `autofocus` on input fields
for accesibility reasons. However, I would respectfully argue that for a
page which is descriptive and obvious where there is nothing but a single
input field and a button on that page that it does not warrant to follow
the recommendation blindly.

if the accessiblity recommendation has more priority or a 100%
accessibility score is more important, then this pull request may be
declined and closed.