### PR TITLE
fix: work around missing indexedDB.databases

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -6,7 +6,7 @@ import './routes/_utils/forceOnline'
 import { mark, stop } from './routes/_utils/marks'
 import { loadPolyfills } from './routes/_utils/polyfills/loadPolyfills'
 import { loadNonCriticalPolyfills } from './routes/_utils/polyfills/loadNonCriticalPolyfills'
-import idbReady from 'safari-14-idb-fix'
+import { idbReady } from './routes/_utils/idbReady'
 
 Promise.all([idbReady(), loadPolyfills()]).then(() => {
   mark('sapperStart')

--- a/src/routes/_utils/idbReady.js
+++ b/src/routes/_utils/idbReady.js
@@ -1,0 +1,14 @@
+import safariIdbReady from 'safari-14-idb-fix'
+import { isWebKit } from './userAgent/isWebKit'
+
+// workaround for a safari 14 bug, see https://github.com/jakearchibald/safari-14-idb-fix
+export async function idbReady () {
+  if (!isWebKit()) {
+    return
+  }
+  if (typeof indexedDB === 'undefined' || !indexedDB.databases) {
+    // fix for https://github.com/jakearchibald/safari-14-idb-fix/pull/2
+    return
+  }
+  await safariIdbReady()
+}


### PR DESCRIPTION
see https://github.com/jakearchibald/safari-14-idb-fix/pull/2