### PR TITLE
fix: fix votes count on Misskey polls

### DIFF
--- a/src/routes/_components/status/StatusPoll.html
+++ b/src/routes/_components/status/StatusPoll.html
@@ -292,13 +292,16 @@
     computed: {
       pollId: ({ originalStatus }) => originalStatus.poll.id,
       poll: ({ originalStatus, $polls, pollId }) => $polls[pollId] || originalStatus.poll,
-      options: ({ poll, originalStatusEmojis, $autoplayGifs, votersCount }) => (
+      options: ({ poll, originalStatusEmojis, $autoplayGifs, votersOrVotesCount }) => (
         poll.options.map(({ title, votes_count: optionsVotesCount }) => ({
           title: emojifyText(escapeHtml(title), originalStatusEmojis, $autoplayGifs),
-          share: votersCount ? Math.round(optionsVotesCount / votersCount * 100) : 0
+          share: votersOrVotesCount ? Math.round(optionsVotesCount / votersOrVotesCount * 100) : 0
         }))
       ),
       votersCount: ({ poll }) => poll.voters_count,
+      votesCount: ({ poll }) => poll.votes_count,
+      // Misskey reports the "voters_count" as null, so just use the "votes_count"
+      votersOrVotesCount: ({ votersCount, votesCount }) => typeof votersCount === 'number' ? votersCount : votesCount,
       voted: ({ poll }) => poll.voted,
       multiple: ({ poll }) => poll.multiple,
       expired: ({ poll }) => poll.expired,
@@ -314,8 +317,8 @@
         !isStatusInOwnThread && $isMobileSize && !expired
       ),
       formDisabled: ({ choices }) => !choices.length,
-      votesText: ({ votersCount }) => (
-        formatIntl('intl.voteCount', { count: votersCount })
+      votesText: ({ votersOrVotesCount }) => (
+        formatIntl('intl.voteCount', { count: votersOrVotesCount })
       ),
       computedClass: ({ isStatusInNotification, isStatusInOwnThread, loading, shown }) => (
         classname(


### PR DESCRIPTION
Misskey reports `voters_cont` as null, so just use the `votes_count` in that case.

The percentages won't be as a percent of the number of voters – instead it'll be as a percent of the number of individual votes. But this is fine. Maybe Misskey only does this for non-multiple-choice polls.

The poll looks like this in Misskey:

```js
    "poll": {
        "id": "96327",
        "expires_at": "2022-05-08T08:26:05.336Z",
        "expired": false,
        "multiple": false,
        "votes_count": 123,
        "voters_count": null,
        "voted": false,
        "own_votes": [],
        "options": [
          /* ... */
        ],
        "emojis": []
    }
}
```