### PR TITLE
Dockerfile: Use explicit node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Using Alpine to keep the images smaller
 # Change to using the official NodeJS Alpine container
-FROM node:alpine
+FROM node:16-alpine
 
 # Pushing all files into image
 WORKDIR /app


### PR DESCRIPTION
The `node:alpine` Docker image appears to have recently been updated to point to Node 17, breaking new builds of Pinafore. This commit explicitly specifies Node 16 until the underlying reason for the build failure on 17+ can be fixed.

I've verified this builds successfully on my own servers.