### PR TITLE
fix: recalculate toot height after voting on poll

### DIFF
--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -34,7 +34,7 @@
     <StatusMediaAttachments {...params} on:recalculateHeight />
   {/if}
   {#if showPoll && (showContent || preloadHiddenContent)}
-    <StatusPoll {...params} shown={showContent} />
+    <StatusPoll {...params} shown={showContent} on:recalculateHeight />
   {/if}
   {#if isStatusInOwnThread}
     <StatusDetails {...params} {...timestampParams} />

--- a/src/routes/_components/status/StatusPoll.html
+++ b/src/routes/_components/status/StatusPoll.html
@@ -364,6 +364,8 @@
             const { polls } = this.store.get()
             polls[pollId] = poll
             this.store.set({ polls })
+            // the height of the status changes after you vote on the poll
+            requestAnimationFrame(() => this.fire('recalculateHeight'))
           }
         } finally {
           this.set({ loading: false })


### PR DESCRIPTION
Subtle bug: when voting on a poll, the status height may change after you vote, so the virtual list sizes have to be recalculated.