### PR TITLE
Improve navigation readability

### DIFF
--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -26,21 +26,21 @@
   --form-border: #{darken($border-color, 10%)};
 
   --nav-bg: #{$main-theme-color};
-  --nav-active-bg: #{lighten($main-theme-color, 9%)};
+  --nav-active-bg: #{lighten($main-theme-color, 3%)};
   --nav-border: #{darken($main-theme-color, 10%)};
   --nav-a-border: #{$main-theme-color};
   --nav-a-selected-border: #{$secondary-text-color};
-  --nav-a-selected-bg: #{lighten($main-theme-color, 10%)};
-  --nav-a-selected-active-bg: #{lighten($main-theme-color, 17%)};
+  --nav-a-selected-bg: #{lighten($main-theme-color, 3%)};
+  --nav-a-selected-active-bg: var(--nav-a-selected-bg-hover);
   --nav-svg-fill: #{$secondary-text-color};
   --nav-text-color: #{$secondary-text-color};
   --nav-indicator-bg: #{rgba($secondary-text-color, 0.8)};
-  --nav-indicator-bg-hover: #{rgba($secondary-text-color, 0.85)};
+  --nav-indicator-bg-hover: #{rgba($secondary-text-color, 0.6)};
 
   --nav-a-selected-border-hover: #{$secondary-text-color};
-  --nav-a-selected-bg-hover: #{lighten($main-theme-color, 15%)};
-  --nav-a-bg-hover: #{lighten($main-theme-color, 5%)};
-  --nav-a-border-hover: #{$main-theme-color};
+  --nav-a-selected-bg-hover: #{lighten($main-theme-color, 4.5%)};
+  --nav-a-bg-hover: #{lighten($main-theme-color, 1.5%)};
+  --nav-a-border-hover: #{rgba($secondary-text-color, 0.6)};
   --nav-svg-fill-hover: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
 

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -21,9 +21,9 @@
   //
 
   --nav-font-size: 1rem;
-  --nav-indicator-height: 2px;
+  --nav-indicator-height: 3px;
   --nav-border-bottom: 0px;
-  --nav-icon-pad-v: 15px;
+  --nav-icon-pad-v: 14px;
   --nav-icon-pad-h: 20px;
   --nav-icon-size: 20px;
 
@@ -46,10 +46,9 @@
   --main-border-size: 1px;
 
   @media (max-width: 991px) {
-    --nav-icon-pad-v: 20px;
+    --nav-icon-pad-v: 18px;
     --nav-icon-pad-h: 10px;
     --nav-icon-size: 25px;
-    --nav-indicator-height: 3px;
     --nav-border-bottom: 0px;
   }
 


### PR DESCRIPTION
Make the background of selected navigation items darker so it is easier to read with white text (this meets WCAG contrast requirements).

Make the indicator bar more prominent to make it clearer which item is selected now that the background is done less to indicate this.

## Screenshots

### Dark mode

#### Page selected

##### Before
![](https://user-images.githubusercontent.com/2445413/204401930-a03f6fb4-ca4b-43c7-b0c5-79bd8fe33545.png)

##### After
![](https://user-images.githubusercontent.com/2445413/204401934-ae7bdfde-defb-41f8-80f6-db17d5846f06.png)

#### Page hovered

##### Before
![](https://user-images.githubusercontent.com/2445413/204402197-dfe7961a-cbae-4bcd-b239-fe3fc36246e4.png)

##### After
![](https://user-images.githubusercontent.com/2445413/204402201-6741a297-086f-4f7f-aa2b-ca607deb7243.png)

### Light

#### Page selected

##### Before
![](https://user-images.githubusercontent.com/2445413/204402423-ef688e58-ea36-4599-aa46-99d68b675a8d.png)

##### After
![](https://user-images.githubusercontent.com/2445413/204402421-68cfd8da-3535-4a1e-a505-9df9a2ecd018.png)

#### Page hovered

##### Before
![](https://user-images.githubusercontent.com/2445413/204402507-59634e5d-d830-4dc4-9c31-98dd9cfecb83.png)

##### After
![](https://user-images.githubusercontent.com/2445413/204402510-df86759c-06c9-4908-b6a3-c0fd42414bf5.png)


### Mobile

#### Before
![](https://user-images.githubusercontent.com/2445413/204402893-3c90c8d3-1d74-4b4b-ab1e-7be519e02bcf.png)

#### After
![](https://user-images.githubusercontent.com/2445413/204402896-14c6ae90-1d78-43ca-8154-821ed09ad26a.png)
