### PR TITLE
perf: reduce tesseract bundle size by directly importing createWorker

### DIFF
--- a/src/routes/_utils/tesseractWorker.js
+++ b/src/routes/_utils/tesseractWorker.js
@@ -4,7 +4,7 @@
 // We should explore this at a later date.
 import corePath from 'tesseract.js-core/tesseract-core.wasm.js'
 import workerPath from 'tesseract.js/dist/worker.min.js'
-import { createWorker } from 'tesseract.js'
+import createWorker from 'tesseract.js/src/createWorker.js'
 
 const { origin } = location
 

--- a/webpack/server.config.js
+++ b/webpack/server.config.js
@@ -15,7 +15,8 @@ const NOOP_MODULES = [
   'tesseract.js/dist/worker.min.js.map',
   'tesseract.js-core/tesseract-core.wasm',
   'tesseract.js-core/tesseract-core.wasm.js',
-  'tesseract.js'
+  'tesseract.js/src/createWorker.js',
+  'tesseract.js/src/createWorker.js.map'
 ]
 
 const serverResolve = JSON.parse(JSON.stringify(resolve))


### PR DESCRIPTION
Reduces total webpack JS size from 1.2 MB to 1.19 MB