### PR TITLE
fix: make ios status bar default color again

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -16,7 +16,7 @@
   <meta name="mobile-web-app-capable" content="yes" >
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="{intl.appName}">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <!-- splashscreen for iOS -->
   <link href="/iphone5_splash.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
   <link href="/iphone6_splash.png" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />


### PR DESCRIPTION
I don't think the change made to the status bar in #2108 is quite right. The status bar now has a translucent background when I test in iOS 15 on an iPod Touch. The timeline content bleeds through, which looks really weird.

I think this should be switched back until we figure out what magic string iOS wants.
![IMG_20220410_105546](https://user-images.githubusercontent.com/283842/162633284-d65a432b-fb38-485c-b131-d477a1d899bd.jpg)
