### PR TITLE
fix: back button icon rendering inconsistently

### DIFF
--- a/bin/svgs.js
+++ b/bin/svgs.js
@@ -1,5 +1,6 @@
 export default [
   { id: 'pinafore-logo', src: 'src/static/sailboat.svg', inline: true },
+  { id: 'fa-arrow-left', src: 'src/thirdparty/font-awesome-svg-png/white/svg/arrow-left.svg' },
   { id: 'fa-bell', src: 'src/thirdparty/font-awesome-svg-png/white/svg/bell.svg', inline: true },
   { id: 'fa-bell-o', src: 'src/thirdparty/font-awesome-svg-png/white/svg/bell-o.svg' },
   { id: 'fa-users', src: 'src/thirdparty/font-awesome-svg-png/white/svg/users.svg', inline: true },

--- a/src/routes/_components/DynamicPageBanner.html
+++ b/src/routes/_components/DynamicPageBanner.html
@@ -8,7 +8,10 @@
   <button type="button"
           class="dynamic-page-go-back"
           aria-label="{intl.goBack}"
-          on:click|preventDefault="onGoBack()">{intl.back}</button>
+          on:click|preventDefault="onGoBack()">
+    <SvgIcon className="dynamic-page-go-back-icon" href="#fa-arrow-left" />
+    {intl.back}
+  </button>
 </div>
 <Shortcut key="Backspace" on:pressed="onGoBack()"/>
 <style>
@@ -34,19 +37,25 @@
     text-overflow: ellipsis;
   }
   .dynamic-page-go-back {
-    font-size: 1.3em;
+    display: inline-flex;
+    align-items: center;
+    justify-self: flex-end;
+    font-size: 1.2857142857142858em;
     color: var(--anchor-text);
     border: 0;
     padding: 0;
     background: none;
-    justify-self: flex-end;
   }
   .dynamic-page-go-back:hover {
     text-decoration: underline;
   }
-  .dynamic-page-go-back::before {
-    content: '←';
-    margin-right: 5px;
+  :global(.dynamic-page-go-back-icon) {
+    position: relative;
+    bottom: 0.06em;
+    margin-right: 0.2em;
+    height: 0.66666666em;
+    width: 0.66666666em;
+    fill: currentColor;
   }
   @media (max-width: 767px) {
     .dynamic-page-banner {


### PR DESCRIPTION
Depending on the operating system and therefore the system font the back icon being a unicode arrow means it'll render inconsistently, sometimes I've seen it looking really odd.

Instead make use of the font awesome arrow so that'll it render consistently no matter the system font.

| Before | After |
| - | - |
| ![Slender back arrow before button label](https://user-images.githubusercontent.com/2445413/205987743-c601ec47-f40c-4918-bd83-b7727f883265.png) | ![Thicker font awesome back arrow before button label](https://user-images.githubusercontent.com/2445413/205987759-d96633a1-913a-4aff-8572-3360413eef0d.png) |
