### PR TITLE
Show image description if present

### DIFF
--- a/src/intl/en-US.js
+++ b/src/intl/en-US.js
@@ -255,6 +255,8 @@ export default {
   showNextMedia: 'Show next media',
   enterPinchZoom: 'Pinch-zoom mode',
   exitPinchZoom: 'Exit pinch-zoom mode',
+  showFullImageDescription: 'Show full image description',
+  hideFullImageDescription: 'Hide full image description',
   showMedia: `Show {index, select,
     1 {first}
     2 {second}

--- a/src/routes/_components/dialog/components/MediaDialog.html
+++ b/src/routes/_components/dialog/components/MediaDialog.html
@@ -25,8 +25,24 @@
         </li>
       {/each}
     </ul>
+    {#if hasDescription }
+    <div class="media-description-outside {showFullImageDescription ? 'expanded' : ''}">
+      {mediaItem.description}
+    </div>
+    {/if}
     <div class="media-controls-outside" on:click="onMediaControlsClick(event)">
-      {#if canPinchZoom}
+      {#if hasDescription }
+        <IconButton
+          className="media-control-button"
+          svgClassName="media-control-button-svg"
+          pressable={hasDescription}
+          pressed={showFullImageDescription}
+          pressedLabel="{intl.hideFullImageDescription}"
+          href="#fa-info-circle"
+          label="{intl.showFullImageDescription}"
+          on:click="toggleFullImageDescription()"
+        />
+      {:elseif canPinchZoom }
         <IconButton
           className="media-control-button media-control-button-dummy-spacer"
           svgClassName="media-control-button-svg"
@@ -77,16 +93,25 @@
             </li>
         </ul>
       {/if}
-      {#if canPinchZoom}
+      {#if canPinchZoom }
         <IconButton
           className="media-control-button"
           svgClassName="media-control-button-svg"
-          pressable={true}
+          pressable={canPinchZoom}
           pressed={pinchZoomMode}
           label="{intl.enterPinchZoom}"
           pressedLabel="{intl.exitPinchZoom}"
           href="#fa-search"
           on:click="togglePinchZoomMode()"
+          ariaHidden={!canPinchZoom}
+        />
+      {:elseif hasDescription }
+        <IconButton
+          className="media-control-button media-control-button-dummy-spacer"
+          svgClassName="media-control-button-svg"
+          href="#fa-search"
+          label=""
+          ariaHidden={true}
         />
       {/if}
     </div>
@@ -140,6 +165,20 @@
     height: calc(100% - 20px); /* 15px padding top + 5px padding bottom */
     width: calc(100% - 10px); /* 5px padding left + 5px padding right */
     padding: 15px 5px 5px 5px;
+  }
+
+  .media-description-outside {
+    margin: 5px 15px;
+    max-height: 1.5em;
+    text-align: center;
+    color: white;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .media-description-outside.expanded {
+    max-height: none;
+    white-space: normal;
   }
 
   .media-controls-outside {
@@ -263,12 +302,14 @@
     },
     store: () => store,
     data: () => ({
-      pinchZoomMode: false
+      pinchZoomMode: false,
+      showFullImageDescription: false
     }),
     computed: {
       length: ({ mediaItems }) => mediaItems.length,
       dots: ({ length }) => times(length, i => ({ i })),
       canPinchZoom: ({ mediaItems }) => !mediaItems.some(media => ['video', 'audio'].includes(media.type)),
+      hasDescription: ({ mediaItem }) => mediaItem.description,
       mediaItem: ({ mediaItems, scrolledItem }) => mediaItems[scrolledItem],
       nativeWidth: ({ mediaItem }) => get(mediaItem, ['meta', 'original', 'width'], 300), // TODO: Pleroma placeholder
       nativeHeight: ({ mediaItem }) => get(mediaItem, ['meta', 'original', 'height'], 200) // TODO: Pleroma placeholder
@@ -354,6 +395,9 @@
       },
       togglePinchZoomMode () {
         this.set({ pinchZoomMode: !this.get().pinchZoomMode })
+      },
+      toggleFullImageDescription () {
+        this.set({ showFullImageDescription: !this.get().showFullImageDescription })
       },
       onImageClick (e) {
         const { nativeWidth, nativeHeight, pinchZoomMode } = this.get()


### PR DESCRIPTION
This is somewhat a proof-of-concept, it's a pretty basic implementation but it does the job!

I'm not actually sure it's worth using the lefthand button slot, it may make more sense to just have tapping on the description expand it instead - we could add something to indicate it was tappable? I'm not sure what that would be (Tusky has a little line in the top center and an outline indicating a "drawer" of sorts, for instance)

This also shows the first line of the image description by default, which takes up a little more vertical space, but I think it's worthwhile - making image descriptions more visible in general is a net good, I think. The button showing up also would indicate this, but for short descriptions the user wouldn't have to do anything.

I also considered making a three-state button, where it would start as hidden, and tapping would toggle through hidden->first line->full, but that seems not really an improvement over just hidden->full.

I made the max height of the expanded box shove the image out of the way and fill up to half the screen, and scroll after that. Another option would be to have it expand into an overlay over the image and take up as much height as it needs - if someone is reading the description, they're generally fine not looking at the image for a bit - but that was harder to implement, so I went with the easy way for the proof-of-concept.