### PR TITLE
fix(ios): change status-bar-style to default

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -16,7 +16,7 @@
   <meta name="mobile-web-app-capable" content="yes" >
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="{intl.appName}" >
-  <meta name="apple-mobile-web-app-status-bar-style" content="white" >
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" >
 
   <!-- inline CSS -->
 


### PR DESCRIPTION
Fixes #2104

I haven't actually tested this, but `white` isn't even documented on Apple's documentation, so I'm guessing at some point it worked but doesn't work anymore in recent iOS versions. I have no idea. https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html