### PR TITLE
chore: cache bundler correctly in CircleCI

### DIFF
--- a/bin/clone-mastodon.js
+++ b/bin/clone-mastodon.js
@@ -10,8 +10,7 @@ const writeFile = promisify(fs.writeFile)
 const dir = __dirname
 
 const GIT_URL = 'https://github.com/tootsuite/mastodon.git'
-const GIT_TAG_OR_COMMIT = 'v3.1.3'
-const GIT_BRANCH = 'master'
+const GIT_TAG = 'v3.1.3'
 
 const mastodonDir = path.join(dir, '../mastodon')
 
@@ -20,9 +19,7 @@ export default async function cloneMastodon () {
     await stat(mastodonDir)
   } catch (e) {
     console.log('Cloning mastodon...')
-    await exec(`git clone --single-branch --branch ${GIT_BRANCH} ${GIT_URL} "${mastodonDir}"`)
-    await exec('git fetch origin --tags', { cwd: mastodonDir }) // may already be cloned, e.g. in CI
-    await exec(`git checkout ${GIT_TAG_OR_COMMIT}`, { cwd: mastodonDir })
+    await exec(`git clone --single-branch --branch ${GIT_TAG} ${GIT_URL} "${mastodonDir}"`)
     await writeFile(path.join(dir, '../mastodon/.env'), envFile, 'utf8')
   }
 }

--- a/bin/run-mastodon.js
+++ b/bin/run-mastodon.js
@@ -59,7 +59,7 @@ async function runMastodon () {
   const cwd = mastodonDir
   const cmds = [
     'gem install bundler foreman',
-    'bundle install',
+    'bundle install --frozen',
     'bundle exec rails db:migrate',
     'yarn --pure-lockfile'
   ]


### PR DESCRIPTION
Also do a more efficient checkout of the Mastodon tag from git