### PR TITLE
fix: add cross-origin-opener-policy

### DIFF
--- a/bin/build-vercel-json.js
+++ b/bin/build-vercel-json.js
@@ -88,7 +88,8 @@ const HTML_HEADERS = {
   'x-content-type-options': 'nosniff',
   'x-download-options': 'noopen',
   'x-frame-options': 'DENY',
-  'x-xss-protection': '1; mode=block'
+  'x-xss-protection': '1; mode=block',
+  'cross-origin-opener-policy': 'same-origin'
 }
 
 async function main () {

--- a/vercel.json
+++ b/vercel.json
@@ -52,7 +52,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -66,7 +67,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -80,7 +82,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -94,7 +97,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -108,7 +112,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -122,7 +127,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -136,7 +142,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -150,7 +157,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -165,7 +173,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -180,7 +189,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -195,7 +205,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -210,7 +221,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -225,7 +237,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -239,7 +252,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -253,7 +267,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -268,7 +283,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -282,7 +298,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -296,7 +313,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -311,7 +329,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -325,7 +344,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -339,7 +359,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -353,7 +374,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -367,7 +389,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -382,7 +405,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -397,7 +421,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -412,7 +437,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -426,7 +452,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -440,7 +467,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -454,7 +482,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -468,7 +497,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -483,7 +513,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -497,7 +528,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -511,7 +543,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     },
     {
@@ -525,7 +558,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       },
       "dest": "service-worker-index.html"
     },
@@ -540,7 +574,8 @@
         "x-content-type-options": "nosniff",
         "x-download-options": "noopen",
         "x-frame-options": "DENY",
-        "x-xss-protection": "1; mode=block"
+        "x-xss-protection": "1; mode=block",
+        "cross-origin-opener-policy": "same-origin"
       }
     }
   ]


### PR DESCRIPTION
This makes it so another website can't open pinafore with `window.open()` and then manipulate the window, e.g. set `window.location`.