### PR TITLE
Replace builds with buildCommand in vercel.json

### DIFF
--- a/bin/build-vercel-json.js
+++ b/bin/build-vercel-json.js
@@ -21,15 +21,7 @@ const JSON_TEMPLATE = {
   github: {
     silent: true
   },
-  builds: [
-    {
-      src: 'package.json',
-      use: '@now/static-build',
-      config: {
-        distDir: '__sapper__/export'
-      }
-    }
-  ],
+  "buildCommand": "yarn build",
   routes: [
     {
       src: '^/service-worker\\.js$',

--- a/bin/build-vercel-json.js
+++ b/bin/build-vercel-json.js
@@ -22,6 +22,7 @@ const JSON_TEMPLATE = {
     silent: true
   },
   buildCommand: 'yarn build',
+  outputDirectory: '__sapper__/export',
   routes: [
     {
       src: '^/service-worker\\.js$',

--- a/bin/build-vercel-json.js
+++ b/bin/build-vercel-json.js
@@ -21,7 +21,7 @@ const JSON_TEMPLATE = {
   github: {
     silent: true
   },
-  "buildCommand": "yarn build",
+  buildCommand: 'yarn build',
   routes: [
     {
       src: '^/service-worker\\.js$',

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
     "silent": true
   },
   "buildCommand": "yarn build",
+  "outputDirectory": "__sapper__/export",
   "routes": [
     {
       "src": "^/service-worker\\.js$",

--- a/vercel.json
+++ b/vercel.json
@@ -6,15 +6,7 @@
   "github": {
     "silent": true
   },
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@now/static-build",
-      "config": {
-        "distDir": "__sapper__/export"
-      }
-    }
-  ],
+  "buildCommand": "yarn build",
   "routes": [
     {
       "src": "^/service-worker\\.js$",


### PR DESCRIPTION
builds property is not recommended in [project config with vercel.json](https://vercel.com/docs/project-configuration).
Using just buildCommand has been useful when I have host the merged translation into Spanish in Vercel. A fellow has registered a domain where it's available. We use the same vercel.json file, but replacing the builds property with `"buildCommand": "LOCALE=es yarn build"`.
I think that this change may make easier to understand how to host translated versions of Pinafore in Vercel.
I'm very grateful with the person who has registered this domain assuming costs himself for the benefit of the spanish community
See the spanish translation working at

https://pinafore.es

I just hosted it in a free Vercel account.
Thanks