### PR TITLE
Remove alert role from the loading indicator so it no longer interferes with screen readers.

### DIFF
--- a/src/routes/_components/timeline/LoadingFooter.html
+++ b/src/routes/_components/timeline/LoadingFooter.html
@@ -1,7 +1,6 @@
 <div class="loading-footer {shown ? '' : 'hidden'}">
   <div class="loading-wrapper {showLoading ? 'shown' : ''}"
        aria-hidden={!showLoading}
-       role="alert"
   >
     <!-- Sapper's mousemove event listener schedules style recalculations for the loading spinner in
          Chrome because it's always animating, even when hidden. So disable animations when not visible


### PR DESCRIPTION
Fixes "Loading more" alert creates extraneous verbosity for screen reader users #2226.#2226