### PR TITLE
fix: fix aria-labels on relative timestamps

### DIFF
--- a/src/routes/_components/status/StatusRelativeDate.html
+++ b/src/routes/_components/status/StatusRelativeDate.html
@@ -41,8 +41,8 @@
         // just a duplicate link in the focus order.
         $disableTapOnStatus ? '0' : '-1'
       ),
-      createdAtLabel: ({ formattedDate }) => (
-        formatIntl('intl.clickToShowThread', { time: formattedDate })
+      createdAtLabel: ({ shortInlineFormattedDate }) => (
+        formatIntl('intl.clickToShowThread', { time: shortInlineFormattedDate })
       )
     }
   }

--- a/tests/spec/022-status-aria-label.js
+++ b/tests/spec/022-status-aria-label.js
@@ -2,7 +2,7 @@ import { loginAsFoobar } from '../roles'
 import {
   generalSettingsButton,
   getNthShowOrHideButton,
-  getNthStatus, homeNavButton,
+  getNthStatus, getNthStatusRelativeDateTime, homeNavButton,
   notificationsNavButton,
   scrollToStatus,
   settingsNavButton
@@ -20,6 +20,9 @@ test('basic aria-labels for statuses', async t => {
     .hover(getNthStatus(1))
     .expect(getNthStatus(1).getAttribute('aria-label')).match(
       /quux, pinned toot 1, .+ ago, @quux, Unlisted, Boosted by admin/i
+    )
+    .expect(getNthStatusRelativeDateTime(1).getAttribute('aria-label')).match(
+      /.* ago - click to show thread/i
     )
     .hover(getNthStatus(1))
     .expect(getNthStatus(2).getAttribute('aria-label')).match(

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -466,6 +466,10 @@ export function getNthStatusRelativeDate (n) {
   return $(`${getNthStatusSelector(n)} .status-relative-date`)
 }
 
+export function getNthStatusRelativeDateTime (n) {
+  return $(`${getNthStatusSelector(n)} .status-relative-date time`)
+}
+
 export function getNthStatusMediaImg (n) {
   return $(`${getNthStatusSelector(n)} .status-media img`)
 }


### PR DESCRIPTION
This regressed due to #2014. Added a test to ensure it doesn't regress again.