### PR TITLE
test: always migrate mastodon server when launching

### DIFF
--- a/bin/run-mastodon.js
+++ b/bin/run-mastodon.js
@@ -58,12 +58,11 @@ async function runMastodon () {
     DB_PORT
   })
   const cwd = mastodonDir
-  const cmds = [
+  const installCommands = [
     'gem update --system',
     'gem install bundler foreman',
     'bundle config set --local frozen \'true\'',
     'bundle install',
-    'bundle exec rails db:migrate',
     'yarn --pure-lockfile'
   ]
 
@@ -73,12 +72,13 @@ async function runMastodon () {
     console.log('Already installed Mastodon')
   } catch (e) {
     console.log('Installing Mastodon...')
-    for (const cmd of cmds) {
+    for (const cmd of installCommands) {
       console.log(cmd)
       await exec(cmd, { cwd, env })
     }
     await writeFile(installedFile, '', 'utf8')
   }
+  await exec('bundle exec rails db:migrate', { cwd, env })
   const promise = spawn('foreman', ['start'], { cwd, env })
   // don't bother writing to mastodon.log in CI; we can't read the file anyway
   const logFile = process.env.CIRCLECI ? '/dev/null' : 'mastodon.log'


### PR DESCRIPTION
This fixes some bugs in dev mode where the Mastodon DB might say it needs a Rails migration stil.