### PR TITLE
fix: tweak language around bookmarking

### DIFF
--- a/src/routes/_actions/bookmark.js
+++ b/src/routes/_actions/bookmark.js
@@ -12,14 +12,14 @@ export async function setStatusBookmarkedOrUnbookmarked (statusId, bookmarked) {
       await unbookmarkStatus(currentInstance, accessToken, statusId)
     }
     if (bookmarked) {
-      toast.say('Bookmarked status')
+      toast.say('Bookmarked toot')
     } else {
-      toast.say('Unbookmarked status')
+      toast.say('Unbookmarked toot')
     }
     store.setStatusBookmarked(currentInstance, statusId, bookmarked)
     await database.setStatusBookmarked(currentInstance, statusId, bookmarked)
   } catch (e) {
     console.error(e)
-    toast.say(`Unable to ${bookmarked ? 'bookmark' : 'unbookmark'} status: ` + (e.message || ''))
+    toast.say(`Unable to ${bookmarked ? 'bookmark' : 'unbookmark'} toot: ` + (e.message || ''))
   }
 }

--- a/src/routes/_components/dialog/components/StatusOptionsDialog.html
+++ b/src/routes/_components/dialog/components/StatusOptionsDialog.html
@@ -83,7 +83,7 @@ export default {
     muteConversationLabel: ({ mutingConversation }) => mutingConversation ? 'Unmute conversation' : 'Mute conversation',
     muteConversationIcon: ({ mutingConversation }) => mutingConversation ? '#fa-volume-up' : '#fa-volume-off',
     isPublicOrUnlisted: ({ visibility }) => visibility === 'public' || visibility === 'unlisted',
-    bookmarkLabel: ({ status }) => status.bookmarked ? 'Unbookmark' : 'Bookmark',
+    bookmarkLabel: ({ status }) => status.bookmarked ? 'Unbookmark toot' : 'Bookmark toot',
     items: ({
       blockLabel, blocking, blockIcon, muteLabel, muteIcon, followLabel, followIcon,
       following, followRequested, pinLabel, isUser, visibility, mentionsUser, mutingConversation,


### PR DESCRIPTION
For consistency with the rest of the UI, say "toot" instead of "status" and specify "toot."