### PR TITLE
test: skip unnecessary navigations in readonly tests

### DIFF
--- a/tests/roles.js
+++ b/tests/roles.js
@@ -1,6 +1,8 @@
 import { getUrl } from './utils'
 import { users } from './users'
 
+export const foobarURL = `http://localhost:4002/?instanceName=localhost:3000&accessToken=${users.foobar.accessToken}`
+
 // quick login using a secret page and a known access token (makes tests run faster)
 async function login (t, user) {
   await t.navigateTo(`/?instanceName=localhost:3000&accessToken=${user.accessToken}`)

--- a/tests/spec/003-basic-timeline-spec.js
+++ b/tests/spec/003-basic-timeline-spec.js
@@ -5,13 +5,12 @@ import {
   validateTimeline
 } from '../utils'
 import { homeTimeline, notifications, localTimeline, favorites, directMessages } from '../fixtures'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`003-basic-timeline-spec.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Shows the home timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })
@@ -26,7 +25,6 @@ test('Shows the home timeline', async t => {
 })
 
 test('Shows notifications', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })
@@ -37,7 +35,6 @@ test('Shows notifications', async t => {
 })
 
 test('Shows the local timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })
@@ -48,7 +45,6 @@ test('Shows the local timeline', async t => {
 })
 
 test('Shows the federated timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })
@@ -61,7 +57,6 @@ test('Shows the federated timeline', async t => {
 })
 
 test('Shows favorites', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })
@@ -74,7 +69,6 @@ test('Shows favorites', async t => {
 })
 
 test('Shows direct messages', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })

--- a/tests/spec/004-pinned-statuses.js
+++ b/tests/spec/004-pinned-statuses.js
@@ -1,12 +1,11 @@
 import { Selector as $ } from 'testcafe'
 import { communityNavButton, getNthPinnedStatus, getUrl } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`004-pinned-statuses.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test("shows a user's pinned statuses", async t => {
-  await loginAsFoobar(t)
   await t
     .click(communityNavButton)
     .expect(getUrl()).contains('/community')
@@ -18,7 +17,6 @@ test("shows a user's pinned statuses", async t => {
 })
 
 test("shows pinned statuses on a user's account page", async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/accounts/2')
     .expect(getNthPinnedStatus(1).getAttribute('aria-posinset')).eql('1')
@@ -27,7 +25,6 @@ test("shows pinned statuses on a user's account page", async t => {
 })
 
 test("shows pinned statuses on a user's account page 2", async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/accounts/3')
     .expect(getNthPinnedStatus(1).getAttribute('aria-posinset')).eql('1')

--- a/tests/spec/005-status-types.js
+++ b/tests/spec/005-status-types.js
@@ -1,12 +1,11 @@
 import { getNthStatusSelector } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`005-status-types.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('shows followers-only vs regular in home timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect($(`${getNthStatusSelector(2)} .status-content`).innerText).contains('notification of unlisted message')
     .expect($(`${getNthStatusSelector(2)} .status-toolbar button:nth-child(2)`).getAttribute('aria-label'))
@@ -19,7 +18,6 @@ test('shows followers-only vs regular in home timeline', async t => {
 })
 
 test('shows direct vs followers-only vs regular in notifications', async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/notifications')
     .expect($(`${getNthStatusSelector(3)} .status-content`).innerText).contains('notification of unlisted message')

--- a/tests/spec/006-tabindex.js
+++ b/tests/spec/006-tabindex.js
@@ -1,12 +1,11 @@
 import { Selector as $ } from 'testcafe'
 import { getNthStatus } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`006-tabindex.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('shows correct tabindex in home timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getNthStatus(1).getAttribute('tabindex')).eql('0')
     .expect(getNthStatus(2).getAttribute('tabindex')).eql('0')
@@ -15,7 +14,6 @@ test('shows correct tabindex in home timeline', async t => {
 })
 
 test('shows correct tabindex in notifications', async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/notifications')
     .expect(getNthStatus(1).getAttribute('tabindex')).eql('0')
@@ -33,7 +31,6 @@ test('shows correct tabindex in notifications', async t => {
 })
 
 test('shows correct tabindex in pinned statuses', async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/pinned')
     .expect($('.status-article').getAttribute('tabindex')).eql('0')

--- a/tests/spec/007-account-profile.js
+++ b/tests/spec/007-account-profile.js
@@ -4,14 +4,13 @@ import {
   accountProfileFollowedBy, accountProfileName, accountProfileUsername, getUrl,
   validateTimeline
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { quuxStatuses } from '../fixtures'
 
 fixture`007-account-profile.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('shows account profile', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('.status-author-name').withText(('quux')))
     .expect(getUrl()).contains('/accounts/3')
@@ -22,7 +21,6 @@ test('shows account profile', async t => {
 })
 
 test('shows account profile 2', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('.status-author-name').withText(('admin')))
     .expect(getUrl()).contains('/accounts/1')
@@ -34,7 +32,6 @@ test('shows account profile 2', async t => {
 })
 
 test('shows account profile 3', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('.mention').withText(('foobar')))
     .expect(getUrl()).contains('/accounts/2')
@@ -46,7 +43,6 @@ test('shows account profile 3', async t => {
 })
 
 test('shows account profile statuses', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('.status-author-name').withText(('quux')))
     .expect(getUrl()).contains('/accounts/3')

--- a/tests/spec/008-status-media.js
+++ b/tests/spec/008-status-media.js
@@ -6,16 +6,14 @@ import {
   modalDialogContents,
   scrollToStatus
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 import { homeTimeline } from '../fixtures'
 
 fixture`008-status-media.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('shows sensitive images and videos', async t => {
-  await loginAsFoobar(t)
-
   const kittenIdx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
   const videoIdx = homeTimeline.findIndex(_ => _.content === 'secret video')
 
@@ -33,8 +31,6 @@ test('shows sensitive images and videos', async t => {
 })
 
 test('click and close image and video modals', async t => {
-  await loginAsFoobar(t)
-
   const videoIdx = homeTimeline.findIndex(_ => _.content === "here's a video")
   const kittenIdx = homeTimeline.findIndex(_ => _.content === "here's an animated kitten gif")
 

--- a/tests/spec/009-threads.js
+++ b/tests/spec/009-threads.js
@@ -3,14 +3,13 @@ import {
   getNthStatus, getUrl, validateTimeline, getFirstVisibleStatus,
   goBack, forceOffline, forceOnline, searchNavButton, searchInput, getNthSearchResult, scrollToStatus
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { bazThreadRelativeTo2, bazThreadRelativeTo2b, bazThreadRelativeTo2B2, quuxThread } from '../fixtures'
 
 fixture`009-threads.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Shows a thread', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('a').withText('quux'))
 
@@ -26,7 +25,6 @@ test('Shows a thread', async t => {
 })
 
 test('Scrolls to proper point in thread', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('a').withText('quux'))
     .hover(getNthStatus(1))
@@ -72,7 +70,6 @@ async function validateForkedThread (t) {
 }
 
 test('Forked threads look correct online and offline', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getFirstVisibleStatus())
   await navigateToBazAccount(t)

--- a/tests/spec/010-focus.js
+++ b/tests/spec/010-focus.js
@@ -16,17 +16,15 @@ import {
   getNthStatusSensitiveMediaButton,
   getActiveElementAriaLabel, settingsNavButton, getActiveElementHref, communityNavButton
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 import { homeTimeline } from '../fixtures'
 
 fixture`010-focus.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('modal preserves focus', async t => {
-  await loginAsFoobar(t)
-
   const idx = homeTimeline.findIndex(_ => _.content === "here's a video")
 
   await scrollToStatus(t, 1 + idx)
@@ -41,7 +39,6 @@ test('modal preserves focus', async t => {
 })
 
 test('timeline preserves focus', async t => {
-  await loginAsFoobar(t)
   // explicitly hover-focus-click
   await t.hover(getNthStatus(1))
   await focus(getNthStatusSelector(1))()
@@ -56,7 +53,6 @@ test('timeline preserves focus', async t => {
 })
 
 test('timeline link preserves focus', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getNthStatus(1).exists).ok({ timeout: 20000 })
     .click($(`${getNthStatusSelector(1)} .status-header a`))
@@ -74,7 +70,6 @@ test('timeline link preserves focus', async t => {
 })
 
 test('notification timeline preserves focus', async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/notifications')
   await scrollToStatus(t, 6)
@@ -90,7 +85,6 @@ test('notification timeline preserves focus', async t => {
 test('thread preserves focus', async t => {
   const timeout = 30000
 
-  await loginAsFoobar(t)
   await t
     .navigateTo('/accounts/3')
     .expect(getNthStatus(1).exists).ok({ timeout })
@@ -116,7 +110,6 @@ test('thread preserves focus', async t => {
 })
 
 test('reply preserves focus and moves focus to the text input', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getNthStatus(2).exists).ok({ timeout: 20000 })
     .click(getNthReplyButton(2))
@@ -128,7 +121,6 @@ test('focus main content element on index page load', async t => {
 })
 
 test('clicking sensitive button returns focus to sensitive button', async t => {
-  await loginAsFoobar(t)
   const sensitiveKittenIdx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
   await scrollToStatus(t, sensitiveKittenIdx + 1)
   await t
@@ -139,7 +131,6 @@ test('clicking sensitive button returns focus to sensitive button', async t => {
 })
 
 test('preserves focus two levels deep', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .click($('.status-author-name').withText(('admin')))
@@ -157,7 +148,6 @@ test('preserves focus two levels deep', async t => {
 })
 
 test('preserves focus on settings page', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click($('a[href="/settings/instances"]'))
@@ -184,7 +174,6 @@ test('preserves focus on settings page', async t => {
 })
 
 test('preserves focus on community page', async t => {
-  await loginAsFoobar(t)
   await t
     .click(communityNavButton)
     .expect(getUrl()).contains('/community')

--- a/tests/spec/011-reblog-favorites-count.js
+++ b/tests/spec/011-reblog-favorites-count.js
@@ -9,13 +9,12 @@ import {
   getUrl,
   reblogsCountElement
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`011-reblog-favorites-count.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('shows favorites', async t => {
-  await loginAsFoobar(t)
   await t
     .click(getNthStatus(1))
     .expect(getUrl()).contains('/statuses/')
@@ -32,7 +31,6 @@ test('shows favorites', async t => {
 })
 
 test('shows boosts', async t => {
-  await loginAsFoobar(t)
   await t
     .click(getNthStatus(1))
     .expect(getUrl()).contains('/statuses/')

--- a/tests/spec/012-compose.js
+++ b/tests/spec/012-compose.js
@@ -13,13 +13,12 @@ import {
   sleep,
   times
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`012-compose.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('shows compose limits', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .expect(composeLengthIndicator.innerText).eql('500')
@@ -46,7 +45,6 @@ test('shows compose limits', async t => {
 })
 
 test('shows compose limits for URLs/handles', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(composeLengthIndicator.innerText).eql('500')
     .expect(composeButton.hasAttribute('disabled')).notOk()
@@ -58,7 +56,6 @@ test('shows compose limits for URLs/handles', async t => {
 })
 
 test('shows compose limits for emoji', async t => {
-  await loginAsFoobar(t)
   await t
     .typeText(composeInput, 'hello world \ud83c\ude01 \ud83d\udc6a')
     .expect(composeLengthIndicator.innerText).eql('485')
@@ -66,7 +63,6 @@ test('shows compose limits for emoji', async t => {
 })
 
 test('shows compose limits for custom emoji', async t => {
-  await loginAsFoobar(t)
   await t
     .typeText(composeInput, 'hello world ')
     .click(emojiButton)
@@ -79,7 +75,6 @@ test('shows compose limits for custom emoji', async t => {
 })
 
 test('inserts custom emoji correctly', async t => {
-  await loginAsFoobar(t)
   await t
     .typeText(composeInput, 'hello world')
     .selectText(composeInput, 6, 6)
@@ -108,7 +103,6 @@ test('inserts custom emoji correctly', async t => {
 })
 
 test('inserts emoji without typing anything', async t => {
-  await loginAsFoobar(t)
   await sleep(1000)
   await t
     .click(emojiButton)
@@ -122,7 +116,6 @@ test('inserts emoji without typing anything', async t => {
 })
 
 test('inserts native emoji without typing anything', async t => {
-  await loginAsFoobar(t)
   await t
     .click(emojiButton)
   await sleep(1000)
@@ -145,7 +138,6 @@ test('inserts native emoji without typing anything', async t => {
 })
 
 test('cannot post an empty status', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getNthStatusContent(1).innerText).contains('pinned toot 1')
     .click(composeButton)

--- a/tests/spec/013-compose-media.js
+++ b/tests/spec/013-compose-media.js
@@ -11,13 +11,12 @@ import {
   sleep,
   uploadKittenImage
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`013-compose-media.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('inserts media', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(mediaButton.hasAttribute('disabled')).notOk()
   await (uploadKittenImage(1)())
@@ -45,7 +44,6 @@ test('inserts media', async t => {
 })
 
 test('removes media', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(mediaButton.exists).ok()
   await (uploadKittenImage(1)())
@@ -61,7 +59,6 @@ test('removes media', async t => {
 })
 
 test('does not add URLs as media is added/removed', async t => {
-  await loginAsFoobar(t)
   await t
     .typeText(composeInput, 'this is a toot')
     .expect(mediaButton.exists).ok()
@@ -78,7 +75,6 @@ test('does not add URLs as media is added/removed', async t => {
 })
 
 test('keeps media descriptions as media is removed', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(mediaButton.exists).ok()
   await (uploadKittenImage(1)())
@@ -97,7 +93,6 @@ test('keeps media descriptions as media is removed', async t => {
 })
 
 test('keeps media in local storage', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(mediaButton.exists).ok()
   await (uploadKittenImage(1)())
@@ -131,7 +126,6 @@ test('keeps media in local storage', async t => {
 })
 
 test('resets sensitive settings when deleting media', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(mediaButton.exists).ok()
   await (uploadKittenImage(1)())

--- a/tests/spec/014-compose-post-privacy.js
+++ b/tests/spec/014-compose-post-privacy.js
@@ -6,13 +6,12 @@ import {
   scrollToStatus,
   sleep
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`014-compose-post-privacy.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Changes post privacy', async t => {
-  await loginAsFoobar(t)
   await sleep(2000)
   await t
     .expect(postPrivacyButton.getAttribute('aria-label')).eql('Adjust privacy (currently Public)')
@@ -27,7 +26,6 @@ test('Changes post privacy', async t => {
 })
 
 test('can use privacy dialog within compose dialog', async t => {
-  await loginAsFoobar(t)
   await scrollToStatus(t, 16)
   await t.expect(composeButton.getAttribute('aria-label')).eql('Compose toot')
   await sleep(2000)

--- a/tests/spec/015-compose-content-warnings.js
+++ b/tests/spec/015-compose-content-warnings.js
@@ -2,13 +2,12 @@ import {
   composeContentWarning, composeInput, composeLengthIndicator, contentWarningButton, homeNavButton,
   notificationsNavButton
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`015-compose-content-warnings.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Changes content warnings', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(composeContentWarning.exists).notOk()
     .expect(contentWarningButton.getAttribute('aria-label')).eql('Add content warning')
@@ -38,7 +37,6 @@ test('Changes content warnings', async t => {
 })
 
 test('Considers content warnings for length limits', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(composeLengthIndicator.innerText).eql('500')
     .click(contentWarningButton)
@@ -55,7 +53,6 @@ test('Considers content warnings for length limits', async t => {
 })
 
 test('Content warning goes away if you hide it', async t => {
-  await loginAsFoobar(t)
   await t
     .click(contentWarningButton)
     .expect(composeContentWarning.value).eql('')

--- a/tests/spec/016-external-links.js
+++ b/tests/spec/016-external-links.js
@@ -1,9 +1,9 @@
 import { getNthStatus, getNthStatusSelector, getUrl } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`016-external-links.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 function getAnchor (nthStatus, nthAnchor) {
   return $(`${getNthStatusSelector(1 + nthStatus)} .status-content a`).nth(nthAnchor)
@@ -14,7 +14,6 @@ function getAnchorInProfile (n) {
 }
 
 test('converts external links in statuses', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .navigateTo('/accounts/4')
@@ -32,7 +31,6 @@ test('converts external links in statuses', async t => {
 })
 
 test('converts external links in profiles', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .navigateTo('/accounts/4')

--- a/tests/spec/017-compose-reply.js
+++ b/tests/spec/017-compose-reply.js
@@ -5,14 +5,13 @@ import {
   getNthReplyContentWarningInput, getNthReplyPostPrivacyButton,
   getNthStatus, getNthStatusRelativeDate, getUrl, homeNavButton, notificationsNavButton, scrollToStatus
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { homeTimeline } from '../fixtures'
 
 fixture`017-compose-reply.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('account handle populated correctly for replies', async t => {
-  await loginAsFoobar(t)
   await t
     .click(getNthReplyButton(1))
     .expect(getNthComposeReplyInput(1).value).eql('@quux ')
@@ -31,7 +30,6 @@ test('account handle populated correctly for replies', async t => {
 })
 
 test('replying to posts with mentions', async t => {
-  await loginAsFoobar(t)
   await t
     .click(getNthReplyButton(2))
     .expect(getNthComposeReplyInput(2).value).eql('@admin ')
@@ -41,7 +39,6 @@ test('replying to posts with mentions', async t => {
 })
 
 test('replies have same privacy as replied-to status by default', async t => {
-  await loginAsFoobar(t)
   const unlistedIdx = homeTimeline.findIndex(_ => _.content === 'notification of unlisted message')
   const privateIdx = homeTimeline.findIndex(_ => _.content === 'notification of followers-only message')
   const publicIdx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
@@ -73,7 +70,6 @@ test('replies have same privacy as replied-to status by default', async t => {
 })
 
 test('replies have same CW as replied-to status', async t => {
-  await loginAsFoobar(t)
   const kittenIdx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
   await t.hover(getNthStatus(1))
   await scrollToStatus(t, 1 + kittenIdx)
@@ -86,7 +82,6 @@ test('replies have same CW as replied-to status', async t => {
 })
 
 test('replies save deletions of CW', async t => {
-  await loginAsFoobar(t)
   const kittenIdx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
   await scrollToStatus(t, 1 + kittenIdx)
   await t.click(getNthReplyButton(1 + kittenIdx))
@@ -100,7 +95,6 @@ test('replies save deletions of CW', async t => {
 })
 
 test('replies save changes to CW', async t => {
-  await loginAsFoobar(t)
   const kittenIdx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
   await scrollToStatus(t, 1 + kittenIdx)
   await t.click(getNthReplyButton(1 + kittenIdx))
@@ -114,7 +108,6 @@ test('replies save changes to CW', async t => {
 })
 
 test('replies save changes to post privacy', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .hover(getNthStatus(2))
@@ -130,7 +123,6 @@ test('replies save changes to post privacy', async t => {
 })
 
 test('replies are the same whatever thread they are in', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .hover(getNthStatus(2))

--- a/tests/spec/018-compose-autosuggest.js
+++ b/tests/spec/018-compose-autosuggest.js
@@ -8,15 +8,14 @@ import {
   sleep
 } from '../utils'
 import { Selector as $ } from 'testcafe'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`018-compose-autosuggest.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 const timeout = 30000
 
 test('autosuggests user handles', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
   await sleep(1000)
@@ -39,7 +38,6 @@ test('autosuggests user handles', async t => {
 })
 
 test('autosuggests custom emoji', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, ':blob')
@@ -61,7 +59,6 @@ test('autosuggests custom emoji', async t => {
 })
 
 test('autosuggest custom emoji works with regular emoji - keyboard', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, '\ud83c\udf4d :blobno')
@@ -71,7 +68,6 @@ test('autosuggest custom emoji works with regular emoji - keyboard', async t => 
 })
 
 test('autosuggest custom emoji works with regular emoji - clicking', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, '\ud83c\udf4d :blobno')
@@ -81,7 +77,6 @@ test('autosuggest custom emoji works with regular emoji - clicking', async t => 
 })
 
 test('autosuggest handles works with regular emoji - keyboard', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, '\ud83c\udf4d @quu')
@@ -91,7 +86,6 @@ test('autosuggest handles works with regular emoji - keyboard', async t => {
 })
 
 test('autosuggest handles works with regular emoji - clicking', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, '\ud83c\udf4d @quu')
@@ -101,7 +95,6 @@ test('autosuggest handles works with regular emoji - clicking', async t => {
 })
 
 test('autosuggest can suggest native emoji', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, ':slight')
@@ -111,7 +104,6 @@ test('autosuggest can suggest native emoji', async t => {
 })
 
 test('autosuggest only shows for one input', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, '@quu')
@@ -124,7 +116,6 @@ test('autosuggest only shows for one input', async t => {
 })
 
 test('autosuggest only shows for one input part 2', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, '@adm')
@@ -141,7 +132,6 @@ test('autosuggest only shows for one input part 2', async t => {
 })
 
 test('autocomplete disappears on blur', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(composeInput)
     .typeText(composeInput, '@adm')

--- a/tests/spec/019-mention.js
+++ b/tests/spec/019-mention.js
@@ -2,13 +2,12 @@ import {
   accountProfileMoreOptionsButton, closeDialogButton, composeModalInput,
   getNthDialogOptionsOption, modalDialog
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`019-mention.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('can mention from account profile', async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/accounts/5')
     .click(accountProfileMoreOptionsButton)

--- a/tests/spec/020-themes.js
+++ b/tests/spec/020-themes.js
@@ -2,14 +2,13 @@ import {
   getCurrentTheme,
   settingsNavButton
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`020-themes.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('can set a theme', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click($('a[href="/settings/instances"]'))

--- a/tests/spec/021-followers-follows.js
+++ b/tests/spec/021-followers-follows.js
@@ -3,14 +3,13 @@ import {
   followsButton, getNthSearchResult,
   getNthStatusSelector, getUrl, goBack
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`021-followers-follows.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('shows followers and follows', async t => {
-  await loginAsFoobar(t)
   await t
     .click($(`${getNthStatusSelector(1)} .status-author-name`))
     .expect(getUrl()).match(/\/accounts\/3$/)

--- a/tests/spec/022-status-aria-label.js
+++ b/tests/spec/022-status-aria-label.js
@@ -1,4 +1,4 @@
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import {
   generalSettingsButton,
   getNthShowOrHideButton,
@@ -12,10 +12,9 @@ import { Selector as $ } from 'testcafe'
 import { homeTimeline } from '../fixtures'
 
 fixture`022-status-aria-label.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('basic aria-labels for statuses', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .expect(getNthStatus(1).getAttribute('aria-label')).match(
@@ -31,7 +30,6 @@ test('basic aria-labels for statuses', async t => {
 })
 
 test('aria-labels for CWed statuses', async t => {
-  await loginAsFoobar(t)
   const kittenIdx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
   await scrollToStatus(t, 1 + kittenIdx)
   await t
@@ -50,7 +48,6 @@ test('aria-labels for CWed statuses', async t => {
 })
 
 test('aria-labels for notifications', async t => {
-  await loginAsFoobar(t)
   await t
     .click(notificationsNavButton)
     .hover(getNthStatus(1))
@@ -80,7 +77,6 @@ test('aria-labels for notifications', async t => {
 })
 
 test('can shorten aria-labels', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click(generalSettingsButton)

--- a/tests/spec/023-mark-media-as-sensitive.js
+++ b/tests/spec/023-mark-media-as-sensitive.js
@@ -1,4 +1,4 @@
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import {
   generalSettingsButton,
   getNthStatus, getNthStatusMediaImg, getNthStatusSensitiveMediaButton, homeNavButton, markMediaSensitiveInput,
@@ -8,7 +8,7 @@ import {
 import { homeTimeline } from '../fixtures'
 
 fixture`023-mark-media-as-sensitive.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 async function checkSensitivityForStatus (t, idx, sensitive) {
   if (sensitive) {
@@ -67,12 +67,10 @@ async function doNeverMarkMediaAsSensitive (t, checked) {
 }
 
 test('default sensitive settings', async t => {
-  await loginAsFoobar(t)
   await checkSensitivity(t, sensitive => sensitive)
 })
 
 test('always mark media sensitive', async t => {
-  await loginAsFoobar(t)
   await doMarkMediaAsSensitive(t, true)
   await checkSensitivity(t, () => true)
   // cleanup
@@ -80,7 +78,6 @@ test('always mark media sensitive', async t => {
 })
 
 test('never mark media sensitive', async t => {
-  await loginAsFoobar(t)
   await doNeverMarkMediaAsSensitive(t, true)
   await checkSensitivity(t, () => false)
   // cleanup
@@ -88,7 +85,6 @@ test('never mark media sensitive', async t => {
 })
 
 test('settings are mutually exclusive', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click(generalSettingsButton)

--- a/tests/spec/024-shortcuts-navigation.js
+++ b/tests/spec/024-shortcuts-navigation.js
@@ -6,14 +6,13 @@ import {
   modalDialogContents,
   notificationsNavButton, scrollToStatus, settingsNavButton, sleep
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`024-shortcuts-navigation.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Shortcut g+l goes to the local timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('g l')
@@ -21,7 +20,6 @@ test('Shortcut g+l goes to the local timeline', async t => {
 })
 
 test('Shortcut g+t goes to the federated timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('g t')
@@ -29,7 +27,6 @@ test('Shortcut g+t goes to the federated timeline', async t => {
 })
 
 test('Shortcut g+h goes back to the home timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .click(notificationsNavButton)
@@ -37,7 +34,6 @@ test('Shortcut g+h goes back to the home timeline', async t => {
 })
 
 test('Shortcut g+f goes to the favorites', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('g f')
@@ -45,7 +41,6 @@ test('Shortcut g+f goes to the favorites', async t => {
 })
 
 test('Shortcut g+c goes to the community page', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('g c')
@@ -53,7 +48,6 @@ test('Shortcut g+c goes to the community page', async t => {
 })
 
 test('Shortcut s goes to the search page', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('s')
@@ -61,7 +55,6 @@ test('Shortcut s goes to the search page', async t => {
 })
 
 test('Shortcut / goes to the search page', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('/')
@@ -69,7 +62,6 @@ test('Shortcut / goes to the search page', async t => {
 })
 
 test('Shortcut backspace goes back from favorites', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('g t')
@@ -81,7 +73,6 @@ test('Shortcut backspace goes back from favorites', async t => {
 })
 
 test('Shortcut h toggles shortcut help dialog', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('h')
@@ -92,7 +83,6 @@ test('Shortcut h toggles shortcut help dialog', async t => {
 })
 
 test('Global shortcut has no effects while in modal dialog', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('g f')
@@ -108,7 +98,6 @@ test('Global shortcut has no effects while in modal dialog', async t => {
 })
 
 test('Shortcut 1 goes to the home timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('1')
@@ -116,7 +105,6 @@ test('Shortcut 1 goes to the home timeline', async t => {
 })
 
 test('Shortcut 6 goes to the settings', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .pressKey('6')
@@ -124,7 +112,6 @@ test('Shortcut 6 goes to the settings', async t => {
 })
 
 test('Shortcut . scrolls to top and focuses', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .hover(getNthStatus(1))
@@ -135,8 +122,6 @@ test('Shortcut . scrolls to top and focuses', async t => {
 })
 
 test('Shortcut left and right changes columns', async t => {
-  await loginAsFoobar(t)
-
   const steps = [
     ['right', 'notifications'],
     ['right', 'local'],
@@ -162,7 +147,6 @@ test('Shortcut left and right changes columns', async t => {
 })
 
 test('Shortcut left and right can change focus', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click($('a[href="/settings/hotkeys"]'))
@@ -180,7 +164,6 @@ test('Shortcut left and right can change focus', async t => {
 })
 
 test('Shortcuts can be disabled', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click($('a[href="/settings/hotkeys"]'))
@@ -198,7 +181,6 @@ test('Shortcuts can be disabled', async t => {
 })
 
 test('Shortcut left/right works on settings page', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click($('a[href="/settings/hotkeys"]'))

--- a/tests/spec/025-shortcuts-status.js
+++ b/tests/spec/025-shortcuts-status.js
@@ -12,12 +12,12 @@ import {
   isNthStatusActive, getActiveElementRectTop, scrollToTop, isActiveStatusPinned, getFirstModalMedia
 } from '../utils'
 import { homeTimeline } from '../fixtures'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 import { Selector as $ } from 'testcafe'
 
 fixture`025-shortcuts-status.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 async function activateStatus (t, idx) {
   const timeout = 20000
@@ -29,7 +29,6 @@ async function activateStatus (t, idx) {
 }
 
 test('Shortcut j/k change the active status', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })
@@ -54,7 +53,6 @@ test('Shortcut j/k change the active status', async t => {
 })
 
 test('Shortcut j goes to the first visible status', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
   await scrollToStatus(t, 11)
@@ -65,7 +63,6 @@ test('Shortcut j goes to the first visible status', async t => {
 })
 
 test('Shortcut o opens active status, backspace goes back', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(3).exists).ok({ timeout: 30000 })
@@ -81,7 +78,6 @@ test('Shortcut o opens active status, backspace goes back', async t => {
 
 test('Shortcut x shows/hides spoilers', async t => {
   const idx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
   await activateStatus(t, idx)
@@ -97,7 +93,6 @@ test('Shortcut x shows/hides spoilers', async t => {
 
 test('Shortcut y shows/hides sensitive image, i opens', async t => {
   const idx = homeTimeline.findIndex(_ => _.content === "here's a secret kitten")
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
   await activateStatus(t, idx)
@@ -115,7 +110,6 @@ test('Shortcut y shows/hides sensitive image, i opens', async t => {
 
 test('Shortcut f toggles favorite status', async t => {
   const idx = homeTimeline.findIndex(_ => _.content === 'this is unlisted')
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1 + idx).exists).ok({ timeout: 30000 })
@@ -130,7 +124,6 @@ test('Shortcut f toggles favorite status', async t => {
 
 test('Shortcut p toggles profile', async t => {
   const idx = homeTimeline.findIndex(_ => _.content === 'pinned toot 1')
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1 + idx).exists).ok({ timeout: 30000 })
@@ -142,7 +135,6 @@ test('Shortcut p toggles profile', async t => {
 
 test('Shortcut m toggles mention', async t => {
   const idx = homeTimeline.findIndex(_ => _.content === 'pinned toot 1')
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .expect(getNthStatus(1 + idx).exists).ok({ timeout: 30000 })
@@ -155,7 +147,6 @@ test('Shortcut m toggles mention', async t => {
 })
 
 test('Shortcut j/k change the active status on a thread', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('a').withText('quux'))
   await scrollToStatus(t, 3)
@@ -187,7 +178,6 @@ test('Shortcut j/k change the active status on a thread', async t => {
 })
 
 test('Shortcut j/k change the active status on pinned statuses', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('a').withText('quux'))
     .expect(getUrl()).contains('/accounts')

--- a/tests/spec/026-shortcuts-notification.js
+++ b/tests/spec/026-shortcuts-notification.js
@@ -6,14 +6,13 @@ import {
   getUrl, modalDialog, notificationsNavButton,
   isNthStatusActive, goBack
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`026-shortcuts-notification.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Shortcut f toggles favorite status in notification', async t => {
   const idx = 0
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .click(notificationsNavButton)
@@ -30,7 +29,6 @@ test('Shortcut f toggles favorite status in notification', async t => {
 
 test('Shortcut p toggles profile in a follow notification', async t => {
   const idx = 5 // "@quux followed you"
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .click(notificationsNavButton)
@@ -47,7 +45,6 @@ test('Shortcut p toggles profile in a follow notification', async t => {
 
 test('Shortcut m toggles mention in a follow notification', async t => {
   const idx = 5 // "@quux followed you"
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .click(notificationsNavButton)
@@ -63,7 +60,6 @@ test('Shortcut m toggles mention in a follow notification', async t => {
 
 test('Shortcut p refers to booster in a boost notification', async t => {
   const idx = 1 // "@admin boosted your status"
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .click(notificationsNavButton)
@@ -77,7 +73,6 @@ test('Shortcut p refers to booster in a boost notification', async t => {
 
 test('Shortcut m refers to favoriter in a favorite notification', async t => {
   const idx = 0 // "@admin favorited your status"
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .click(notificationsNavButton)

--- a/tests/spec/027-web-share-and-web-shortcuts.js
+++ b/tests/spec/027-web-share-and-web-shortcuts.js
@@ -2,14 +2,13 @@ import {
   composeModalInput, getComposeModalNthMediaListItem,
   getUrl, modalDialogContents, simulateWebShare
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { ONE_TRANSPARENT_PIXEL } from '../../src/routes/_static/media'
 
 fixture`027-web-share-and-web-shortcuts.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Can take a shortcut directly to a compose dialog', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .navigateTo('http://localhost:4002/?compose=true')
@@ -19,7 +18,6 @@ test('Can take a shortcut directly to a compose dialog', async t => {
 })
 
 test('Can share title/text using Web Share', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
   await (simulateWebShare({ title: 'my title', url: undefined, text: 'my text' })())
@@ -31,7 +29,6 @@ test('Can share title/text using Web Share', async t => {
 })
 
 test('Can share a file using Web Share', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
   await (simulateWebShare({ title: undefined, url: undefined, text: undefined, file: ONE_TRANSPARENT_PIXEL })())

--- a/tests/spec/028-report-ui.js
+++ b/tests/spec/028-report-ui.js
@@ -4,14 +4,13 @@ import {
   getNthStatusOptionsButton,
   modalDialog
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`028-report-ui.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Can open a report UI from a status', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .click(getNthStatusOptionsButton(1))
@@ -25,7 +24,6 @@ test('Can open a report UI from a status', async t => {
 })
 
 test('Can open a report UI from an account', async t => {
-  await loginAsFoobar(t)
   await t
     .navigateTo('/accounts/3')
     .click(accountProfileMoreOptionsButton)

--- a/tests/spec/029-back-button-modal.js
+++ b/tests/spec/029-back-button-modal.js
@@ -19,15 +19,14 @@ import {
   sleep,
   visibleModalDialog
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 import { homeTimeline } from '../fixtures'
 
 fixture`029-back-button-modal.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Back button dismisses the modal', async t => {
-  await loginAsFoobar(t)
   const idx = homeTimeline.findIndex(_ => (_.content || '').includes('2 kitten photos'))
   await scrollToStatus(t, idx + 1)
   await t
@@ -43,7 +42,6 @@ test('Back button dismisses the modal', async t => {
 })
 
 test('Back button dismisses a nested modal', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .hover(getNthStatus(1))
@@ -60,7 +58,6 @@ test('Back button dismisses a nested modal', async t => {
 })
 
 test('Forward and back buttons', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getUrl()).eql('http://localhost:4002/')
     .hover(getNthStatus(1))
@@ -78,7 +75,6 @@ test('Forward and back buttons', async t => {
 })
 
 test('Closing dialog pops history state', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .click(getNthStatus(1))
@@ -95,7 +91,6 @@ test('Closing dialog pops history state', async t => {
 })
 
 test('Pressing backspace pops history state', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .click(getNthStatus(1))
@@ -114,7 +109,6 @@ test('Pressing backspace pops history state', async t => {
 })
 
 test('Pressing Esc pops history state', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .click(getNthStatus(1))
@@ -133,7 +127,6 @@ test('Pressing Esc pops history state', async t => {
 })
 
 test('Clicking outside dialog pops history state', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .click(getNthStatus(1))
@@ -153,7 +146,6 @@ test('Clicking outside dialog pops history state', async t => {
 })
 
 test('Closing nested modal pops history state', async t => {
-  await loginAsFoobar(t)
   await t
     .hover(getNthStatus(1))
     .click(getNthStatus(1))
@@ -175,7 +167,6 @@ test('Closing nested modal pops history state', async t => {
 })
 
 test('History works correctly for nested modal', async t => {
-  await loginAsFoobar(t)
   await t
     .click(notificationsNavButton)
     .click(homeNavButton)
@@ -203,7 +194,6 @@ test('History works correctly for nested modal', async t => {
 })
 
 test('History works correctly for nested modal 2', async t => {
-  await loginAsFoobar(t)
   await t
     .click(notificationsNavButton)
     .click(homeNavButton)
@@ -232,7 +222,6 @@ test('History works correctly for nested modal 2', async t => {
 })
 
 test('History works correctly for nested modal 3', async t => {
-  await loginAsFoobar(t)
   await t
     .click(notificationsNavButton)
     .click(homeNavButton)
@@ -261,7 +250,6 @@ test('History works correctly for nested modal 3', async t => {
 })
 
 test('History and scroll position work correctly for link in compose dialog', async t => {
-  await loginAsFoobar(t)
   await scrollToStatus(t, 10)
   await t
     .expect(getScrollTop()).notEql(0)

--- a/tests/spec/030-shortcuts-modal.js
+++ b/tests/spec/030-shortcuts-modal.js
@@ -3,15 +3,14 @@ import {
   getNthStatusMediaButton, getNthStatusOptionsButton,
   modalDialog, scrollToStatus, sleep
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 import { homeTimeline } from '../fixtures'
 
 fixture`030-shortcuts-modal.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Backspace dismisses modal', async t => {
-  await loginAsFoobar(t)
   await t
     .click(getNthStatusOptionsButton(1))
     .expect(modalDialog.hasAttribute('aria-hidden')).notOk()
@@ -22,7 +21,6 @@ test('Backspace dismisses modal', async t => {
 })
 
 test('Backspace dismisses media modal', async t => {
-  await loginAsFoobar(t)
   const idx = homeTimeline.findIndex(_ => (_.content || '').includes('2 kitten photos'))
   await scrollToStatus(t, idx + 1)
   await t
@@ -35,7 +33,6 @@ test('Backspace dismisses media modal', async t => {
 })
 
 test('Left/right changes active media in modal', async t => {
-  await loginAsFoobar(t)
   const idx = homeTimeline.findIndex(_ => (_.content || '').includes('2 kitten photos'))
   await scrollToStatus(t, idx + 1)
   await t

--- a/tests/spec/031-account-filters.js
+++ b/tests/spec/031-account-filters.js
@@ -5,13 +5,12 @@ import {
   getNthPinnedStatus, getNthStatus,
   getUrl
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`031-account-filters.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Basic account filters test', async t => {
-  await loginAsFoobar(t)
   await t
     .click(avatarInComposeBox)
     .expect(getUrl()).contains('/accounts/2')

--- a/tests/spec/032-mute-dialog.js
+++ b/tests/spec/032-mute-dialog.js
@@ -3,13 +3,12 @@ import {
   getNthStatus, getNthStatusOptionsButton,
   modalDialog, sleep, visibleModalDialog
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 
 fixture`032-mute-dialog.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Can open the mute dialog twice', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getNthStatus(1).exists).ok({ timeout: 30000 })
     .hover(getNthStatus(1))

--- a/tests/spec/033-notification-mentions.js
+++ b/tests/spec/033-notification-mentions.js
@@ -2,14 +2,13 @@ import {
   getUrl, notificationsTabAll, notificationsTabMentions,
   notificationsNavButton, validateTimeline
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { notificationsMentions, notifications } from '../fixtures'
 
 fixture`033-notification-mentions.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Shows notification mentions', async t => {
-  await loginAsFoobar(t)
   await t
     .click(notificationsNavButton)
     .expect(getUrl()).match(/\/notifications$/)

--- a/tests/spec/034-home-timeline-filters.js
+++ b/tests/spec/034-home-timeline-filters.js
@@ -1,15 +1,14 @@
 import {
   validateTimeline, settingsNavButton, instanceSettingHomeReblogs, homeNavButton
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { homeTimeline } from '../fixtures'
 import { Selector as $ } from 'testcafe'
 
 fixture`034-home-timeline-filters.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Filters reblogs from home timeline', async t => {
-  await loginAsFoobar(t)
   await t
     .click(settingsNavButton)
     .click($('a').withText('Instances'))

--- a/tests/spec/035-notification-timeline-filters.js
+++ b/tests/spec/035-notification-timeline-filters.js
@@ -7,12 +7,12 @@ import {
   instanceSettingNotificationFollows,
   instanceSettingNotificationMentions
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { notifications } from '../fixtures'
 import { Selector as $ } from 'testcafe'
 
 fixture`035-notification-timeline-filters.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 function setSettingAndGoToNotifications (t, setting) {
   return t.click(settingsNavButton)
@@ -24,25 +24,21 @@ function setSettingAndGoToNotifications (t, setting) {
 }
 
 test('Filters reblogs from notification timeline', async t => {
-  await loginAsFoobar(t)
   await setSettingAndGoToNotifications(t, instanceSettingNotificationReblogs)
   await validateTimeline(t, notifications.filter(_ => !_.rebloggedBy))
 })
 
 test('Filters favs from notification timeline', async t => {
-  await loginAsFoobar(t)
   await setSettingAndGoToNotifications(t, instanceSettingNotificationFavs)
   await validateTimeline(t, notifications.filter(_ => !_.favoritedBy))
 })
 
 test('Filters follows from notification timeline', async t => {
-  await loginAsFoobar(t)
   await setSettingAndGoToNotifications(t, instanceSettingNotificationFollows)
   await validateTimeline(t, notifications.filter(_ => !_.followedBy))
 })
 
 test('Filters mentions from notification timeline', async t => {
-  await loginAsFoobar(t)
   await setSettingAndGoToNotifications(t, instanceSettingNotificationMentions)
   await validateTimeline(t, notifications.filter(_ => !_.content))
 })

--- a/tests/spec/036-disable-infinite-load.js
+++ b/tests/spec/036-disable-infinite-load.js
@@ -5,15 +5,14 @@ import {
   scrollToStatus,
   loadMoreButton, getFirstVisibleStatus, scrollFromStatusToStatus, sleep, getActiveElementAriaPosInSet
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 import { homeTimeline } from '../fixtures'
 
 fixture`036-disable-infinite-load.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Can disable loading items at bottom of timeline', async t => {
-  await loginAsFoobar(t)
   await t.click(settingsNavButton)
     .click($('a').withText('General'))
     .click(disableInfiniteScroll)

--- a/tests/spec/037-pin-timelines.js
+++ b/tests/spec/037-pin-timelines.js
@@ -1,15 +1,13 @@
 import {
   communityNavButton, getUrl, goBack, reload
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`037-pin-timelines.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Can pin a timeline', async t => {
-  await loginAsFoobar(t)
-
   const pinLocal = $('button[aria-label="Pin Local timeline"]')
   const pinFederated = $('button[aria-label="Pin Federated timeline"]')
   const pinnedNav = $('.main-nav-li:nth-child(3)')

--- a/tests/spec/038-memory-leaks.js
+++ b/tests/spec/038-memory-leaks.js
@@ -12,16 +12,15 @@ import {
   scrollToTop,
   settingsNavButton, sleep, getNumStoreListeners
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { installDomListenerListener, getNumDomListeners } from '../spyDomListeners'
 import { homeTimeline } from '../fixtures'
 import { Selector as $ } from 'testcafe'
 
 fixture`038-memory-leaks.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 async function runMemoryLeakTest (t, firstStep, secondStep) {
-  await loginAsFoobar(t)
   await installDomListenerListener()
   await firstStep()
   await sleep(1000)

--- a/tests/spec/039-empty-list.js
+++ b/tests/spec/039-empty-list.js
@@ -2,14 +2,13 @@ import {
   communityNavButton,
   getUrl, timeline
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`039-empty-list.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Can show an empty list of bookmarks', async t => {
-  await loginAsFoobar(t)
   await t
     .click(communityNavButton)
     .click($('a').withText('Bookmarks'))
@@ -18,7 +17,6 @@ test('Can show an empty list of bookmarks', async t => {
 })
 
 test('Can show an empty list of media', async t => {
-  await loginAsFoobar(t)
   await t
     .click($('a').withText('quux'))
     .expect(getUrl()).contains('accounts/3')

--- a/tests/spec/041-wellness.js
+++ b/tests/spec/041-wellness.js
@@ -5,14 +5,13 @@ import {
   getUrl,
   disableRelativeTimestamps, getNthStatus, getNthStatusRelativeDate
 } from '../utils'
-import { loginAsFoobar } from '../roles'
+import { foobarURL } from '../roles'
 import { Selector as $ } from 'testcafe'
 
 fixture`041-wellness.js`
-  .page`http://localhost:4002`
+  .page`${foobarURL}`
 
 test('Can disable relative time stamps', async t => {
-  await loginAsFoobar(t)
   await t
     .expect(getFirstVisibleStatus().exists).ok()
     .expect(getNthStatusRelativeDate(1).innerText).match(/\bago\b/i)


### PR DESCRIPTION
There's no point in navigating to the non-logged-in homepage if we're just going to log in afterwards.