### PR TITLE
chore: attempt to fix flaky test

### DIFF
--- a/bin/restore-mastodon-data.js
+++ b/bin/restore-mastodon-data.js
@@ -17,10 +17,10 @@ export async function restoreMastodonData () {
   console.log('Restoring mastodon data...')
   const internalIdsToIds = {}
   for (const action of actions) {
-    if (!action.post) {
-      // If the action is a boost, favorite, etc., then it needs to
+    if (!action.post || /@/.test(action.post.text)) {
+      // If the action is a boost, favorite, mention, etc., then it needs to
       // be delayed, otherwise it may appear in an unpredictable order and break the tests.
-      await new Promise(resolve => setTimeout(resolve, 1000))
+      await new Promise(resolve => setTimeout(resolve, 1500))
     }
     console.log(JSON.stringify(action))
     const accessToken = users[action.user].accessToken


### PR DESCRIPTION
Managed to repro the flaky notifications test; it turns out that Mastodon randomly changes the order on some of these notifications. Hoping that changing the restore delays fixes this.

Spot the difference in these two timelines (last three notifications):

![Screenshot from 2022-11-17 07-53-37](https://user-images.githubusercontent.com/283842/202494459-cef5986a-0ead-493e-871a-5f53d9cd9ef2.png)
![Screenshot from 2022-11-17 07-50-14](https://user-images.githubusercontent.com/283842/202494516-cb43096c-cb6f-4806-8037-bd7ac21816a4.png)
