### PR TITLE
fix: hide invisible content consistently

### DIFF
--- a/src/routes/_components/status/StatusContent.html
+++ b/src/routes/_components/status/StatusContent.html
@@ -67,16 +67,6 @@
     color: var(--very-deemphasized-link-color);
   }
 
-  :global(.status-content .invisible) {
-    /* copied from Mastodon */
-    font-size: 0;
-    line-height: 0;
-    display: inline-block;
-    width: 0;
-    height: 0;
-    position: absolute;
-  }
-
   :global(.underline-links .status-content a) {
     text-decoration: underline;
   }

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -207,3 +207,13 @@ textarea {
 .inline-emoji {
   font-family: CountryFlagEmojiPolyfill, PinaforeEmoji, sans-serif;
 }
+
+.invisible {
+  /* copied from Mastodon */
+  font-size: 0;
+  line-height: 0;
+  display: inline-block;
+  width: 0;
+  height: 0;
+  position: absolute;
+}


### PR DESCRIPTION
Some other parts of the interface for example URLs in profiles use the invisible class, move this to the top level global file so it'll be applied everywhere.

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/204026358-985b61a5-1dc1-4fda-8297-25633ad0c5b7.png) | ![](https://user-images.githubusercontent.com/2445413/204026412-d2521e8f-0933-4b17-baa7-8003b374ae6e.png) |

