### PR TITLE
fix: use absolute positioning over transform

### DIFF
--- a/src/routes/_components/virtualList/VirtualListItem.html
+++ b/src/routes/_components/virtualList/VirtualListItem.html
@@ -1,7 +1,7 @@
 <div class="virtual-list-item list-item {shown ? 'shown' : ''}"
      aria-hidden={!shown}
      ref:node
-     style="transform: translateY({offset}px);" >
+     style="top: {offset}px;" >
   <svelte:component this={component}
               virtualProps={props}
               virtualIndex={index}
@@ -13,7 +13,6 @@
   .virtual-list-item {
     position: absolute;
     width: 100%;
-    top: 0;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s linear;


### PR DESCRIPTION
This fixes an issue in Firefox (on Ubuntu anyway) where it doesn't always draw the border between virtual list items. Also in terms of performance it should be roughly the same; my quick testing doesn't uncover any big difference in perf between the two, at least according to Chrome. We're not animating the property, so I don't think we need to use `transform`.

Before and after in Firefox:

![Screenshot from 2020-08-29 15-55-14](https://user-images.githubusercontent.com/283842/91647501-51bdf000-ea10-11ea-818f-589d6c6de7ca.png)

![Screenshot from 2020-08-29 15-55-24](https://user-images.githubusercontent.com/283842/91647503-55ea0d80-ea10-11ea-9dbf-cd287342a464.png)
