### PR TITLE
fix: disable :focus-visible on Firefox

### DIFF
--- a/src/routes/_utils/supportsFocusVisible.js
+++ b/src/routes/_utils/supportsFocusVisible.js
@@ -4,4 +4,4 @@ import { isFirefox } from './userAgent/isFirefox'
 
 // TODO: remove the Firefox check once this bug is fixed
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1699154
-export const supportsFocusVisible = thunk(() => !isFirefox() && supportsSelector(':focus-visible'))
+export const supportsFocusVisible = thunk(() => (!isFirefox() && supportsSelector(':focus-visible')))

--- a/src/routes/_utils/supportsFocusVisible.js
+++ b/src/routes/_utils/supportsFocusVisible.js
@@ -1,4 +1,7 @@
 import { thunk } from './thunk'
 import { supportsSelector } from './supportsSelector'
+import { isFirefox } from './userAgent/isFirefox'
 
-export const supportsFocusVisible = thunk(() => supportsSelector(':focus-visible'))
+// TODO: remove the Firefox check once this bug is fixed
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1699154
+export const supportsFocusVisible = thunk(() => !isFirefox() && supportsSelector(':focus-visible'))

--- a/src/routes/_utils/userAgent/isFirefox.js
+++ b/src/routes/_utils/userAgent/isFirefox.js
@@ -1,0 +1,3 @@
+export function isFirefox () {
+  return typeof InstallTrigger !== 'undefined' // https://stackoverflow.com/a/9851769/680742
+}


### PR DESCRIPTION
I'm sufficiently annoyed by [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1699154) that I'm willing to use the `:focus-visible` polyfill rather than Firefox's native implementation. It even triggers focus rings on mobile, which is too jarring IMO.

Testing WebKit nightly, it does not appear to have the same bug.