### PR TITLE
fix: lighten button colors on some themes

### DIFF
--- a/src/scss/themes/grayscale.scss
+++ b/src/scss/themes/grayscale.scss
@@ -12,3 +12,10 @@ $compose-background: lighten($main-theme-color, 17%);
 
 @import "_base.scss";
 @import "_light_scrollbars.scss";
+
+:root {
+  // make the action buttons a bit lighter
+  --action-button-fill-color: #{lighten($main-theme-color, 17%)};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 10%)};
+  --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
+}

--- a/src/scss/themes/majesty.scss
+++ b/src/scss/themes/majesty.scss
@@ -12,3 +12,10 @@ $compose-background: lighten($main-theme-color, 32%);
 
 @import "_base.scss";
 @import "_light_scrollbars.scss";
+
+:root {
+  // make the action buttons a bit lighter
+  --action-button-fill-color: #{lighten($main-theme-color, 17%)};
+  --action-button-fill-color-hover: #{lighten($main-theme-color, 10%)};
+  --action-button-fill-color-active: #{lighten($main-theme-color, 5%)};
+}


### PR DESCRIPTION
Tweaks the colors on the majesty/grayscale themes. The buttons are still >3.0 contrast ratio.