### PR TITLE
perf: avoid importing the DB for non-logged-in users

### DIFF
--- a/src/routes/_pages/index.html
+++ b/src/routes/_pages/index.html
@@ -8,26 +8,13 @@
   import { store } from '../_store/store.js'
   import TimelineHomePage from '../_components/TimelineHomePage.html'
   import { observe } from 'svelte-extras'
-  import { showShareDialogIfNecessary } from '../_actions/showShareDialogIfNecessary'
   import { doQuickLoginIfNecessary } from '../_actions/doQuickLoginIfNecessary'
 
   export default {
     async oncreate () {
       doQuickLoginIfNecessary()
-      let observed = false
-      this.observe('currentVerifyCredentials', verifyCredentials => {
-        if (verifyCredentials && !observed) {
-          // when the verifyCredentials object is available, we can check to see
-          // if the user is trying to share something, then share it
-          observed = true
-          /* no await */ showShareDialogIfNecessary()
-        }
-      })
     },
     store: () => store,
-    computed: {
-      currentVerifyCredentials: ({ $currentVerifyCredentials }) => $currentVerifyCredentials
-    },
     methods: {
       observe
     },

--- a/src/routes/_store/observers/loggedInObservers.js
+++ b/src/routes/_store/observers/loggedInObservers.js
@@ -7,6 +7,7 @@ import { customScrollbarObservers } from './customScrollbarObservers'
 import { customEmojiObservers } from './customEmojiObservers'
 import { cleanup } from './cleanup'
 import { wordFilterObservers } from './wordFilterObservers'
+import { showShareDialogObservers } from './showShareDialogObservers'
 
 // These observers can be lazy-loaded when the user is actually logged in.
 // Prevents circular dependencies and reduces the size of main.js
@@ -19,5 +20,6 @@ export function loggedInObservers () {
   notificationPermissionObservers()
   customScrollbarObservers()
   customEmojiObservers()
+  showShareDialogObservers()
   cleanup()
 }

--- a/src/routes/_store/observers/showShareDialogObservers.js
+++ b/src/routes/_store/observers/showShareDialogObservers.js
@@ -1,0 +1,19 @@
+import { store } from '../store'
+import { showShareDialogIfNecessary } from '../../_actions/showShareDialogIfNecessary'
+
+// If the user is logged in, and if the Service Worker handled a POST and set special data
+// in IndexedDB, then we want to handle it on the home page.
+export function showShareDialogObservers () {
+  let observedOnce = false
+  store.observe('currentVerifyCredentials', verifyCredentials => {
+    if (verifyCredentials && !observedOnce) {
+      // when the verifyCredentials object is available, we can check to see
+      // if the user is trying to share something, then share it
+      observedOnce = true
+      const { currentPage } = store.get()
+      if (currentPage === 'home') {
+        /* no await */ showShareDialogIfNecessary()
+      }
+    }
+  })
+}


### PR DESCRIPTION
Saves us one JS request on a normal non-logged-in home page load