### PR TITLE
Add a Wellness option to show absolute timestamps instead of relative

### DIFF
--- a/src/intl/en-US.js
+++ b/src/intl/en-US.js
@@ -392,6 +392,9 @@ export default {
   hideReblogCount: 'Hide boost counts',
   hideFavoriteCount: 'Hide favorite counts',
   hideUnread: 'Hide unread notifications count (i.e. the red dot)',
+  // The quality that makes something seem important or interesting because it seems to be happening now
+  immediacy: 'Immediacy',
+  showAbsoluteTimestamps: 'Show absolute timestamps instead of relative timestamps',
   ui: 'UI',
   grayscaleMode: 'Grayscale mode',
   wellnessFooter: `These settings are partly based on guidelines from the

--- a/src/routes/_components/status/StatusRelativeDate.html
+++ b/src/routes/_components/status/StatusRelativeDate.html
@@ -4,9 +4,9 @@
    rel="prefetch"
    {tabindex}
 >
-  <time datetime={createdAtDate} title={absoluteFormattedDate}
+  <time datetime={createdAtDate} title={formattedDateTitle}
         aria-label={createdAtLabel}>
-    {timeagoFormattedDate}
+    {formattedDate}
   </time>
 </a>
 <style>
@@ -41,9 +41,23 @@
         // just a duplicate link in the focus order.
         $disableTapOnStatus ? '0' : '-1'
       ),
-      createdAtLabel: ({ timeagoFormattedDate }) => (
-        formatIntl('intl.clickToShowThread', { time: timeagoFormattedDate })
-      )
+      formattedDateTitle: ({ $disableRelativeTimestamps, absoluteFormattedDate }) => {
+        if ($disableRelativeTimestamps) {
+          return ''
+        } else {
+          return absoluteFormattedDate
+        }
+      },
+      createdAtLabel: ({ formattedDate }) => (
+        formatIntl('intl.clickToShowThread', { time: formattedDate })
+      ),
+      formattedDate: ({ $disableRelativeTimestamps, timeagoFormattedDate, absoluteFormattedDate }) => {
+        if ($disableRelativeTimestamps) {
+          return absoluteFormattedDate
+        } else {
+          return timeagoFormattedDate
+        }
+      }
     }
   }
 </script>

--- a/src/routes/_pages/settings/wellness.html
+++ b/src/routes/_pages/settings/wellness.html
@@ -33,13 +33,18 @@
     </label>
   </form>
 
-  <h2>{intl.notifications}</h2>
+  <h2>{intl.immediacy}</h2>
 
   <form class="ui-settings">
     <label class="setting-group">
       <input type="checkbox" id="choice-disable-unread-notification-counts"
              bind:checked="$disableNotificationBadge" on:change="onChange(event)">
       {intl.hideUnread}
+    </label>
+    <label class="settings-group">
+      <input type="checkbox" id="choice-disable-relative-timestamps"
+             bind:checked="$disableRelativeTimestamps" on:change="onChange(event)">
+      {intl.showAbsoluteTimestamps}
     </label>
   </form>
 
@@ -90,12 +95,14 @@
           disableReblogCounts,
           disableFavCounts,
           disableNotificationBadge,
+          disableRelativeTimestamps,
           enableGrayscale
         } = this.store.get()
         document.querySelector('#choice-check-all').checked = disableFollowerCounts &&
           disableReblogCounts &&
           disableFavCounts &&
           disableNotificationBadge &&
+          disableRelativeTimestamps &&
           enableGrayscale
       },
       onCheckAllChange (e) {
@@ -105,6 +112,7 @@
           disableReblogCounts: checked,
           disableFavCounts: checked,
           disableNotificationBadge: checked,
+          disableRelativeTimestamps: checked,
           enableGrayscale: checked
         })
         this.store.save()

--- a/src/routes/_store/store.js
+++ b/src/routes/_store/store.js
@@ -21,6 +21,7 @@ const persistedState = {
   disableLongAriaLabels: false,
   disableNotificationBadge: false,
   disableReblogCounts: false,
+  disableRelativeTimestamps: false,
   disableTapOnStatus: false,
   enableGrayscale: false,
   hideCards: false,


### PR DESCRIPTION
Relative timestamps can cause you to feel that things are especially
interesting because they are happening "right now"; the effect is
lessened if you see absolute timestamps instead.

This fixes #2011

As it stands, this PR has a couple of issues that still need to be solved:

When absolute timestamps are enabled, I intended to remove the `title` attribute on the timestamps, as they're no longer needed. [According to the svelte docs](https://v2.svelte.dev/guide#tags), attributes are supposed to be removed from the element if their value is `undefined` or `null`, but instead the `title` attribute is getting set to the literal string `undefined`.

The wording of the option name is a bit too long, and wraps. I'm unsure about the option group heading that I've chosen in the settings panel.