### PR TITLE
OAuth2: use correct `Content-Type` as specified in RFC

### DIFF
--- a/src/routes/_api/oauth.js
+++ b/src/routes/_api/oauth.js
@@ -5,7 +5,7 @@ const WEBSITE = 'https://pinafore.social'
 const SCOPES = 'read write follow push'
 const CLIENT_NAME = 'Pinafore'
 
-export function registerApplication(instanceName, redirectUri) {
+export function registerApplication (instanceName, redirectUri) {
   const url = `${basename(instanceName)}/api/v1/apps`
   return post(url, {
     client_name: CLIENT_NAME,
@@ -15,7 +15,7 @@ export function registerApplication(instanceName, redirectUri) {
   }, null, { timeout: WRITE_TIMEOUT })
 }
 
-export function generateAuthLink(instanceName, clientId, redirectUri) {
+export function generateAuthLink (instanceName, clientId, redirectUri) {
   const params = paramsString({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -25,7 +25,7 @@ export function generateAuthLink(instanceName, clientId, redirectUri) {
   return `${basename(instanceName)}/oauth/authorize?${params}`
 }
 
-export function getAccessTokenFromAuthCode(instanceName, clientId, clientSecret, code, redirectUri) {
+export function getAccessTokenFromAuthCode (instanceName, clientId, clientSecret, code, redirectUri) {
   const url = `${basename(instanceName)}/oauth/token`
   // Using URLSearchParams here guarantees a content type of application/x-www-form-urlencoded
   // See https://fetch.spec.whatwg.org/#bodyinit-unions

--- a/src/routes/_api/oauth.js
+++ b/src/routes/_api/oauth.js
@@ -5,7 +5,7 @@ const WEBSITE = 'https://pinafore.social'
 const SCOPES = 'read write follow push'
 const CLIENT_NAME = 'Pinafore'
 
-export function registerApplication (instanceName, redirectUri) {
+export function registerApplication(instanceName, redirectUri) {
   const url = `${basename(instanceName)}/api/v1/apps`
   return post(url, {
     client_name: CLIENT_NAME,
@@ -15,7 +15,7 @@ export function registerApplication (instanceName, redirectUri) {
   }, null, { timeout: WRITE_TIMEOUT })
 }
 
-export function generateAuthLink (instanceName, clientId, redirectUri) {
+export function generateAuthLink(instanceName, clientId, redirectUri) {
   const params = paramsString({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -25,13 +25,13 @@ export function generateAuthLink (instanceName, clientId, redirectUri) {
   return `${basename(instanceName)}/oauth/authorize?${params}`
 }
 
-export function getAccessTokenFromAuthCode (instanceName, clientId, clientSecret, code, redirectUri) {
+export function getAccessTokenFromAuthCode(instanceName, clientId, clientSecret, code, redirectUri) {
   const url = `${basename(instanceName)}/oauth/token`
-  return post(url, {
+  return post(url, new URLSearchParams({
     client_id: clientId,
     client_secret: clientSecret,
     redirect_uri: redirectUri,
     grant_type: 'authorization_code',
     code
-  }, null, { timeout: WRITE_TIMEOUT })
+  }), null, { timeout: WRITE_TIMEOUT })
 }

--- a/src/routes/_api/oauth.js
+++ b/src/routes/_api/oauth.js
@@ -27,6 +27,8 @@ export function generateAuthLink(instanceName, clientId, redirectUri) {
 
 export function getAccessTokenFromAuthCode(instanceName, clientId, clientSecret, code, redirectUri) {
   const url = `${basename(instanceName)}/oauth/token`
+  // Using URLSearchParams here guarantees a content type of application/x-www-form-urlencoded
+  // See https://fetch.spec.whatwg.org/#bodyinit-unions
   return post(url, new URLSearchParams({
     client_id: clientId,
     client_secret: clientSecret,

--- a/src/routes/_utils/ajax.js
+++ b/src/routes/_utils/ajax.js
@@ -51,7 +51,7 @@ async function _fetch (url, fetchOptions, options) {
 async function _putOrPostOrPatch (method, url, body, headers, options) {
   const fetchOptions = makeFetchOptions(method, headers, options)
   if (body) {
-    if (body instanceof FormData) {
+    if (body instanceof FormData || body instanceof URLSearchParams) {
       fetchOptions.body = body
     } else {
       fetchOptions.body = JSON.stringify(body)


### PR DESCRIPTION
* Token request should use `application/x-www-form-urlencoded`: https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3