### PR TITLE
chore: update formatjs deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "build-vercel-json": "node bin/build-vercel-json.js"
   },
   "dependencies": {
-    "@formatjs/intl-listformat": "^6.5.2",
-    "@formatjs/intl-locale": "^2.4.45",
-    "@formatjs/intl-pluralrules": "^4.3.2",
-    "@formatjs/intl-relativetimeformat": "^9.1.7",
+    "@formatjs/intl-listformat": "^7.1.3",
+    "@formatjs/intl-locale": "^3.0.7",
+    "@formatjs/intl-pluralrules": "^5.1.4",
+    "@formatjs/intl-relativetimeformat": "^11.1.4",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-replace": "^2.4.2",
     "@stdlib/utils-noop": "^0.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,69 +1158,63 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@formatjs/ecma402-abstract@1.11.3":
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.3.tgz#f25276dfd4ef3dac90da667c3961d8aa9732e384"
-  integrity sha512-kP/Buv5vVFMAYLHNvvUzr0lwRTU0u2WTy44Tqwku1X3C3lJ5dKqDCYVqA8wL+Y19Bq+MwHgxqd5FZJRCIsLRyQ==
+"@formatjs/ecma402-abstract@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.13.0.tgz#df6db3cbee0182bbd2fd6217103781c802aee819"
+  integrity sha512-CQ8Ykd51jYD1n05dtoX6ns6B9n/+6ZAxnWUAonvHC4kkuAemROYBhHkEB4tm1uVrRlE7gLDqXkAnY51Y0pRCWQ==
   dependencies:
-    "@formatjs/intl-localematcher" "0.2.24"
-    tslib "^2.1.0"
+    "@formatjs/intl-localematcher" "0.2.31"
+    tslib "2.4.0"
 
-"@formatjs/ecma402-abstract@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.9.4.tgz#797ae6c407fb5a0d09023a60c86f19aca1958c5e"
-  integrity sha512-ePJXI7tWC9PBxQxS7jtbkCLGVmpC8MH8n9Yjmg8dsh9wXK9svu7nAbq76Oiu5Zb+5GVkLkeTVerlSvHCbNImlA==
+"@formatjs/intl-getcanonicallocales@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-2.0.4.tgz#6e294c43c1753d4713ec3e055440b0f10e6fa7dc"
+  integrity sha512-+Sd9QcfnUQlo/hnBq8Czh3TyVgHWK1AW2fAlUABLCd6zVxJwFpHX20CATetH9lKKgbaG8fOP/ijn/7So6aa2fQ==
   dependencies:
-    tslib "^2.1.0"
+    tslib "2.4.0"
 
-"@formatjs/intl-getcanonicallocales@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.9.0.tgz#3fbe3fff5ac639b27e56d19c2f3e8c24a7b13e5f"
-  integrity sha512-5f/5oX0lYw4SOPT6KEOJn/TFKY2GRemrxNuvi/+xdyb3kQhsQlUU0vbcSJhnP+sBcrZFOfoL7OVRkw/vFl9KOA==
+"@formatjs/intl-listformat@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-7.1.3.tgz#e2bda750a46d2a90d7fa023b02a984588978829c"
+  integrity sha512-rs0Kxl78PeRCedx2cmFoBqcun2Kf0bCQrF8ycna54sfePpDhMskvODWeI4G/xBioW01FjK7CJSvtJJ87hrr79A==
   dependencies:
-    tslib "^2.1.0"
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/intl-localematcher" "0.2.31"
+    tslib "2.4.0"
 
-"@formatjs/intl-listformat@^6.5.2":
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-6.5.2.tgz#7fbc310db89e866250e34084e914894c67e09254"
-  integrity sha512-/IYagQJkzTvpBlhhaysGYNgM3o72WBg1ZWZcpookkgXEJbINwLP5kVagHxmgxffYKs1CDzQ8rmKHghu2qR/7zw==
+"@formatjs/intl-locale@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-locale/-/intl-locale-3.0.7.tgz#e8fa1eddb31d4f9d1e5228eca5f400ba1949b5b9"
+  integrity sha512-XucpMNDhiS/gkp+OdvGyHOKBgnB7DVnY81ErjUFI/ztLWxskEDfFhQrWJ4VeG+z0+k2kVnm2akAixhJws3hoKA==
   dependencies:
-    "@formatjs/ecma402-abstract" "1.11.3"
-    "@formatjs/intl-localematcher" "0.2.24"
-    tslib "^2.1.0"
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/intl-getcanonicallocales" "2.0.4"
+    tslib "2.4.0"
 
-"@formatjs/intl-locale@^2.4.45":
-  version "2.4.45"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-locale/-/intl-locale-2.4.45.tgz#34623bb56b6ef10e92f058fe45d514fde47472a4"
-  integrity sha512-qNaAFJ1dTfDM03YMajntB885JZL0UekjL2Iv9yK27iwIE6BKzOK350d9P/xuw75eI6tcpcvcndb0UhZ7IZxaWA==
+"@formatjs/intl-localematcher@0.2.31":
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.31.tgz#aada2b1e58211460cedba56889e3c489117eb6eb"
+  integrity sha512-9QTjdSBpQ7wHShZgsNzNig5qT3rCPvmZogS/wXZzKotns5skbXgs0I7J8cuN0PPqXyynvNVuN+iOKhNS2eb+ZA==
   dependencies:
-    "@formatjs/ecma402-abstract" "1.11.3"
-    "@formatjs/intl-getcanonicallocales" "1.9.0"
-    tslib "^2.1.0"
+    tslib "2.4.0"
 
-"@formatjs/intl-localematcher@0.2.24":
-  version "0.2.24"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.24.tgz#b49fd753c0f54421f26a3c1d0e9cf98a3966e78f"
-  integrity sha512-K/HRGo6EMnCbhpth/y3u4rW4aXkmQNqRe1L2G+Y5jNr3v0gYhvaucV8WixNju/INAMbPBlbsRBRo/nfjnoOnxQ==
+"@formatjs/intl-pluralrules@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-pluralrules/-/intl-pluralrules-5.1.4.tgz#7b8f0101a47a017d6b747a5a42959ccb604e4bef"
+  integrity sha512-SD9G54mH5Kp8COUxZbGL44oLG5ZoNc3MYG/09jtPbPLv8GjLXbs9EEvnwGi0OD9PEnj7dkg0FoOLMulFLcoeCA==
   dependencies:
-    tslib "^2.1.0"
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/intl-localematcher" "0.2.31"
+    tslib "2.4.0"
 
-"@formatjs/intl-pluralrules@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-pluralrules/-/intl-pluralrules-4.3.2.tgz#8ac4b8592bc231fd2adcccc6e3012d17d007c638"
-  integrity sha512-ptV6vYF9asaDWbU3WvfXCgLYRZLGbl3LuiY1hFRr/BJtVXSLP+ocgLs2k6oEME401p3ucW+ZVMeqxftRTH8BFA==
+"@formatjs/intl-relativetimeformat@^11.1.4":
+  version "11.1.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-11.1.4.tgz#e8ececbae337caf4c62946f6080ef9eecfc6f36f"
+  integrity sha512-vUz2O1OpmKAyLTyQw6BUT0KMrm/2373zPUlF5wlCmy6mT4YIvxUAizaeSLHKpjQgc6qWmzsOiQTJG04Sz2vtYA==
   dependencies:
-    "@formatjs/ecma402-abstract" "1.11.3"
-    "@formatjs/intl-localematcher" "0.2.24"
-    tslib "^2.1.0"
-
-"@formatjs/intl-relativetimeformat@^9.1.7":
-  version "9.1.7"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.1.7.tgz#9c5481b4d4ac39de3162c836cedef52feeae8a05"
-  integrity sha512-uthmRnNg+agzulNxa4Em2Jbll1msbJdkb6CO8JrOg/CFHyXH9YPMaPjCxgzR2wdDeMjBjGnFhbTJZtqz5LN+Uw==
-  dependencies:
-    "@formatjs/ecma402-abstract" "1.9.4"
-    tslib "^2.1.0"
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/intl-localematcher" "0.2.31"
+    tslib "2.4.0"
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"
@@ -2813,9 +2807,9 @@ emoji-picker-element-data@^1.3.0:
   integrity sha512-0Hsp+MgX0R7wUKaRx34ILJsVsTaz2rpEDwdnb0lP3eEoquLVgZUY+jyrbdFzuwceY026egaeIRMVCcs239SCbQ==
 
 emoji-picker-element@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/emoji-picker-element/-/emoji-picker-element-1.11.1.tgz#3b36ce615c92aedc9d18d2c572d61508e7d773c4"
-  integrity sha512-xF8tUKr9WIXpS6gcrQgZC7ghdcbzamknKF7t9+81bJHjQEXzMGSwhyvZrx2S3XeNFtKcx9RqwwGStog5iUjZeQ==
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/emoji-picker-element/-/emoji-picker-element-1.13.1.tgz#721e2afb72c546f8f0b33766bd792b2dc70e4480"
+  integrity sha512-xOUYg6piwCmnYJw5Uh47rV5F2CwcFZcbfZx5jzU43gELJDbg8hrv6CBsikVe5VJSyiUH+N2QeQHc2f0h+V74PA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -6946,15 +6940,15 @@ tsconfig-paths@^3.11.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslib@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Doesn't seem like these new updates should break us