### PR TITLE
fix: bring check closer to icon

### DIFF
--- a/src/routes/_components/IconButton.html
+++ b/src/routes/_components/IconButton.html
@@ -37,8 +37,8 @@
 
   :global(.icon-button-check) {
     position: absolute;
-    top: 0;
-    right: 1px;
+    top: 1px;
+    right: 2px;
     height: 12px;
     width: 12px;
   }


### PR DESCRIPTION
Just a small aesthetic change to make them feel more connected.

## Screenshot

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/203971277-d52edcf7-d350-4847-931c-9d7ae6238b90.png) | ![](https://user-images.githubusercontent.com/2445413/203971070-f1ba6bb6-222c-4275-b2cb-da00853db140.png) |

