### PR TITLE
Add automated contrast checking

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -5,5 +5,10 @@
     "takeOnFails": false
   },
   "skipJsErrors": true,
-  "stopOnFirstFail": true
+  "stopOnFirstFail": true,
+  "clientScripts": [
+    {
+      "module": "axe-core/axe.min.js"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -119,7 +119,9 @@
     "worker-loader": "^3.0.8"
   },
   "devDependencies": {
+    "@testcafe-community/axe": "^3.5.0",
     "assert": "^2.0.0",
+    "axe-core": "^4.6.1",
     "eslint-plugin-html": "^7.1.0",
     "fake-indexeddb": "^4.0.0",
     "globby": "^13.1.2",

--- a/tests/spec/020-themes.js
+++ b/tests/spec/020-themes.js
@@ -1,12 +1,19 @@
-import {
-  getCurrentTheme,
-  settingsNavButton
-} from '../utils'
+import { settingsNavButton, getCurrentTheme, getNthStatus } from '../utils'
 import { loginAsFoobar } from '../roles'
 import { Selector as $ } from 'testcafe'
+import { checkForViolations } from '@testcafe-community/axe';
 
 fixture`020-themes.js`
   .page`http://localhost:4002`
+
+function checkColorsAreReadable(t) {
+  return checkForViolations(t, null, {
+    runOnly: 'color-contrast',
+    rules: {
+      'color-contrast': { enabled: true }
+    }
+  })
+}
 
 test('can set a theme', async t => {
   await loginAsFoobar(t)
@@ -20,3 +27,27 @@ test('can set a theme', async t => {
     .click($('input[value="default"]'))
     .expect(getCurrentTheme()).eql('default')
 })
+
+test(`Default light theme should pass automated color contrast checks`, async t => {
+  await loginAsFoobar(t)
+  await t
+    .navigateTo('/settings/general')
+    .expect(getCurrentTheme()).eql('default')
+  await t.navigateTo('/')
+    .expect(getNthStatus(1).exists)
+    .ok({ timeout: 30000 })
+  await checkColorsAreReadable(t)
+});
+
+test(`Default dark theme should pass automated color contrast checks`, async t => {
+  await loginAsFoobar(t)
+  await t
+    .navigateTo('/settings/general')
+    .click($(`input[value="ozark"]`))
+    .expect(getCurrentTheme()).eql('ozark')
+  await t.navigateTo('/')
+    .expect(getNthStatus(1).exists)
+    .ok({ timeout: 30000 })
+  await checkColorsAreReadable(t)
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,13 @@
   resolved "https://registry.yarnpkg.com/@stdlib/utils-noop/-/utils-noop-0.0.13.tgz#d8b113c605d327d786106448571c44b0f070751d"
   integrity sha512-JRWHGWYWP5QK7SQ2cOYiL8NETw8P33LriZh1p9S2xC4e0rBoaY849h1A2IL2y1+x3s29KNjSaBWMrMUIV5HCSw==
 
+"@testcafe-community/axe@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@testcafe-community/axe/-/axe-3.5.0.tgz#09d7444ac1fca8d938c0f42b18fc6ccebbade77f"
+  integrity sha512-JFYW8IYtvVZ2788y6d0kb3LGZAQZWgS82SrsFcd/4zJU7b9j2oPruLxpmPKqbM4HwQLk8RhyzkOmECRxRbrLhA==
+  dependencies:
+    chalk "^2.4.1"
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -1728,6 +1735,11 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axe-core@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.1.tgz#79cccdee3e3ab61a8f42c458d4123a6768e6fbce"
+  integrity sha512-lCZN5XRuOnpG4bpMq8v0khrWtUOn+i8lZSb6wHZH56ZfbIEv6XwJV84AAueh9/zi7qPVJ/E4yz6fmsiyOmXR4w==
 
 babel-plugin-module-resolver@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Seeing if we can get automated testing running in GitHub actions, we could add checks in other specs if this is viable.

As part of #513