### PR TITLE
fix: action buttons background for better contrast

### DIFF
--- a/src/routes/_components/IconButton.html
+++ b/src/routes/_components/IconButton.html
@@ -25,10 +25,14 @@
   }
 
   :global(.icon-button-svg) {
+    --svg-bg-color: transparent;
     width: 24px;
     height: 24px;
     fill: var(--action-button-fill-color);
     pointer-events: none; /* hack for Edge */
+    border-radius: 0.1%;
+    background: var(--svg-bg-color);
+    box-shadow: 0 0 0 5px var(--svg-bg-color);
   }
 
   :global(.icon-button.big-icon .icon-button-svg) {
@@ -39,26 +43,23 @@
   /*
    * regular styles
    */
-
   :global(.icon-button:hover .icon-button-svg) {
-    fill: var(--action-button-fill-color-hover);
+    --svg-bg-color: var(--action-button-bg-color-hover);
   }
-
-  :global(.icon-button.not-pressable:active .icon-button-svg,
-  .icon-button.same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-fill-color-active);
+  :global(.icon-button:active .icon-button-svg) {
+    --svg-bg-color: var(--action-button-bg-color-active);
   }
-
+  :global(.icon-button.pressed .icon-button-svg) {
+    --svg-bg-color: var(--action-button-bg-color-pressed);
+  }
+  :global(.icon-button.pressed:hover .icon-button-svg) {
+    --svg-bg-color: var(--action-button-bg-color-pressed-hover);
+  }
+  :global(.icon-button.pressed:active .icon-button-svg) {
+    --svg-bg-color: var(--action-button-bg-color-pressed-active);
+  }
   :global(.icon-button.pressed.not-same-pressed .icon-button-svg) {
     fill: var(--action-button-fill-color-pressed);
-  }
-
-  :global(.icon-button.pressed.not-same-pressed:hover .icon-button-svg) {
-    fill: var(--action-button-fill-color-pressed-hover);
-  }
-
-  :global(.icon-button.pressed.not-same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-fill-color-pressed-active);
   }
 
   /*

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -44,12 +44,13 @@
   --nav-svg-fill-hover: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 18%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 22%)};
-  --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
-  --action-button-fill-color-pressed: #{darken($main-theme-color, 7%)};
-  --action-button-fill-color-pressed-hover: #{darken($main-theme-color, 2%)};
-  --action-button-fill-color-pressed-active: #{darken($main-theme-color, 15%)};
+  --action-button-fill-color: #{lighten($main-theme-color, 6%)};
+  --action-button-bg-color-hover: #{fade-out($main-theme-color, 0.8)};
+  --action-button-bg-color-active: #{fade-out($main-theme-color, 0.6)};
+  --action-button-bg-color-pressed: var(--action-button-fill-color);
+  --action-button-fill-color-pressed: #{$main-bg-color};
+  --action-button-bg-color-pressed-hover: #{fade-out($main-theme-color, 0.1)};
+  --action-button-bg-color-pressed-active: #{fade-out($main-theme-color, 0)};
 
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
   --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};


### PR DESCRIPTION
The issue with the current buttons is we are making the distinction between pressed based on the contrast between two colours, this will always be difficult.

This proposal instead changes the shape by relying on an 'inverse' style which makes it very clear if it is pressed or not no matter someone's perception of colour.

## Screenshots

### Status toolbar

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/202910891-c4acd717-a320-427b-9223-f044ba4b35d0.png) | ![](https://user-images.githubusercontent.com/2445413/202910903-605dac1e-386b-4dad-b47c-6eef717867eb.png) |

### Compose toolbar

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/202910975-95776dc6-c9fb-40d1-90ed-810f091ce29e.png) | ![](https://user-images.githubusercontent.com/2445413/202910979-dc078f80-8878-4789-99f2-29a5d9e58737.png) |

### Dark
| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/202911200-6a33f3e7-b7ab-4e80-b0de-76b7a22e9e1d.png) | ![](https://user-images.githubusercontent.com/2445413/202911208-27394e17-5da7-4dd9-aeec-928612488fed.png) |
