### PR TITLE
fix: fix tappable area between toolbar buttons

### DIFF
--- a/src/routes/_components/IconButton.html
+++ b/src/routes/_components/IconButton.html
@@ -21,6 +21,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    pointer-events: auto;
   }
 
   :global(.icon-button-svg) {

--- a/src/routes/_components/status/StatusToolbar.html
+++ b/src/routes/_components/status/StatusToolbar.html
@@ -47,6 +47,7 @@
     grid-area: toolbar;
     display: flex;
     justify-content: space-between;
+    pointer-events: none;
   }
   .status-toolbar.status-in-own-thread {
     margin-left: 63px; /* offset to align all toolbar items: 48px avatar + 15px margin-right */


### PR DESCRIPTION
fixes #1884

If "disable entire toot area" is on, then the cursor becomes default between the buttons, and clicking does nothing. If it is off (default), then the cursor is always pointer and clicking between the buttons clicks the whole toot.