### PR TITLE
fix: ensure bookmarks page has generated HTML file

### DIFF
--- a/src/routes/_pages/community/index.html
+++ b/src/routes/_pages/community/index.html
@@ -78,17 +78,15 @@
     <p>Community options appear here when logged in.</p>
   </FreeTextLayout>
 </HiddenFromSSR>
-  <div style="display: none">
-    <!-- TODO: this is just a hack so that `sapper export` knows to crawl these files -->
-    <a href="/muted">Muted</a>
-    <a href="/blocked">Blocked</a>
-    <a href="/pinned">Pinned</a>
-    <a href="/requests">Requests</a>
-    <a href="/share">Share</a>
-    <a href="/federated">Federated</a>
-    <a href="/favorites">Favorites</a>
-    <a href="/direct">Conversations</a>
-  </div>
+<div style="display: none">
+  <!-- TODO: this is just a hack so that `sapper export` knows to crawl these files -->
+  <!-- Note that these links have to be spread out or else they result in ECONNRESET errors during crawling -->
+  <!-- See also search.html -->
+  <a href="/requests">Requests</a>
+  <a href="/muted">Muted</a>
+  <a href="/blocked">Blocked</a>
+  <a href="/pinned">Pinned</a>
+</div>
 {/if}
 <style>
   .community-page {

--- a/src/routes/_pages/search.html
+++ b/src/routes/_pages/search.html
@@ -11,6 +11,17 @@
   </FreeTextLayout>
 </HiddenFromSSR>
 {/if}
+<div style="display: none">
+  <!-- TODO: this is just a hack so that `sapper export` knows to crawl these files -->
+  <!-- Note that these links have to be spread out or else they result in ECONNRESET errors during crawling -->
+  <!-- See also community/index.html -->
+  <a href="/local">Local</a>
+  <a href="/federated">Federated</a>
+  <a href="/favorites">Favorites</a>
+  <a href="/direct">Conversations</a>
+  <a href="/bookmarks">Bookmarks</a>
+  <a href="/share">Share</a>
+</div>
 <style>
   .search-page {
     padding: 20px 20px;

--- a/src/routes/_pages/search.html
+++ b/src/routes/_pages/search.html
@@ -10,7 +10,6 @@
     <p>You can search once logged in to an instance.</p>
   </FreeTextLayout>
 </HiddenFromSSR>
-{/if}
 <div style="display: none">
   <!-- TODO: this is just a hack so that `sapper export` knows to crawl these files -->
   <!-- Note that these links have to be spread out or else they result in ECONNRESET errors during crawling -->
@@ -22,6 +21,7 @@
   <a href="/bookmarks">Bookmarks</a>
   <a href="/share">Share</a>
 </div>
+{/if}
 <style>
   .search-page {
     padding: 20px 20px;


### PR DESCRIPTION
This probably really doesn't matter, as it's an extreme edge case (only occurs if you're on the bookmarks page, on a browser that doesn't support Service Worker or doesn't have Service Worker enabled for whatever reason, and you refresh), but it seems worth covering.