### PR TITLE
Adjust German help text for Expand All CWs

### DIFF
--- a/src/intl/de.js
+++ b/src/intl/de.js
@@ -155,7 +155,7 @@ export default {
     <li><kbd>p</kbd> das Profil des Verfassers öffnen</li>
     <li><kbd>l</kbd> den Link des aktuellen Tröts in einem neuen Tab öffnen</li>
     <li><kbd>x</kbd> den Text hinter der Inhaltswarnung anzeigen oder verbergen</li>
-    <li><kbd>z</kbd> den Text hinter der Inhaltswarnung anzeigen oder verbergen (alle)</li>
+    <li><kbd>z</kbd> den Text hinter der Inhaltswarnung für alle in dieser Unterhaltung anzeigen oder verbergen</li>
   `,
   mediaHotkeys: `
     <li><kbd>←</kbd> / <kbd>→</kbd> zum nächsten oder vorherigen Inhalt gehen</li>


### PR DESCRIPTION
This adjusts the help text to be more explicit about the purpose of the z shortcut key.