### PR TITLE
fix: correctly label toot edited notification

### DIFF
--- a/src/intl/en-US.js
+++ b/src/intl/en-US.js
@@ -513,6 +513,7 @@ export default {
   rebloggedYou: 'boosted your toot',
   favoritedYou: 'favorited your toot',
   followedYou: 'followed you',
+  edited: 'edited their toot',
   signedUp: 'signed up',
   posted: 'posted',
   pollYouCreatedEnded: 'A poll you created has ended',
@@ -528,6 +529,7 @@ export default {
   // Accessible status labels
   accountRebloggedYou: '{account} boosted your toot',
   accountFavoritedYou: '{account} favorited your toot',
+  accountEdited: '{account} edited their toot',
   rebloggedByAccount: 'Boosted by {account}',
   contentWarningContent: 'Content warning: {spoiler}',
   hasMedia: 'has media',

--- a/src/routes/_a11y/getAccessibleLabelForStatus.js
+++ b/src/routes/_a11y/getAccessibleLabelForStatus.js
@@ -11,6 +11,8 @@ function getNotificationText (notification, omitEmojiInDisplayNames) {
     return formatIntl('intl.accountRebloggedYou', { account: notificationAccountDisplayName })
   } else if (notification.type === 'favourite') {
     return formatIntl('intl.accountFavoritedYou', { account: notificationAccountDisplayName })
+  } else if (notification.type === 'update') {
+    return formatIntl('intl.accountEdited', { account: notificationAccountDisplayName })
   }
 }
 

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -309,7 +309,7 @@
         )
       ),
       showHeader: ({ notification, status, timelineType }) => (
-        (notification && ['reblog', 'favourite', 'poll', 'status'].includes(notification.type)) ||
+        (notification && ['reblog', 'favourite', 'poll', 'status', 'update'].includes(notification.type)) ||
         status.reblog ||
         timelineType === 'pinned'
       ),

--- a/src/routes/_components/status/StatusHeader.html
+++ b/src/routes/_components/status/StatusHeader.html
@@ -137,6 +137,8 @@
           return '#fa-comment'
         } else if (notificationType === 'admin.sign_up') {
           return '#fa-user-plus'
+        } else if (notificationType === 'update') {
+          return '#fa-pencil'
         }
         return '#fa-star'
       },
@@ -159,6 +161,8 @@
           }
         } else if (status && status.reblog) {
           return 'intl.reblogged'
+        } else if (notificationType === 'update') {
+          return 'intl.edited'
         } else {
           return ''
         }


### PR DESCRIPTION
Fixes #2280

![toot-edit](https://user-images.githubusercontent.com/1730853/205756175-f2203ad5-7026-4721-8268-911a8863c110.png)

I looked at "Inspect accessibility properties" in Firefox DevTools and the accessibility label looks right, similar to that for a boost notification.

Of course, these new strings aren't internationalized, as I'm not fluent in the relevant languages; let me know if there's anything you recommend I do about that.