### PR TITLE
fix: If the focus is inside a toot, make keyboard commands operate relative to the parent toot.

### DIFF
--- a/src/routes/_components/shortcut/ScrollListShortcuts.html
+++ b/src/routes/_components/shortcut/ScrollListShortcuts.html
@@ -119,7 +119,13 @@
         if (!activeElement) {
           return null
         }
-        const activeItem = activeElement.getAttribute('id')
+        // The user might be focused on an element inside a toot. We want to
+        // move relative to that toot.
+        const activeArticle = activeElement.closest('article')
+        if (!activeArticle) {
+          return null
+        }
+        const activeItem = activeArticle.getAttribute('id')
         if (!activeItem) {
           return null
         }


### PR DESCRIPTION
Previously, if focus was on an element inside a toot instead of the toot itself (e.g. moving to a toot and pressing tab), keyboard commands acted as if no toot was active. In particular, this meant that the arrow keys scrolled to the first visible toot.

Fixes #2228.