### PR TITLE
fix: switch to native :focus-visible for firefox 88+

### DIFF
--- a/src/routes/_utils/supportsFocusVisible.js
+++ b/src/routes/_utils/supportsFocusVisible.js
@@ -1,7 +1,7 @@
 import { thunk } from './thunk'
 import { supportsSelector } from './supportsSelector'
-import { isFirefox } from './userAgent/isFirefox'
+import { isFirefoxPre88 } from './userAgent/isFirefoxPre88'
 
-// TODO: remove the Firefox check once this bug is fixed
+// Firefox pre-88 had a focus-visible bug:
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1699154
-export const supportsFocusVisible = thunk(() => (!isFirefox() && supportsSelector(':focus-visible')))
+export const supportsFocusVisible = thunk(() => (!isFirefoxPre88() && supportsSelector(':focus-visible')))

--- a/src/routes/_utils/userAgent/isFirefox.js
+++ b/src/routes/_utils/userAgent/isFirefox.js
@@ -1,3 +1,5 @@
-export function isFirefox () {
-  return typeof InstallTrigger !== 'undefined' // https://stackoverflow.com/a/9851769/680742
-}
+import { thunk } from '../thunk'
+
+export const isFirefox = thunk(() => {
+  return process.browser && typeof InstallTrigger !== 'undefined' // https://stackoverflow.com/a/9851769/680742
+})

--- a/src/routes/_utils/userAgent/isFirefoxPre88.js
+++ b/src/routes/_utils/userAgent/isFirefoxPre88.js
@@ -1,0 +1,17 @@
+import { isFirefox } from './isFirefox'
+import { thunk } from '../thunk'
+
+export const isFirefoxPre88 = thunk(() => {
+  if (!isFirefox()) {
+    return false
+  }
+  try {
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/88#javascript
+    // https://github.com/tc39/proposal-regexp-match-indices
+    // eslint-disable-next-line no-invalid-regexp,prefer-regex-literals
+    RegExp('', 'd')
+    return false
+  } catch (e) {
+    return true
+  }
+})


### PR DESCRIPTION
https://github.com/nolanlawson/pinafore/issues/2038 made me realize Firefox has shipped this fix, so we can use native focus-visible now. https://bugzilla.mozilla.org/show_bug.cgi?id=1699154