### PR TITLE
add `/` as a navigation shortcut for search

### DIFF
--- a/src/routes/_components/NavShortcuts.html
+++ b/src/routes/_components/NavShortcuts.html
@@ -5,7 +5,7 @@
 <Shortcut key="g n" on:pressed="goto('/notifications')"/>
 <Shortcut key="g c" on:pressed="goto('/community')"/>
 <Shortcut key="g d" on:pressed="goto('/direct')"/>
-<Shortcut key="s" on:pressed="goto('/search')"/>
+<Shortcut key="s|/" on:pressed="goto('/search')"/>
 <Shortcut key="h|?" on:pressed="showShortcutHelpDialog()"/>
 <Shortcut key="c|7" on:pressed="showComposeDialog()"/>
 {#if !$leftRightChangesFocus}

--- a/tests/spec/024-shortcuts-navigation.js
+++ b/tests/spec/024-shortcuts-navigation.js
@@ -60,6 +60,14 @@ test('Shortcut s goes to the search page', async t => {
     .expect(getUrl()).contains('/search')
 })
 
+test('Shortcut / goes to the search page', async t => {
+  await loginAsFoobar(t)
+  await t
+    .expect(getUrl()).eql('http://localhost:4002/')
+    .pressKey('/')
+    .expect(getUrl()).contains('/search')
+})
+
 test('Shortcut backspace goes back from favorites', async t => {
   await loginAsFoobar(t)
   await t


### PR DESCRIPTION
`/` is a well-known vi/vim key-binding for search. It is supported by
Firefox for a 'quick find' feature in addition to the main find feature
available with the Ctrl+F key combination. [DuckDuckGo](https://duckduckgo.com) also supports the
key to focus the search bar as well. Other websites like GMail also
focuses the search bar on pressing the `/`. It is not only DuckDuckGo or
GMail alone that supports the key. I've noticed it on multiple websites
but I can only think of these 2 that are popular enough to argue support
over the top of my head. I cannot say if it is a good practice per se;
but I feel that it is a good feature to support.