### PR TITLE
fix: remove performance-now module, use perf_hooks

### DIFF
--- a/bin/build-template-html.js
+++ b/bin/build-template-html.js
@@ -5,7 +5,7 @@ import { promisify } from 'util'
 import { buildSass } from './build-sass'
 import { buildInlineScript } from './build-inline-script'
 import { buildSvg } from './build-svg'
-import now from 'performance-now'
+import { performance } from 'perf_hooks'
 import debounce from 'lodash-es/debounce'
 import applyIntl from '../webpack/svelte-intl-loader'
 import { LOCALE } from '../src/routes/_static/intl'
@@ -80,7 +80,7 @@ function doWatch () {
 }
 
 async function buildAll () {
-  const start = now()
+  const start = performance.now()
   let html = (await Promise.all(partials.map(async partial => {
     if (typeof partial === 'string') {
       return partial
@@ -95,7 +95,7 @@ async function buildAll () {
     .replace('{process.env.LOCALE}', LOCALE)
     .replace('{process.env.LOCALE_DIRECTION}', LOCALE_DIRECTION)
   await writeFile(path.resolve(__dirname, '../src/template.html'), html, 'utf8')
-  const end = now()
+  const end = performance.now()
   console.log(`Built template.html in ${(end - start).toFixed(2)}ms`)
 }
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "npm-run-all": "^4.1.5",
     "p-any": "^3.0.0",
     "page-lifecycle": "^0.1.2",
-    "performance-now": "^2.1.0",
     "pinch-zoom-element": "^1.1.1",
     "promise-worker": "^2.0.1",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5430,11 +5430,6 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"


### PR DESCRIPTION
Probably a breaking change for self-hosters because we'll have to bump the minimum required Node version to whichever versions support `perf_hooks`.