### PR TITLE
Add Docker image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,42 @@
+name: Build and push Docker image
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    paths:
+      - .github/workflows/build-image.yml
+      - Dockerfile
+jobs:
+  build-image:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/pinafore
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=edge,branch=master
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
----
 version: "3"
+
 services:
   pinafore:
+    container_name: pinafore
+    image: nolanlawson/pinafore:latest
     restart: unless-stopped
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: pinafore:latest
     ports:
-      - 4002:4002
+      - "4002:4002"


### PR DESCRIPTION
Added a GH Actions workflow to automatically publish Docker images with the following tags:
- SemVer tags (`X.Y.Z`, `X.Y`, `X`)
- `latest` tag
- `edge` tag that follows the master branch

Closes #2148. Regarding #1284, if you don't want to use Docker Hub, GHCR could be an alternative, since the project is already on GitHub. Having an official Docker image somewhere significantly eases self-hosting.
