### PR TITLE
Add option to always expand posts marked with content warnings

### DIFF
--- a/src/intl/en-US.js
+++ b/src/intl/en-US.js
@@ -368,7 +368,7 @@ export default {
   general: 'General',
   generalSettings: 'General settings',
   showSensitive: 'Show sensitive media by default',
-  showAllSpoilers: 'Always expand posts marked with content warnings',
+  showAllSpoilers: 'Expand content warnings by default',
   showPlain: 'Show a plain gray color for sensitive media',
   allSensitive: 'Treat all media as sensitive',
   largeMedia: 'Show large inline images and videos',

--- a/src/intl/en-US.js
+++ b/src/intl/en-US.js
@@ -368,6 +368,7 @@ export default {
   general: 'General',
   generalSettings: 'General settings',
   showSensitive: 'Show sensitive media by default',
+  showAllSpoilers: 'Always expand posts marked with content warnings',
   showPlain: 'Show a plain gray color for sensitive media',
   allSensitive: 'Treat all media as sensitive',
   largeMedia: 'Show large inline images and videos',

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -260,7 +260,7 @@
         notification && notification.status &&
           notification.type !== 'mention' && notification.status.id === originalStatusId
       ),
-      spoilerShown: ({ $spoilersShown, uuid }) => !!$spoilersShown[uuid],
+      spoilerShown: ({ $spoilersShown, uuid, $showAllSpoilers }) => ($spoilersShown[uuid] === undefined ? !!$showAllSpoilers : !!$spoilersShown[uuid]),
       replyShown: ({ $repliesShown, uuid }) => !!$repliesShown[uuid],
       showCard: ({ originalStatus, isStatusInNotification, showMedia, $hideCards }) => (
         !$hideCards &&

--- a/src/routes/_components/status/Status.html
+++ b/src/routes/_components/status/Status.html
@@ -260,7 +260,7 @@
         notification && notification.status &&
           notification.type !== 'mention' && notification.status.id === originalStatusId
       ),
-      spoilerShown: ({ $spoilersShown, uuid, $showAllSpoilers }) => ($spoilersShown[uuid] === undefined ? !!$showAllSpoilers : !!$spoilersShown[uuid]),
+      spoilerShown: ({ $spoilersShown, uuid, $showAllSpoilers }) => (typeof $spoilersShown[uuid] === 'undefined' ? !!$showAllSpoilers : !!$spoilersShown[uuid]),
       replyShown: ({ $repliesShown, uuid }) => !!$repliesShown[uuid],
       showCard: ({ originalStatus, isStatusInNotification, showMedia, $hideCards }) => (
         !$hideCards &&

--- a/src/routes/_components/status/StatusSpoiler.html
+++ b/src/routes/_components/status/StatusSpoiler.html
@@ -76,8 +76,9 @@
     methods: {
       toggleSpoilers (shown) {
         const { uuid } = this.get()
-        const { spoilersShown } = this.store.get()
-        spoilersShown[uuid] = typeof shown === 'undefined' ? !spoilersShown[uuid] : !!shown
+        const { spoilersShown, showAllSpoilers } = this.store.get()
+        const currentValue = typeof spoilersShown[uuid] === 'undefined' ? !!showAllSpoilers : spoilersShown[uuid]
+        spoilersShown[uuid] = typeof shown === 'undefined' ? !currentValue : !!shown
         this.store.set({ spoilersShown })
         requestAnimationFrame(() => {
           mark('clickSpoilerButton')

--- a/src/routes/_pages/settings/general.html
+++ b/src/routes/_pages/settings/general.html
@@ -9,6 +9,11 @@
       {intl.showSensitive}
     </label>
     <label class="setting-group">
+      <input type="checkbox" id="choice-show-all-spoilers"
+             bind:checked="$showAllSpoilers" on:change="onChange(event)">
+      {intl.showAllSpoilers}
+    </label>
+    <label class="setting-group">
       <input type="checkbox" id="choice-use-blurhash"
               bind:checked="$ignoreBlurhash" on:change="onChange(event)">
       {intl.showPlain}

--- a/src/routes/_store/store.js
+++ b/src/routes/_store/store.js
@@ -35,6 +35,7 @@ const persistedState = {
   loggedInInstances: {},
   loggedInInstancesInOrder: [],
   markMediaAsSensitive: false,
+  showAllSpoilers: false,
   neverMarkMediaAsSensitive: false,
   ignoreBlurhash: false,
   omitEmojiInDisplayNames: undefined,

--- a/tests/spec/043-content-warnings.js
+++ b/tests/spec/043-content-warnings.js
@@ -1,0 +1,37 @@
+import {
+  getUrl,
+  scrollToStatus,
+  getNthStatusSpoiler,
+  settingsNavButton,
+  generalSettingsButton,
+  homeNavButton,
+  getNthStatus,
+  getNthShowOrHideButton
+} from '../utils'
+import { loginAsFoobar } from '../roles'
+import { homeTimeline } from '../fixtures.js'
+import { Selector as $ } from 'testcafe'
+
+fixture`043-spoilers.js`
+  .page`http://localhost:4002`
+
+test('Can set content warnings to auto-expand', async t => {
+  await loginAsFoobar(t)
+  await t
+    .expect(getUrl()).eql('http://localhost:4002/')
+    .click(settingsNavButton)
+    .click(generalSettingsButton)
+    .click($('#choice-show-all-spoilers'))
+    .click(homeNavButton)
+    .expect(getUrl()).eql('http://localhost:4002/')
+    .expect(getNthStatus(1).exists).ok()
+  const idx = homeTimeline.findIndex(_ => _.spoiler === 'kitten CW')
+  await scrollToStatus(t, idx + 1)
+  await t
+    .expect(getNthStatusSpoiler(1 + idx).innerText).contains('kitten CW')
+    .expect(getNthStatus(1 + idx).innerText).contains('here\'s a kitten with a CW')
+    .click(getNthShowOrHideButton(1 + idx))
+    .expect(getNthStatus(1 + idx).innerText).notContains('here\'s a kitten with a CW')
+    .click(getNthShowOrHideButton(1 + idx))
+    .expect(getNthStatus(1 + idx).innerText).contains('here\'s a kitten with a CW')
+})

--- a/tests/spec/043-content-warnings.js
+++ b/tests/spec/043-content-warnings.js
@@ -12,7 +12,7 @@ import { loginAsFoobar } from '../roles'
 import { homeTimeline } from '../fixtures.js'
 import { Selector as $ } from 'testcafe'
 
-fixture`043-spoilers.js`
+fixture`043-content-warnings.js`
   .page`http://localhost:4002`
 
 test('Can set content warnings to auto-expand', async t => {


### PR DESCRIPTION
Added an option to always expand posts marked with content warnings. If the option is enabled, posts with content warnings are expanded by default, but can be closed using the "show less" button as usual.

This adds a new intl key. I wasn't sure whether the correct approach was just to add the key to en_US or to add it (untranslated) to every language; I've just done the former for now, but if it does need to be added untranslated to every language please let me know and I'll do so.

Fixes #1997.