### PR TITLE
Improve notification page readability

### DIFF
--- a/src/routes/_components/IconButton.html
+++ b/src/routes/_components/IconButton.html
@@ -52,25 +52,16 @@
    * regular styles
    */
 
-  :global(.icon-button:hover .icon-button-svg) {
-    fill: var(--action-button-fill-color-hover);
+  .icon-button:hover {
+    background: var(--action-button-bg-color-hover);
   }
 
-  :global(.icon-button.not-pressable:active .icon-button-svg,
-  .icon-button.same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-fill-color-active);
+  .icon-button:active {
+    background: var(--action-button-bg-color-active);
   }
 
   :global(.icon-button.pressed.not-same-pressed .icon-button-svg) {
     fill: var(--action-button-fill-color-pressed);
-  }
-
-  :global(.icon-button.pressed.not-same-pressed:hover .icon-button-svg) {
-    fill: var(--action-button-fill-color-pressed-hover);
-  }
-
-  :global(.icon-button.pressed.not-same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-fill-color-pressed-active);
   }
 
   /*
@@ -81,25 +72,8 @@
     fill: var(--action-button-deemphasized-fill-color);
   }
 
-  :global(.icon-button.muted-style:hover .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-hover);
-  }
-
-  :global(.icon-button.muted-style.not-pressable:active .icon-button-svg,
-  .icon-button.muted-style.same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-active);
-  }
-
   :global(.icon-button.muted-style.pressed.not-same-pressed .icon-button-svg) {
     fill: var(--action-button-deemphasized-fill-color-pressed);
-  }
-
-  :global(.icon-button.muted-style.pressed.not-same-pressed:hover .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-pressed-hover);
-  }
-
-  :global(.icon-button.muted-style.pressed.not-same-pressed:active .icon-button-svg) {
-    fill: var(--action-button-deemphasized-fill-color-pressed-active);
   }
 
 </style>

--- a/src/routes/_components/community/PageListItem.html
+++ b/src/routes/_components/community/PageListItem.html
@@ -70,24 +70,8 @@
     height: 24px;
   }
 
-  :global(.pinnable-button:hover .pinnable-svg) {
-    fill: var(--action-button-fill-color-hover);
-  }
-
-  :global(.pinnable-button:active .pinnable-svg) {
-    fill: var(--action-button-fill-color-active);
-  }
-
   :global(.pinnable-button.checked .pinnable-svg) {
     fill: var(--action-button-fill-color-pressed);
-  }
-
-  :global(.pinnable-button.checked:hover .pinnable-svg) {
-    fill: var(--action-button-fill-color-pressed-hover);
-  }
-
-  :global(.pinnable-button.checked:active .pinnable-svg) {
-    fill: var(--action-button-fill-color-pressed-active);
   }
 
   /* TODO: end copypasta */

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -39,7 +39,9 @@
   {#if isStatusInOwnThread}
     <StatusDetails {...params} {...timestampParams} />
   {/if}
-  <StatusToolbar {...params} {replyShown} on:recalculateHeight on:focusArticle="focusArticle()" />
+  {#if !isStatusInNotificationIncludingMentions}
+    <StatusToolbar {...params} {replyShown} on:recalculateHeight on:focusArticle="focusArticle()" />
+  {/if}
   {#if replyShown}
     <StatusComposeBox {...params} on:recalculateHeight />
   {/if}
@@ -254,9 +256,11 @@
       isStatusInOwnThread: ({ timelineType, timelineValue, originalStatusId }) => (
         (timelineType === 'status' || timelineType === 'reply') && timelineValue === originalStatusId
       ),
-      isStatusInNotification: ({ originalStatusId, notification }) => (
-        notification && notification.status &&
-          notification.type !== 'mention' && notification.status.id === originalStatusId
+      isStatusInNotificationIncludingMentions: ({ originalStatusId, notification }) => (
+        notification && notification.status && notification.status.id === originalStatusId
+      ),
+      isStatusInNotification: ({ isStatusInNotificationIncludingMentions, notification }) => (
+        isStatusInNotificationIncludingMentions && notification.type !== 'mention'
       ),
       spoilerShown: ({ $spoilersShown, uuid }) => !!$spoilersShown[uuid],
       replyShown: ({ $repliesShown, uuid }) => !!$repliesShown[uuid],

--- a/src/routes/_components/status/StatusPoll.html
+++ b/src/routes/_components/status/StatusPoll.html
@@ -122,7 +122,7 @@
   }
 
   .status-in-notification svg {
-    opacity: 0.5;
+    stroke: var(--very-deemphasized-text-color);
   }
 
   .status-in-own-thread .option-text {

--- a/src/routes/_components/status/StatusToolbar.html
+++ b/src/routes/_components/status/StatusToolbar.html
@@ -69,11 +69,6 @@
       height: 20px;
     }
   }
-
-  /* Hack, do this properly with state... */
-  :global(.status-in-notification ~ .status-toolbar) {
-    display: none !important;
-  }
 </style>
 <script>
   import IconButton from '../IconButton.html'

--- a/src/routes/_components/status/StatusToolbar.html
+++ b/src/routes/_components/status/StatusToolbar.html
@@ -69,6 +69,11 @@
       height: 20px;
     }
   }
+
+  /* Hack, do this properly with state... */
+  :global(.status-in-notification ~ .status-toolbar) {
+    display: none !important;
+  }
 </style>
 <script>
   import IconButton from '../IconButton.html'

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -83,8 +83,8 @@
   --deemphasized-text-color: #{$deemphasized-color};
   --focus-outline: #{$focus-outline};
 
-  --very-deemphasized-link-color: #{rgba($anchor-color, 0.6)};
-  --very-deemphasized-text-color: #{rgba(#666, 0.6)};
+  --very-deemphasized-text-color: #757575;
+  --very-deemphasized-link-color: var(--very-deemphasized-link-color);
 
   --status-direct-background: #{darken($body-bg-color, 5%)};
   --main-theme-color: #{$main-theme-color};

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -44,19 +44,13 @@
   --nav-svg-fill-hover: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 18%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 22%)};
-  --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
-  --action-button-fill-color-pressed: #{darken($main-theme-color, 7%)};
-  --action-button-fill-color-pressed-hover: #{darken($main-theme-color, 2%)};
-  --action-button-fill-color-pressed-active: #{darken($main-theme-color, 15%)};
+  --action-button-fill-color: #{lighten($deemphasized-color, 16%)};
+  --action-button-bg-color-hover: #{fade-out($main-text-color, 0.94)};
+  --action-button-bg-color-active: #{fade-out($main-text-color, 0.9)};
+  --action-button-fill-color-pressed: #{saturate($main-theme-color, 10%)};
 
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
-  --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};
-  --action-button-deemphasized-fill-color-active: #{lighten($deemphasized-color, 5%)};
   --action-button-deemphasized-fill-color-pressed: #{darken($deemphasized-color, 7%)};
-  --action-button-deemphasized-fill-color-pressed-hover: #{darken($deemphasized-color, 2%)};
-  --action-button-deemphasized-fill-color-pressed-active: #{darken($deemphasized-color, 15%)};
 
   --settings-list-item-bg: #{$main-bg-color};
   --settings-list-item-text: #{$main-theme-color};

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -1,5 +1,5 @@
 :root {
-  $deemphasized-color: lighten($main-bg-color, 45%);
+  $deemphasized-color: lighten($main-bg-color, 54%);
 
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
   --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};
@@ -12,8 +12,8 @@
 
   --deemphasized-text-color: #{$deemphasized-color};
 
-  --very-deemphasized-link-color: #{rgba($anchor-color, 0.8)};
-  --very-deemphasized-text-color: #{lighten($main-bg-color, 32%)};
+  --very-deemphasized-text-color: #{lighten($main-bg-color, 44%)};
+  --very-deemphasized-link-color: var(--very-deemphasized-text-color);
 
   --status-direct-background: #{darken($body-bg-color, 5%)};
   --main-theme-color: #{$main-theme-color};

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -1,12 +1,10 @@
 :root {
   $deemphasized-color: lighten($main-bg-color, 54%);
 
+  --action-button-fill-color: #{darken($deemphasized-color, 2%)};
+  --action-button-fill-color-pressed: #{lighten($main-theme-color, 5%)};
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
-  --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};
-  --action-button-deemphasized-fill-color-active: #{lighten($deemphasized-color, 5%)};
   --action-button-deemphasized-fill-color-pressed: #{darken($deemphasized-color, 7%)};
-  --action-button-deemphasized-fill-color-pressed-hover: #{darken($deemphasized-color, 2%)};
-  --action-button-deemphasized-fill-color-pressed-active: #{darken($deemphasized-color, 15%)};
 
   --loading-bg: #{#222};
 

--- a/src/scss/themes/ozark.scss
+++ b/src/scss/themes/ozark.scss
@@ -1,4 +1,4 @@
-$main-theme-color: #5263af;
+$main-theme-color: saturate(#5263af, 10%);
 $body-bg-color: #0f1427;
 $main-bg-color: #212433;
 $anchor-color: lighten($main-theme-color, 20%);

--- a/src/scss/themes/pitchblack.scss
+++ b/src/scss/themes/pitchblack.scss
@@ -33,9 +33,6 @@ $compose-background: darken($main-theme-color, 12%);
   --form-bg: #{$body-bg-color};
   --form-border: #{darken($border-color, 10%)};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 20%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 30%)};
-  --action-button-fill-color-active: #{darken($main-theme-color, 40%)};
   --action-button-fill-color-pressed: #{lighten($main-theme-color, 85%)};
   --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 100%)};
   --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 80%)};


### PR DESCRIPTION
Use lowest possible contrast gray that meets WCAG requirements for very deemphasised text.

Makes the notification page more readable without compromising access as much.

Closes https://github.com/nolanlawson/pinafore/issues/2249