### PR TITLE
Query remote Mastodon server for follower list, on clicking follower …

### DIFF
--- a/src/routes/_api/followsAndFollowers.js
+++ b/src/routes/_api/followsAndFollowers.js
@@ -1,5 +1,7 @@
 import { get, paramsString, DEFAULT_TIMEOUT } from '../_utils/ajax.js'
 import { auth, basename } from './utils.js'
+import { getAccount } from '../_api/user.js'
+
 
 export async function getFollows (instanceName, accessToken, accountId, limit = 80) {
   let url = `${basename(instanceName)}/api/v1/accounts/${accountId}/following`
@@ -7,8 +9,24 @@ export async function getFollows (instanceName, accessToken, accountId, limit = 
   return get(url, auth(accessToken), { timeout: DEFAULT_TIMEOUT })
 }
 
+export async function lookup (instanceName, accountName) {
+  let url = `${basename(instanceName)}/api/v1/accounts/lookup?acct=${accountName}`
+  return get(url, { timeout: DEFAULT_TIMEOUT })
+}
+
 export async function getFollowers (instanceName, accessToken, accountId, limit = 80) {
-  let url = `${basename(instanceName)}/api/v1/accounts/${accountId}/followers`
-  url += '?' + paramsString({ limit })
-  return get(url, auth(accessToken), { timeout: DEFAULT_TIMEOUT })
+window.console.log(instanceName, accessToken, accountId, limit);
+
+return getAccount(instanceName, accessToken, accountId).then(account => {
+  let [accountName, remoteInstanceName] = account.acct.split('@');
+
+  return lookup(remoteInstanceName, accountName).then(remoteAccount => {
+    let url = `${basename(remoteInstanceName)}/api/v1/accounts/${remoteAccount.id}/followers`
+    url += '?' + paramsString({ limit })
+    return get(url, { timeout: DEFAULT_TIMEOUT })
+  });
+
+});
+
+
 }

--- a/src/routes/_api/followsAndFollowers.js
+++ b/src/routes/_api/followsAndFollowers.js
@@ -15,17 +15,14 @@ export async function lookup (instanceName, accountName) {
 }
 
 export async function getFollowers (instanceName, accessToken, accountId, limit = 80) {
-window.console.log(instanceName, accessToken, accountId, limit);
+  return getAccount(instanceName, accessToken, accountId).then(account => {
+    let [accountName, remoteInstanceName] = account.acct.split('@');
 
-return getAccount(instanceName, accessToken, accountId).then(account => {
-  let [accountName, remoteInstanceName] = account.acct.split('@');
-
-  return lookup(remoteInstanceName, accountName).then(remoteAccount => {
-    let url = `${basename(remoteInstanceName)}/api/v1/accounts/${remoteAccount.id}/followers`
-    url += '?' + paramsString({ limit })
-    return get(url, { timeout: DEFAULT_TIMEOUT })
-  });
-
+    return lookup(remoteInstanceName, accountName).then(remoteAccount => {
+      let url = `${basename(remoteInstanceName)}/api/v1/accounts/${remoteAccount.id}/followers`
+      url += '?' + paramsString({ limit })
+      return get(url, { timeout: DEFAULT_TIMEOUT })
+    });
 });
 
 

--- a/src/routes/_components/search/AccountSearchResult.html
+++ b/src/routes/_components/search/AccountSearchResult.html
@@ -1,4 +1,4 @@
-<SearchResult href="/accounts/{account.id}">
+<SearchResult href="{account.url}">
   <div class="search-result-account">
     <div class="search-result-account-avatar">
       <Avatar {account} size="small" />


### PR DESCRIPTION
When looking at followers of a profile, I only see followers on my local instance - which isn't what I want.

This change:
When viewing the follower list for an account, query the API on the account's home instance not mine, to get a full list of followers (up to page limit).
On clicking the follower, go to their home instance's profile page where I can view posts and decide to follow.