### PR TITLE
fix: tweak emoji picker style on mobile

### DIFF
--- a/src/routes/_components/dialog/components/EmojiDialog.html
+++ b/src/routes/_components/dialog/components/EmojiDialog.html
@@ -17,29 +17,29 @@
   </div>
 </ModalDialog>
 <style>
-  :global(emoji-picker) {
+  emoji-picker {
     --indicator-color: var(--main-theme-color);
     --outline-color: var(--focus-outline);
   }
 
   @media (max-width: 479px) {
-    .emoji-container, :global(emoji-picker) {
+    .emoji-container, emoji-picker {
       width: 100%;
     }
   }
 
   @media (max-width: 320px) {
-    :global(emoji-picker) {
+    emoji-picker {
       --emoji-padding: 0.25rem;
       --input-padding: 0.125rem;
     }
-    :global(emoji-picker) {
+    emoji-picker {
       --num-columns: 6;
     }
   }
 
   @media (max-width: 240px) {
-    :global(emoji-picker) {
+    emoji-picker {
       --num-columns: 6;
       --emoji-size: 1.125rem;
       --emoji-padding: 0.125rem;
@@ -48,7 +48,7 @@
   }
 
   @media (max-height: 450px) {
-    :global(emoji-picker) {
+    emoji-picker {
       height: calc(100vh - 75px); /* leave room for the dialog bar */
     }
   }

--- a/src/routes/_components/dialog/components/EmojiDialog.html
+++ b/src/routes/_components/dialog/components/EmojiDialog.html
@@ -23,17 +23,16 @@
   }
 
   @media (max-width: 479px) {
-    :global(emoji-picker) {
-      --emoji-padding: 0.25rem;
-      --input-padding: 0.125rem;
-    }
-
     .emoji-container, :global(emoji-picker) {
       width: 100%;
     }
   }
 
   @media (max-width: 320px) {
+    :global(emoji-picker) {
+      --emoji-padding: 0.25rem;
+      --input-padding: 0.125rem;
+    }
     :global(emoji-picker) {
       --num-columns: 6;
     }


### PR DESCRIPTION
Just makes the padding a bit better on large mobile phone sizes, I felt it was getting too cramped