### PR TITLE
chore: clean up input.type property access

### DIFF
--- a/src/routes/_components/shortcut/ScrollListShortcuts.html
+++ b/src/routes/_components/shortcut/ScrollListShortcuts.html
@@ -26,7 +26,7 @@
     const { target, key } = event
     const isRadio = target &&
     target.tagName === 'INPUT' &&
-    (target.type || '').toLowerCase() === 'radio'
+    target.type === 'radio'
     const isArrow = key === 'ArrowUp' || key === 'ArrowDown'
     return isRadio && isArrow
   }


### PR DESCRIPTION
Follows-up 4218c4ce640ab33897733b4858d5c60676b4a5aa.

When accessing the IDL property, values tend to be reflected in a normalised
type and form. In the case of HTMLInputElement.type, this means the
returned value is always one of the supported and canonical lowercase
values regardless of what value the corresponding attribute holds, or
even if the attribute doesn't exist (the default will still be "text").