### PR TITLE
fix: grayscale mode support for header images

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -55,7 +55,7 @@
      */
     img, svg, video,
     input[type="checkbox"], input[type="radio"],
-    .inline-emoji, .theme-preview {
+    .inline-emoji, .theme-preview, .account-profile {
       filter: grayscale(100%);
     }
   </style>


### PR DESCRIPTION
Currently, the grayscale filter does not apply to header images. This PR aims to remediate that by adding the `account-profile` class to the `theGrayscaleStyle` style definitions.