### PR TITLE
Ensure UI is readable by improving the contrast for all themes

### DIFF
--- a/src/routes/_components/IconButton.html
+++ b/src/routes/_components/IconButton.html
@@ -52,21 +52,16 @@
    * regular styles
    */
 
-  :global(.icon-button:hover .icon-button-svg) {
-    fill: var(--action-button-fill-color-hover);
+  .icon-button:hover {
+    background: var(--action-button-bg-color-hover);
   }
 
-  :global(.icon-button.not-pressable:active .icon-button-svg,
-  .icon-button.same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-fill-color-active);
+  .icon-button:active {
+    background: var(--action-button-bg-color-active);
   }
 
   :global(.icon-button.pressed.not-same-pressed .icon-button-svg) {
     fill: var(--action-button-fill-color-pressed);
-  }
-
-  :global(.icon-button.pressed.not-same-pressed:hover .icon-button-svg) {
-    fill: var(--action-button-fill-color-pressed-hover);
   }
 
   :global(.icon-button.pressed.not-same-pressed:active .icon-button-svg) {
@@ -81,25 +76,8 @@
     fill: var(--action-button-deemphasized-fill-color);
   }
 
-  :global(.icon-button.muted-style:hover .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-hover);
-  }
-
-  :global(.icon-button.muted-style.not-pressable:active .icon-button-svg,
-  .icon-button.muted-style.same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-active);
-  }
-
   :global(.icon-button.muted-style.pressed.not-same-pressed .icon-button-svg) {
     fill: var(--action-button-deemphasized-fill-color-pressed);
-  }
-
-  :global(.icon-button.muted-style.pressed.not-same-pressed:hover .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-pressed-hover);
-  }
-
-  :global(.icon-button.muted-style.pressed.not-same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-pressed-active);
   }
 
 </style>

--- a/src/routes/_components/IconButton.html
+++ b/src/routes/_components/IconButton.html
@@ -64,10 +64,6 @@
     fill: var(--action-button-fill-color-pressed);
   }
 
-  :global(.icon-button.pressed.not-same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-fill-color-pressed-active);
-  }
-
   /*
    * muted
    */

--- a/src/routes/_components/community/PageListItem.html
+++ b/src/routes/_components/community/PageListItem.html
@@ -70,24 +70,8 @@
     height: 24px;
   }
 
-  :global(.pinnable-button:hover .pinnable-svg) {
-    fill: var(--action-button-fill-color-hover);
-  }
-
-  :global(.pinnable-button:active .pinnable-svg) {
-    fill: var(--action-button-fill-color-active);
-  }
-
   :global(.pinnable-button.checked .pinnable-svg) {
     fill: var(--action-button-fill-color-pressed);
-  }
-
-  :global(.pinnable-button.checked:hover .pinnable-svg) {
-    fill: var(--action-button-fill-color-pressed-hover);
-  }
-
-  :global(.pinnable-button.checked:active .pinnable-svg) {
-    fill: var(--action-button-fill-color-pressed-active);
   }
 
   /* TODO: end copypasta */

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -44,19 +44,13 @@
   --nav-svg-fill-hover: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 18%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 22%)};
-  --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
-  --action-button-fill-color-pressed: #{darken($main-theme-color, 7%)};
-  --action-button-fill-color-pressed-hover: #{darken($main-theme-color, 2%)};
-  --action-button-fill-color-pressed-active: #{darken($main-theme-color, 15%)};
+  --action-button-fill-color: #{lighten($deemphasized-color, 16%)};
+  --action-button-bg-color-hover: #{fade-out($main-text-color, 0.94)};
+  --action-button-bg-color-active: #{fade-out($main-text-color, 0.9)};
+  --action-button-fill-color-pressed: #{saturate($main-theme-color, 10%)};
 
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
-  --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};
-  --action-button-deemphasized-fill-color-active: #{lighten($deemphasized-color, 5%)};
   --action-button-deemphasized-fill-color-pressed: #{darken($deemphasized-color, 7%)};
-  --action-button-deemphasized-fill-color-pressed-hover: #{darken($deemphasized-color, 2%)};
-  --action-button-deemphasized-fill-color-pressed-active: #{darken($deemphasized-color, 15%)};
 
   --settings-list-item-bg: #{$main-bg-color};
   --settings-list-item-text: #{$main-theme-color};

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -26,23 +26,22 @@
   --form-border: #{darken($border-color, 10%)};
 
   --nav-bg: #{$main-theme-color};
-  --nav-active-bg: #{lighten($main-theme-color, 9%)};
+  --nav-active-bg: #{lighten($main-theme-color, 6%)};
   --nav-border: #{darken($main-theme-color, 10%)};
   --nav-a-border: #{$main-theme-color};
+  --nav-a-border-hover: #{rgba($secondary-text-color, 0.6)};
+  --nav-a-bg-hover: #{lighten($main-theme-color, 3%)};
   --nav-a-selected-border: #{$secondary-text-color};
-  --nav-a-selected-bg: #{lighten($main-theme-color, 10%)};
-  --nav-a-selected-active-bg: #{lighten($main-theme-color, 17%)};
-  --nav-svg-fill: #{$secondary-text-color};
-  --nav-text-color: #{$secondary-text-color};
-  --nav-indicator-bg: #{rgba($secondary-text-color, 0.8)};
-  --nav-indicator-bg-hover: #{rgba($secondary-text-color, 0.85)};
-
+  --nav-a-selected-bg: #{lighten($main-theme-color, 3%)};
+  --nav-a-selected-bg-hover: #{lighten($main-theme-color, 6%)};
   --nav-a-selected-border-hover: #{$secondary-text-color};
-  --nav-a-selected-bg-hover: #{lighten($main-theme-color, 15%)};
-  --nav-a-bg-hover: #{lighten($main-theme-color, 5%)};
-  --nav-a-border-hover: #{$main-theme-color};
+  --nav-a-selected-active-bg: var(--nav-a-selected-bg-hover);
+  --nav-svg-fill: #{$secondary-text-color};
   --nav-svg-fill-hover: #{$secondary-text-color};
+  --nav-text-color: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
+  --nav-indicator-bg: #{rgba($secondary-text-color, 0.8)};
+  --nav-indicator-bg-hover: #{rgba($secondary-text-color, 0.6)};
 
   --action-button-fill-color: #{lighten($deemphasized-color, 16%)};
   --action-button-bg-color-hover: #{fade-out($main-text-color, 0.94)};

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -20,7 +20,7 @@
   --body-bg: #{$body-bg-color};
   --body-text-color: #{$main-text-color};
   --main-border: #{$border-color};
-  --svg-fill: #{$main-theme-color};
+  --svg-fill: #{$main-text-color};
 
   --form-bg: #{darken($main-bg-color, 3%)};
   --form-border: #{darken($border-color, 10%)};

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -26,14 +26,14 @@
   --form-border: #{darken($border-color, 10%)};
 
   --nav-bg: #{$main-theme-color};
-  --nav-active-bg: #{lighten($main-theme-color, 6%)};
+  --nav-active-bg: #{lighten($main-theme-color, 3%)};
   --nav-border: #{darken($main-theme-color, 10%)};
   --nav-a-border: #{$main-theme-color};
   --nav-a-border-hover: #{rgba($secondary-text-color, 0.6)};
-  --nav-a-bg-hover: #{lighten($main-theme-color, 3%)};
+  --nav-a-bg-hover: #{lighten($main-theme-color, 1.5%)};
   --nav-a-selected-border: #{$secondary-text-color};
   --nav-a-selected-bg: #{lighten($main-theme-color, 3%)};
-  --nav-a-selected-bg-hover: #{lighten($main-theme-color, 6%)};
+  --nav-a-selected-bg-hover: #{lighten($main-theme-color, 4.5%)};
   --nav-a-selected-border-hover: #{$secondary-text-color};
   --nav-a-selected-active-bg: var(--nav-a-selected-bg-hover);
   --nav-svg-fill: #{$secondary-text-color};

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -44,7 +44,7 @@
 
   --toast-anchor-color: #{$anchor-color};
 
-  --length-indicator-color: var(--action-button-fill-color);
+  --length-indicator-color: #{$deemphasized-color};
 
   --blurhash-sensitive-text-color: #{lighten($deemphasized-color, 15%)};
 

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -1,12 +1,9 @@
 :root {
   $deemphasized-color: lighten($main-bg-color, 45%);
 
+  --action-button-fill-color: #{darken($deemphasized-color, 2%)};
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
-  --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};
-  --action-button-deemphasized-fill-color-active: #{lighten($deemphasized-color, 5%)};
   --action-button-deemphasized-fill-color-pressed: #{darken($deemphasized-color, 7%)};
-  --action-button-deemphasized-fill-color-pressed-hover: #{darken($deemphasized-color, 2%)};
-  --action-button-deemphasized-fill-color-pressed-active: #{darken($deemphasized-color, 15%)};
 
   --loading-bg: #{#222};
 

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -2,6 +2,7 @@
   $deemphasized-color: lighten($main-bg-color, 45%);
 
   --action-button-fill-color: #{darken($deemphasized-color, 2%)};
+  --action-button-fill-color-pressed: #{lighten($main-theme-color, 5%)};
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
   --action-button-deemphasized-fill-color-pressed: #{darken($deemphasized-color, 7%)};
 

--- a/src/scss/themes/ozark.scss
+++ b/src/scss/themes/ozark.scss
@@ -1,4 +1,4 @@
-$main-theme-color: #5263af;
+$main-theme-color: saturate(#5263af, 10%);
 $body-bg-color: #0f1427;
 $main-bg-color: #212433;
 $anchor-color: lighten($main-theme-color, 20%);

--- a/src/scss/themes/pitchblack.scss
+++ b/src/scss/themes/pitchblack.scss
@@ -33,9 +33,6 @@ $compose-background: darken($main-theme-color, 12%);
   --form-bg: #{$body-bg-color};
   --form-border: #{darken($border-color, 10%)};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 20%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 30%)};
-  --action-button-fill-color-active: #{darken($main-theme-color, 40%)};
   --action-button-fill-color-pressed: #{lighten($main-theme-color, 85%)};
   --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 100%)};
   --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 80%)};

--- a/src/scss/themes/pitchblack.scss
+++ b/src/scss/themes/pitchblack.scss
@@ -1,7 +1,7 @@
 $main-theme-color: #000;
 $body-bg-color: #000;
 $main-bg-color: #000;
-$anchor-color: lighten($main-theme-color, 90%);
+$anchor-color: #fafaff;
 $main-text-color: #fafaff;
 $border-color: #222;
 $secondary-text-color: #f6f6ff;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -21,9 +21,9 @@
   //
 
   --nav-font-size: 1rem;
-  --nav-indicator-height: 2px;
+  --nav-indicator-height: 3px;
   --nav-border-bottom: 0px;
-  --nav-icon-pad-v: 15px;
+  --nav-icon-pad-v: 14px;
   --nav-icon-pad-h: 20px;
   --nav-icon-size: 20px;
 
@@ -46,10 +46,9 @@
   --main-border-size: 1px;
 
   @media (max-width: 991px) {
-    --nav-icon-pad-v: 20px;
+    --nav-icon-pad-v: 18px;
     --nav-icon-pad-h: 10px;
     --nav-icon-size: 25px;
-    --nav-indicator-height: 3px;
     --nav-border-bottom: 0px;
   }
 


### PR DESCRIPTION
An initial pass to improve overall contrast for themes, this does not fix all issues but trying not to do too much at once...

## Icons

Icons now have hover and active states on their touch area background rather than the icon themselves, this also simplifies the logic allowing both pressed and non-pressed state to share more states.

## Navigation
The background for the navigation when selected or interacted with have a better contrast, to ensure that it's clear what you're interacting with I have increased the width of the indicator line on desktop so we are relying on that being clear rather than the background itself.

## Loading indicators
Loading indicator and similar SVG filled icons now use the text colour to ensure good contrast