### PR TITLE
fix: show proper text for signup notifications

### DIFF
--- a/src/intl/en-US.js
+++ b/src/intl/en-US.js
@@ -495,6 +495,7 @@ export default {
     other {video}
   }: {description}`,
   accountFollowedYou: '{name} followed you, {account}',
+  accountSignedUp: '{name} signed up, {account}',
   reblogCountsHidden: 'Boost counts hidden',
   favoriteCountsHidden: 'Favorite counts hidden',
   rebloggedTimes: `Boosted {count, plural,
@@ -509,6 +510,7 @@ export default {
   rebloggedYou: 'boosted your toot',
   favoritedYou: 'favorited your toot',
   followedYou: 'followed you',
+  signedUp: 'signed up',
   posted: 'posted',
   pollYouCreatedEnded: 'A poll you created has ended',
   pollYouVotedEnded: 'A poll you voted on has ended',

--- a/src/routes/_components/status/Notification.html
+++ b/src/routes/_components/status/Notification.html
@@ -58,6 +58,7 @@
       account: ({ notification }) => notification.account,
       accountId: ({ account }) => account.id,
       notificationId: ({ notification }) => notification.id,
+      notificationType: ({ notification }) => notification.type,
       status: ({ notification }) => notification.status,
       statusId: ({ status }) => status && status.id,
       uuid: ({ $currentInstance, timelineType, timelineValue, notificationId, statusId }) => (
@@ -65,12 +66,20 @@
       ),
       elementId: ({ uuid }) => uuid,
       shortcutScope: ({ elementId }) => elementId,
-      ariaLabel: ({ status, account, $omitEmojiInDisplayNames }) => (
-        !status && formatIntl('intl.accountFollowedYou', {
+      ariaLabel: ({ status, account, $omitEmojiInDisplayNames, notificationType }) => {
+        if (status) {
+          return undefined // aria-label not needed if there's a status
+        }
+        const params = {
           name: getAccountAccessibleName(account, $omitEmojiInDisplayNames),
           account: `@${account.acct}`
-        })
-      ),
+        }
+        if (notificationType === 'admin.sign_up') {
+          return formatIntl('intl.accountSignedUp', params)
+        } else { // 'follow'
+          return formatIntl('intl.accountFollowedYou', params)
+        }
+      },
       className: ({ $underlineLinks }) => (classname(
         'notification-article',
         'shortcut-list-item',

--- a/src/routes/_components/status/StatusHeader.html
+++ b/src/routes/_components/status/StatusHeader.html
@@ -127,6 +127,8 @@
           return '#fa-bar-chart'
         } else if (notificationType === 'status') {
           return '#fa-comment'
+        } else if (notificationType === 'admin.sign_up') {
+          return '#fa-user-plus'
         }
         return '#fa-star'
       },
@@ -135,6 +137,8 @@
           return 'intl.rebloggedYou'
         } else if (notificationType === 'favourite') {
           return 'intl.favoritedYou'
+        } else if (notificationType === 'admin.sign_up') {
+          return 'intl.signedUp'
         } else if (notificationType === 'follow') {
           return 'intl.followedYou'
         } else if (notificationType === 'status') {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -200,7 +200,8 @@ async function showRichNotification (data, notification) {
   const badge = '/icon-push-badge.png'
 
   switch (notification.type) {
-    case 'follow': {
+    case 'follow':
+    case 'admin.sign_up': {
       await self.registration.showNotification(data.title, {
         badge,
         icon,


### PR DESCRIPTION
This only matters for instance admins, but there's apparently a notification when new users sign up. I'm not going to bother adding filters for these, but we can at least fix the text so it doesn't say "followed you."