### PR TITLE
fix: fix status bar color in iOS 14

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -16,7 +16,7 @@
   <meta name="mobile-web-app-capable" content="yes" >
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="Pinafore" >
-  <meta name="apple-mobile-web-app-status-bar-style" content="white" >
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" >
 
   <!-- inline CSS -->
 


### PR DESCRIPTION
In iOS 14, the "white" status bar option is removed: https://firt.dev/ios-14#white-status-bar-gone

But it seems that setting it to "default" does basically the same thing: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html