### PR TITLE
Improve icon readability in pitch black theme

### DIFF
--- a/src/scss/themes/pitchblack.scss
+++ b/src/scss/themes/pitchblack.scss
@@ -33,9 +33,9 @@ $compose-background: darken($main-theme-color, 12%);
   --form-bg: #{$body-bg-color};
   --form-border: #{darken($border-color, 10%)};
 
-  --action-button-fill-color: #{lighten($main-theme-color, 20%)};
-  --action-button-fill-color-hover: #{lighten($main-theme-color, 30%)};
-  --action-button-fill-color-active: #{darken($main-theme-color, 40%)};
+  --action-button-fill-color: #{lighten($main-theme-color, 50%)};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 60%)};
+  --action-button-fill-color-active: #{darken($main-theme-color, 70%)};
   --action-button-fill-color-pressed: #{lighten($main-theme-color, 85%)};
   --action-button-fill-color-pressed-hover: #{lighten($main-theme-color, 100%)};
   --action-button-fill-color-pressed-active: #{lighten($main-theme-color, 80%)};


### PR DESCRIPTION
Increase the contrast of unpressed action buttons so they're easier to see.

This brings the icons to 3:1 contrast while keeping colour in themes.

## Before

![](https://user-images.githubusercontent.com/2445413/208299643-c4aa2398-7ef9-416f-bc2b-ed496143ca4e.png)

## After
![](https://user-images.githubusercontent.com/2445413/208299645-bc90647a-8820-4a16-b7f4-fdd5fd6b9082.png)
