### PR TITLE
chore: update tested mastodon to fix mimemagic

### DIFF
--- a/bin/clone-mastodon.js
+++ b/bin/clone-mastodon.js
@@ -9,8 +9,8 @@ const stat = promisify(fs.stat)
 const writeFile = promisify(fs.writeFile)
 const dir = __dirname
 
-const GIT_URL = 'https://github.com/tootsuite/mastodon.git'
-const GIT_TAG = 'v3.3.0'
+const GIT_URL = 'https://github.com/nolanlawson/mastodon.git'
+const GIT_TAG = 'tag-abad99f'
 
 const mastodonDir = path.join(dir, '../mastodon')
 


### PR DESCRIPTION
CI is failing due to this fun situation: https://github.com/tootsuite/mastodon/issues/15986