### PR TITLE
fix: use empty array for ws protocols instead of null

### DIFF
--- a/src/routes/_thirdparty/websocket/websocket.js
+++ b/src/routes/_thirdparty/websocket/websocket.js
@@ -8,7 +8,7 @@ export class WebSocketClient {
    * @param protocols DOMString|DOMString[] Either a single protocol string or an array of protocol strings. These strings are used to indicate sub-protocols, so that a single server can implement multiple WebSocket sub-protocols (for example, you might want one server to be able to handle different types of interactions depending on the specified protocol). If you don't specify a protocol string, an empty string is assumed.
    * @param options options
    */
-  constructor (url, protocols = null, options = {}) {
+  constructor (url, protocols = [], options = {}) {
     this.url = url
     this.protocols = protocols
 


### PR DESCRIPTION
Heya! I was running into a bug using Pinafore with GoToSocial, but only under Chrome.

Specifically, was getting the following error:

`Error during WebSocket handshake: Sent non-empty 'Sec-WebSocket-Protocol' header but no response was received`

I looked at the request headers that were being sent by the websocket connection, and saw 'Sec-Websocket-Protocol: null`.

After a bit of digging through the code, I noticed that if you pass 'null' to the WebSocket client constructor, it will pass 'null' via the headers, whereas if you just pass an empty array by default, this header is skipped.

This seems to resolve the issue :) Tested with Chrome and GtS