### PR TITLE
fix: use /api/v2/media

### DIFF
--- a/src/routes/_api/media.js
+++ b/src/routes/_api/media.js
@@ -20,7 +20,7 @@ export async function uploadMedia (instanceName, accessToken, file, description)
   try {
     return (await doUploadMedia('v2', instanceName, accessToken, file, description))
   } catch (err) {
-    if (err && err.status === 404) { // fall back to old search API
+    if (err && err.status === 404) { // fall back to old v1 API
       return doUploadMedia('v1', instanceName, accessToken, file, description)
     } else {
       throw err
@@ -32,7 +32,7 @@ export async function putMediaMetadata (instanceName, accessToken, mediaId, desc
   try {
     return (await doPutMediaMetadata('v2', instanceName, accessToken, mediaId, description, focus))
   } catch (err) {
-    if (err && err.status === 404) { // fall back to old search API
+    if (err && err.status === 404) { // fall back to old v1 API
       return doPutMediaMetadata('v1', instanceName, accessToken, mediaId, description, focus)
     } else {
       throw err

--- a/src/routes/_api/media.js
+++ b/src/routes/_api/media.js
@@ -1,17 +1,41 @@
 import { auth, basename } from './utils.js'
 import { post, put, MEDIA_WRITE_TIMEOUT, WRITE_TIMEOUT } from '../_utils/ajax.js'
 
-export async function uploadMedia (instanceName, accessToken, file, description) {
+async function doUploadMedia (version, instanceName, accessToken, file, description) {
   const formData = new FormData()
   formData.append('file', file)
   if (description) {
     formData.append('description', description)
   }
-  const url = `${basename(instanceName)}/api/v1/media`
+  const url = `${basename(instanceName)}/api/${version}/media`
   return post(url, formData, auth(accessToken), { timeout: MEDIA_WRITE_TIMEOUT })
 }
 
-export async function putMediaMetadata (instanceName, accessToken, mediaId, description, focus) {
-  const url = `${basename(instanceName)}/api/v1/media/${mediaId}`
+async function doPutMediaMetadata (version, instanceName, accessToken, mediaId, description, focus) {
+  const url = `${basename(instanceName)}/api/${version}/media/${mediaId}`
   return put(url, { description, focus: (focus && focus.join(',')) }, auth(accessToken), { timeout: WRITE_TIMEOUT })
+}
+
+export async function uploadMedia (instanceName, accessToken, file, description) {
+  try {
+    return (await doUploadMedia('v2', instanceName, accessToken, file, description))
+  } catch (err) {
+    if (err && err.status === 404) { // fall back to old search API
+      return doUploadMedia('v1', instanceName, accessToken, file, description)
+    } else {
+      throw err
+    }
+  }
+}
+
+export async function putMediaMetadata (instanceName, accessToken, mediaId, description, focus) {
+  try {
+    return (await doPutMediaMetadata('v2', instanceName, accessToken, mediaId, description, focus))
+  } catch (err) {
+    if (err && err.status === 404) { // fall back to old search API
+      return doPutMediaMetadata('v1', instanceName, accessToken, mediaId, description, focus)
+    } else {
+      throw err
+    }
+  }
 }


### PR DESCRIPTION
Fixes #2078. Falls back to v1 if v2 is unavailable.

There doesn't seem to be any breakage. I don't think we were using the `url` from the v1 API.