### PR TITLE
fix: pinning the bookmarks page

### DIFF
--- a/src/routes/_store/computations/navComputations.js
+++ b/src/routes/_store/computations/navComputations.js
@@ -42,6 +42,13 @@ export function navComputations (store) {
           svg: '#fa-star',
           label: 'Favorites'
         }
+      } else if (pinnedPage === '/bookmarks') {
+        pinnedPageObject = {
+          name: 'bookmarks',
+          href: '/bookmarks',
+          svg: '#fa-bookmark',
+          label: 'Bookmarks'
+        }
       } else if (pinnedPage.startsWith('/lists/')) {
         pinnedPageObject = {
           name: `lists/${pinnedPage.split('/').slice(-1)[0]}`,


### PR DESCRIPTION
Pinning the bookmarks page would accidentally pin the local timeline page due a forgotten `else if`. :heart:

Fixes #1858