### PR TITLE
fix: fix mismatched dark/light color-scheme

### DIFF
--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -135,5 +135,5 @@
   --focus-bg: #{rgba(0, 0, 0, 0.1)};
 
   accent-color: #{$main-theme-color};
-  color-scheme: light dark;
+  color-scheme: light;
 }

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -53,5 +53,5 @@
 
   --focus-bg: #{rgba(255, 255, 255, 0.1)};
 
-  color-scheme: dark light;
+  color-scheme: dark;
 }


### PR DESCRIPTION
If your OS is in dark mode but the theme is light, then the radio buttons might look dark when they should be light, or vice versa. At least in Firefox. This fixes that.