### PR TITLE
Improve icon readability in dark themes

### DIFF
--- a/src/scss/themes/mastodon.scss
+++ b/src/scss/themes/mastodon.scss
@@ -23,6 +23,11 @@ $compose-background: darken($main-theme-color, 12%);
   --button-primary-bg-hover: #56a7e1;
   --button-primary-border: transparent;
 
+
+  --action-button-fill-color: #{lighten($main-theme-color, 30%)};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 36%)};
+  --action-button-fill-color-active: #{lighten($main-theme-color, 42%)};
   --action-button-fill-color-pressed: #2b90d9;
-  --action-button-fill-color-pressed-hover: #2b90d9;
+  --action-button-fill-color-pressed-hover: #{darken(#2b90d9, 6%)};
+  --action-button-fill-color-pressed-active: #{darken(#2b90d9, 12%)};
 }

--- a/src/scss/themes/ozark.scss
+++ b/src/scss/themes/ozark.scss
@@ -13,3 +13,9 @@ $compose-background: darken($main-theme-color, 12%);
 @import "_base.scss";
 @import "_dark.scss";
 @import "_dark_scrollbars.scss";
+
+:root {
+    --action-button-fill-color-pressed: #{lighten(saturate($main-theme-color, 25%), 8%)};
+    --action-button-fill-color-pressed-hover: #{lighten(saturate($main-theme-color, 25%), 12%)};
+    --action-button-fill-color-pressed-active: #{lighten(saturate($main-theme-color, 25%), 15%)};
+}


### PR DESCRIPTION
I think this'll be the last of the icon improvements for now...

## Ozark

### Before
![](https://user-images.githubusercontent.com/2445413/208325440-f6ef6378-1fbe-444f-a3f4-8d2db54e90a0.png)

### After
![](https://user-images.githubusercontent.com/2445413/208325438-b9a1648c-d30e-4d3e-9bd0-08b4dd50a51a.png)

## Mastodon

### Before
![](https://user-images.githubusercontent.com/2445413/208325437-2a58de0b-b933-4666-819e-ebee18ec1fac.png)

### After
![](https://user-images.githubusercontent.com/2445413/208325434-a33dae1e-7661-4d74-8a11-ccb7f48fa5e3.png)
