### PR TITLE
fix: switch from no-referrer to strict-origin

### DIFF
--- a/bin/build-vercel-json.js
+++ b/bin/build-vercel-json.js
@@ -77,7 +77,7 @@ const HTML_HEADERS = {
     "form-action 'none'",
     "base-uri 'self'"
   ].join(';'),
-  'referrer-policy': 'no-referrer',
+  'referrer-policy': 'strict-origin',
   'strict-transport-security': 'max-age=15552000; includeSubDomains',
   'x-content-type-options': 'nosniff',
   'x-download-options': 'noopen',


### PR DESCRIPTION
Not sending the referer is great for privacy but sadly it breaks some cross-origin scenarios, in particular when you try to run OCR on an image after a refresh. By not sending the `referer` header in the cross-origin request, many cloud providers will just not send the CORS headers (e.g. AWS Cloudfront does this).

Since the Mastodon frontend also uses `origin` (and `strict-origin` is better), I don't think we're veering too far from user expectations. Although it would be nice to be able to control outgoing link clicks and cross-origin requests separately.