### PR TITLE
Improve icon readability in light theme

### DIFF
--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -45,9 +45,9 @@
   --action-button-fill-color: #{lighten($main-theme-color, 11.5%)};
   --action-button-fill-color-hover: #{lighten($main-theme-color, 6%)};
   --action-button-fill-color-active: #{$main-theme-color};
-  --action-button-fill-color-pressed: #{saturate($main-theme-color, 5%)};
-  --action-button-fill-color-pressed-hover: #{darken(saturate($main-theme-color, 5%), 4%)};
-  --action-button-fill-color-pressed-active: #{darken(saturate($main-theme-color, 5%), 8%)};
+  --action-button-fill-color-pressed: #{darken(saturate($main-theme-color, 5%), 6%)};
+  --action-button-fill-color-pressed-hover: #{darken(saturate($main-theme-color, 5%), 12%)};
+  --action-button-fill-color-pressed-active: #{darken(saturate($main-theme-color, 5%), 15%)};
 
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
   --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};

--- a/src/scss/themes/_base.scss
+++ b/src/scss/themes/_base.scss
@@ -42,12 +42,12 @@
   --nav-svg-fill-hover: #{$secondary-text-color};
   --nav-text-color-hover: #{$secondary-text-color};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 18%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 22%)};
-  --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
-  --action-button-fill-color-pressed: #{darken($main-theme-color, 7%)};
-  --action-button-fill-color-pressed-hover: #{darken($main-theme-color, 2%)};
-  --action-button-fill-color-pressed-active: #{darken($main-theme-color, 15%)};
+  --action-button-fill-color: #{lighten($main-theme-color, 11.5%)};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 6%)};
+  --action-button-fill-color-active: #{$main-theme-color};
+  --action-button-fill-color-pressed: #{saturate($main-theme-color, 5%)};
+  --action-button-fill-color-pressed-hover: #{darken(saturate($main-theme-color, 5%), 4%)};
+  --action-button-fill-color-pressed-active: #{darken(saturate($main-theme-color, 5%), 8%)};
 
   --action-button-deemphasized-fill-color: #{$deemphasized-color};
   --action-button-deemphasized-fill-color-hover: #{lighten($deemphasized-color, 22%)};


### PR DESCRIPTION
Increase the contrast of unpressed action buttons so they're easier to see.

This brings the icons to 3:1 contrast while keeping colour in themes.


## Before
![](https://user-images.githubusercontent.com/2445413/208256982-4f4d73d9-ced8-407b-9cff-9cfa783c4239.png)

## After
![](https://user-images.githubusercontent.com/2445413/208256981-2617f82d-2742-44ca-b20c-09450c2d390c.png)
