### PR TITLE
fix: remove license files from service worker

### DIFF
--- a/bin/build-vercel-json.js
+++ b/bin/build-vercel-json.js
@@ -41,7 +41,7 @@ const JSON_TEMPLATE = {
       dest: 'client/$1'
     },
     {
-      src: '^/client/.*\\.(js|css|map|LICENSE)$',
+      src: '^/client/.*\\.(js|css|map|LICENSE|txt)$',
       headers: {
         'cache-control': 'public,max-age=31536000,immutable'
       }

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -34,7 +34,7 @@ const assets = __assets__
 const webpackAssets = __shell__
   .filter(filename => !filename.endsWith('.map')) // don't bother with sourcemaps
   .filter(filename => !filename.includes('tesseract-core.wasm')) // cache on-demand
-  .filter(filename => !filename.endsWith('.LICENSE')) // don't bother with license files
+  .filter(filename => !filename.includes('LICENSE')) // don't bother with license files
 
 // `routes` is an array of `{ pattern: RegExp }` objects that
 // match the pages in your src


### PR DESCRIPTION
Somehow some `.LICENSE.txt` files ended up in the Service Worker cache; we definitely don't need those.