### PR TITLE
fix: improve button a11y for theme Sorcery

### DIFF
--- a/src/scss/themes/sorcery.scss
+++ b/src/scss/themes/sorcery.scss
@@ -23,4 +23,7 @@ $scrollbar-face-active: #{lighten($main-theme-color, 1%)};
 
 :root {
   accent-color: #{darken($main-theme-color, 12%)};
+
+  --button-primary-bg: #{$main-theme-color};
+  --button-primary-text: #141414;
 }


### PR DESCRIPTION
Similar to https://github.com/tootcafe/mastodon/pull/183

Contract ratio is now > 7:1: https://contrast-ratio.com/#%23ae91e8-on-%23141414