### PR TITLE
fix: change dark grayscale to use have a brighter action-button color

### DIFF
--- a/src/scss/themes/dark-grayscale.scss
+++ b/src/scss/themes/dark-grayscale.scss
@@ -14,3 +14,14 @@ $compose-background: lighten($main-theme-color, 52%);
 @import "_dark.scss";
 @import "_dark_navbar.scss";
 @import "_dark_scrollbars.scss";
+
+:root {
+  // like base.scss, but with $anchor-color instead of $main-theme-color
+  // <https://github.com/nolanlawson/pinafore/issues/1880>
+  --action-button-fill-color: #{lighten($anchor-color, 18%)};
+  --action-button-fill-color-hover: #{lighten($anchor-color, 22%)};
+  --action-button-fill-color-active: #{lighten($anchor-color, 5%)};
+  --action-button-fill-color-pressed: #{darken($anchor-color, 7%)};
+  --action-button-fill-color-pressed-hover: #{darken($anchor-color, 2%)};
+  --action-button-fill-color-pressed-active: #{darken($anchor-color, 15%)};
+}


### PR DESCRIPTION
The pressed state, such as used for the "Unfollow" button, was effectively identical to the background, thus making it invisible.

Brighten it up to fix this. The relative differences are kept the same as before and match the default theme,, e.g. the brightness ranges from (darkest) Unfollow > Unfollow-hover > Follow > Follow-hover (brightest)

| | Before | After
|--|--|--
| Follow | <img width="216" alt="before-follow" src="https://user-images.githubusercontent.com/156867/97092797-d27b2000-163e-11eb-99ac-a1539a5c371e.png"> | <img width="208" alt="after-follow" src="https://user-images.githubusercontent.com/156867/97092799-d444e380-163e-11eb-9605-029754d55713.png">
| Unfollow | <img width="209" alt="before-unfollow" src="https://user-images.githubusercontent.com/156867/97092798-d3ac4d00-163e-11eb-8076-666ee347603a.png"> | <img width="209" alt="after-unfollow" src="https://user-images.githubusercontent.com/156867/97092801-d4dd7a00-163e-11eb-8dc1-a866c8b96f28.png">


Fixes https://github.com/nolanlawson/pinafore/issues/1880.