### PR TITLE
chore: update sapper to actually fix webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-terser": "^7.0.2",
     "rtl-detect": "^1.0.2",
-    "sapper": "nolanlawson/sapper#for-pinafore-24",
+    "sapper": "nolanlawson/sapper#for-pinafore-25",
     "sass": "^1.32.8",
     "stringz": "^2.1.0",
     "svelte": "^2.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6448,9 +6448,9 @@ sanitize-filename@^1.6.0:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-sapper@nolanlawson/sapper#for-pinafore-24:
+sapper@nolanlawson/sapper#for-pinafore-25:
   version "0.27.12"
-  resolved "https://codeload.github.com/nolanlawson/sapper/tar.gz/15ab2446a54eadb0a12881bc39cb73013c94c474"
+  resolved "https://codeload.github.com/nolanlawson/sapper/tar.gz/acf196a742b0b25c59b51d5280308d198f32a22e"
   dependencies:
     html-minifier "^3.5.20"
     http-link-header "^1.0.2"


### PR DESCRIPTION
Maintaining this old Sapper fork is not fun, but here I am