### PR TITLE
fix: fix position of toast/snackbar for bottom nav

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -38,6 +38,7 @@
       --nav-bottom: 0px;
       --main-content-pad-top: 0px;
       --main-content-pad-bottom: var(--main-content-pad-vertical);
+      --toast-gap-bottom: var(--nav-total-height);
     }
   </style>
 

--- a/src/routes/_components/snackbar/Snackbar.html
+++ b/src/routes/_components/snackbar/Snackbar.html
@@ -21,14 +21,14 @@
 <style>
   .snackbar-modal {
     position: fixed;
-    bottom: 0;
+    bottom: var(--toast-gap-bottom);
     left: 0;
     right: 0;
     transition: transform 333ms ease-in-out;
     display: flex;
     flex-direction: column;
     align-items: center;
-    z-index: 99000;
+    z-index: 90; /* lower than the Nav.html .main-nav which is 100 */
     transform: translateY(100%);
   }
 

--- a/src/routes/_components/toast/Toast.html
+++ b/src/routes/_components/toast/Toast.html
@@ -6,7 +6,7 @@
 <style>
   .toast-modal {
     position: fixed;
-    bottom: 40px;
+    bottom: calc(40px + var(--toast-gap-bottom));
     left: 0;
     right: 0;
     opacity: 0;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -65,7 +65,7 @@
   // Used for moving the nav bar to the bottom
   --nav-top: 0px;
   --nav-bottom: initial;
-
+  --toast-gap-bottom: 0px; // used to position the Toast and Snackbar above the bottom nav
 
   //
   // focus outline


### PR DESCRIPTION
When the nav is on the bottom (#2164), the toast and snackbar obscure it (or are not positioned properly relative to it). Dumb oversight I made. This fixes it.