### PR TITLE
Improve icon readability

### DIFF
--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -44,12 +44,12 @@
   --nav-svg-fill-hover: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 18%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 22%)};
-  --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
-  --action-button-fill-color-pressed: #{darken($main-theme-color, 7%)};
-  --action-button-fill-color-pressed-hover: #{darken($main-theme-color, 2%)};
-  --action-button-fill-color-pressed-active: #{darken($main-theme-color, 15%)};
+  --action-button-fill-color: #{lighten($deemphasized-color, 15%)};
+  --action-button-fill-color-hover: #{lighten($deemphasized-color, 7.5%)};
+  --action-button-fill-color-active: #{$deemphasized-color};
+  --action-button-fill-color-pressed: #{saturate($main-theme-color, 5%)};
+  --action-button-fill-color-pressed-hover: #{darken(saturate($main-theme-color, 5%), 4%)};
+  --action-button-fill-color-pressed-active: #{darken(saturate($main-theme-color, 5%), 8%)};
 
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
   --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -1,6 +1,13 @@
 :root {
   $deemphasized-color: lighten($main-bg-color, 45%);
 
+  --action-button-fill-color: #{darken($deemphasized-color, 2%)};
+  --action-button-fill-color-hover: #{lighten($deemphasized-color, 9%)};
+  --action-button-fill-color-active: #{$deemphasized-color};
+  --action-button-fill-color-pressed: #{lighten($main-theme-color, 5%)};
+  --action-button-fill-color-pressed-hover: #{lighten(saturate($main-theme-color, 10%), 4%)};
+  --action-button-fill-color-pressed-active: #{lighten(saturate($main-theme-color, 10%), 8%)};
+
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
   --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};
   --action-button-deemphasized-fill-color-active: #{lighten($deemphasized-color, 5%)};

--- a/src/scss/themes/ozark.scss
+++ b/src/scss/themes/ozark.scss
@@ -1,4 +1,4 @@
-$main-theme-color: #5263af;
+$main-theme-color: saturate(#5263af, 10%);
 $body-bg-color: #0f1427;
 $main-bg-color: #212433;
 $anchor-color: lighten($main-theme-color, 20%);

--- a/src/scss/themes/pitchblack.scss
+++ b/src/scss/themes/pitchblack.scss
@@ -33,10 +33,9 @@ $compose-background: darken($main-theme-color, 12%);
   --form-bg: #{$body-bg-color};
   --form-border: #{darken($border-color, 10%)};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 20%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 30%)};
-  --action-button-fill-color-active: #{darken($main-theme-color, 40%)};
   --action-button-fill-color-pressed: #{lighten($main-theme-color, 85%)};
   --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 100%)};
   --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 80%)};
+
+  --svg-fill: #{$secondary-text-color};
 }


### PR DESCRIPTION
Change the baseline colour of the icons match the deemphasised text.

Unpressed button icons will be a darker grey similar to the text that surrounds toots.

Pressed button icons will match the theme colour and be more saturated.

This means the icons meet at least 3:1 contrast ratio against the background.

## Light

### Status toolbar

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/204404856-57a4c501-ee65-4388-ac2f-dc940e89da88.png) | ![](https://user-images.githubusercontent.com/2445413/204404871-17dcf1af-21b8-4e2c-ad95-23faa47b4820.png) |

### Compose toolbar

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/205400626-399d1f81-ef15-447e-a657-07b1ec81b680.png) | ![](https://user-images.githubusercontent.com/2445413/205400628-c970efdf-3970-4eeb-b2e5-6abe2b9f0c2e.png) |

## Dark

### Status toolbar

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/204405253-bbc21e52-b98a-4416-9d76-111532b7df34.png) | ![](https://user-images.githubusercontent.com/2445413/204405333-25ef7c42-993a-4f35-b728-77049e766c0a.png) |

### Compose toolbar

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/205400384-7f541950-fca5-436e-b6f1-0b3f5f1d0f7b.png) | ![](https://user-images.githubusercontent.com/2445413/205400309-8fbcf86a-6e6f-46b0-ad68-284acce06c5c.png) |
